### PR TITLE
chore: simplify issue forms and skip Markdown-only CI

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -9,41 +9,9 @@ body:
       value: |
         Do not paste credentials, prompts, personal paths, local model inventories, proprietary model files, or unredacted logs.
   - type: textarea
-    id: behavior
+    id: report
     attributes:
-      label: Observed behavior
-      description: Describe what happened and the user-visible impact.
+      label: What happened?
+      description: Describe the problem in your own words.
     validations:
       required: true
-  - type: textarea
-    id: expected
-    attributes:
-      label: Expected behavior
-    validations:
-      required: true
-  - type: textarea
-    id: reproduction
-    attributes:
-      label: Reproduction
-      description: Provide minimal steps using fictional paths and redacted data.
-    validations:
-      required: true
-  - type: input
-    id: revision
-    attributes:
-      label: Astronomical revision
-      placeholder: Commit identifier or release
-    validations:
-      required: true
-  - type: input
-    id: environment
-    attributes:
-      label: Environment
-      description: macOS version and Apple Silicon generation only. Do not include device names or serial numbers.
-    validations:
-      required: true
-  - type: textarea
-    id: verification
-    attributes:
-      label: Additional evidence
-      description: Include bounded, redacted diagnostics only when necessary.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -5,26 +5,9 @@ labels:
   - enhancement
 body:
   - type: textarea
-    id: problem
+    id: proposal
     attributes:
-      label: User problem
-      description: Describe the concrete local-user problem without private machine details.
+      label: What would make Astronomical better?
+      description: Describe the improvement in your own words. Do not include private machine details.
     validations:
       required: true
-  - type: textarea
-    id: outcome
-    attributes:
-      label: Desired outcome
-      description: State observable acceptance criteria rather than an architecture.
-    validations:
-      required: true
-  - type: textarea
-    id: constraints
-    attributes:
-      label: Precision, performance, and memory constraints
-      description: Explain any model-fidelity or adaptive-memory requirements.
-  - type: textarea
-    id: simplicity
-    attributes:
-      label: Simplest viable approach
-      description: Identify how to avoid new layers or configuration when possible.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,11 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '**/*.md'
   pull_request:
+    paths-ignore:
+      - '**/*.md'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

- Reduce each issue form to one required free-text response.
- Skip the macOS CI workflow when every changed file is Markdown.

## Why

Issue reporting should impose minimal form overhead. Markdown-only changes do not affect executable code, dependency state, native provisioning, or test behavior, so they do not need an expensive macOS verification run.

## Scope

The workflow runs whenever any changed file is not Markdown. Changes to issue forms, workflow configuration, Rust code, native dependencies, or other repository content remain covered by CI.

## Verification

- actionlint
- Issue-form YAML parsing with one response field confirmed per form
- scripts/verify-before-commit.sh