### PR TITLE
Show prompt processing ETA in the menu

### DIFF
--- a/apps/astronomical-menu/Sources/AstronomicalMenu/OrbitalTelemetryPopover.swift
+++ b/apps/astronomical-menu/Sources/AstronomicalMenu/OrbitalTelemetryPopover.swift
@@ -102,7 +102,7 @@ struct OrbitalTelemetryPopover: View {
         total: Double(statusDocument.progressTotalTokenCount)
       ).tint(.cyan)
       metricRow("Progress", statusDocument.progressTitle)
-      metricRow("Elapsed", statusDocument.elapsedTimeTitle)
+      metricRow(statusDocument.elapsedTimeMetricTitle, statusDocument.elapsedTimeTitle)
       Divider()
       GPUUtilizationBar(
         gpuUtilizationPercentage: telemetryStore.systemTelemetrySnapshot.gpuUtilizationPercentage

--- a/apps/astronomical-menu/Sources/AstronomicalMenu/SupervisorStatusDocument.swift
+++ b/apps/astronomical-menu/Sources/AstronomicalMenu/SupervisorStatusDocument.swift
@@ -234,9 +234,25 @@ struct SupervisorStatusDocument: Codable, Equatable {
   var progressTitle: String {
     progress.map { "\($0.processedTokens) / \($0.totalTokens) tokens" } ?? "Standing by"
   }
+  var elapsedTimeMetricTitle: String {
+    progress?.phase == "generation" ? "Elapsed" : "Elapsed / ETA"
+  }
+
   var elapsedTimeTitle: String {
     guard let progress else { return "Not active" }
-    return String(format: "%.1f s", Double(progress.elapsedMilliseconds) / 1_000)
+    let elapsedSeconds = Double(progress.elapsedMilliseconds) / 1_000
+    guard progress.phase != "generation" else {
+      return String(format: "%.1f s", elapsedSeconds)
+    }
+    guard progress.processedTokens > 0 else {
+      return String(format: "%.1f s / Calculating", elapsedSeconds)
+    }
+    let remainingTokenCount =
+      progress.totalTokens > progress.processedTokens
+      ? progress.totalTokens - progress.processedTokens : 0
+    let estimatedRemainingSeconds =
+      elapsedSeconds * Double(remainingTokenCount) / Double(progress.processedTokens)
+    return String(format: "%.1f s / %.1f s", elapsedSeconds, estimatedRemainingSeconds)
   }
   var progressProcessedTokenCount: UInt32 { progress?.processedTokens ?? 0 }
   var progressTotalTokenCount: UInt32 { max(1, progress?.totalTokens ?? 1) }

--- a/apps/astronomical-menu/tests/AstronomicalMenuContractTests/StatusPresentationContractTests.swift
+++ b/apps/astronomical-menu/tests/AstronomicalMenuContractTests/StatusPresentationContractTests.swift
@@ -221,6 +221,7 @@ final class StatusPresentationContractTests: XCTestCase {
     XCTAssertEqual(statusDocument.phaseTitle, "Generating")
     XCTAssertEqual(statusDocument.modelFootprintTitle, "RAM + SSD streaming")
     XCTAssertEqual(statusDocument.progressTitle, "27 / 512 tokens")
+    XCTAssertEqual(statusDocument.elapsedTimeMetricTitle, "Elapsed")
     XCTAssertEqual(statusDocument.elapsedTimeTitle, "1.0 s")
     XCTAssertEqual(statusDocument.progressProcessedTokenCount, 27)
     XCTAssertEqual(statusDocument.progressTotalTokenCount, 512)
@@ -275,10 +276,25 @@ final class StatusPresentationContractTests: XCTestCase {
 
     XCTAssertEqual(statusDocument.flightTitle, "Standing by")
     XCTAssertEqual(statusDocument.progressTitle, "Standing by")
+    XCTAssertEqual(statusDocument.elapsedTimeTitle, "Not active")
     XCTAssertEqual(statusDocument.progressProcessedTokenCount, 0)
     XCTAssertEqual(statusDocument.progressTotalTokenCount, 1)
     XCTAssertEqual(statusDocument.modelFootprintTitle, "Not loaded")
     XCTAssertEqual(statusDocument.mlxMemoryLimitTitle, "40.00 GB")
+  }
+
+  func test_should_calculate_eta_after_the_first_progress_token() throws {
+    let statusDocument = try JSONDecoder().decode(
+      SupervisorStatusDocument.self,
+      from: Data(
+        #"{"status":"ready","activity":"prompt_processing","progress":{"phase":"prefill","processed_tokens":0,"total_tokens":14412,"elapsed_ms":250}}"#.utf8
+      )
+    )
+
+    XCTAssertEqual(
+      statusDocument.elapsedTimeTitle,
+      "0.2 s / Calculating"
+    )
   }
 
   func test_should_use_plain_language_for_prompt_processing_rate() throws {
@@ -292,6 +308,8 @@ final class StatusPresentationContractTests: XCTestCase {
 
     XCTAssertEqual(statusDocument.menuBarTitle, "PP 1076 tok/s")
     XCTAssertEqual(statusDocument.flightTitle, "Prompt processing · 1076 tok/s")
+    XCTAssertEqual(statusDocument.elapsedTimeMetricTitle, "Elapsed / ETA")
+    XCTAssertEqual(statusDocument.elapsedTimeTitle, "1.0 s / 12.4 s")
   }
 
   func test_should_use_singular_request_grammar_for_one_completed_request() throws {


### PR DESCRIPTION
## Summary
- show elapsed time and estimated remaining time during prompt processing
- keep generation telemetry limited to elapsed time because output length is unknown
- cover active, initial, and idle presentation states

## Verification
- scripts/verify-before-commit.sh
- scripts/test-macos-menu-contracts.sh
- optimized macOS application build and post-build validation