### PR TITLE
perf: overlap resident decode graph submission

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,7 +83,7 @@
 
 - This codebase needs to be performance optimized, to achieve that, all our code, regardless which part, needs to have performance logging and attribution that can be switched on and off through config parameter. The performance logging needs to capture start time and end time of each operation. this will allow us to ATTRIBUTE performance issues to specific code parts. Without attribution we will be guessing why we are observing a slow down, which is a bad state to be in, hence it is imperative that when you are editing code or refactoring or creating new code that they follow a unified performance logging and attribution pattern.
 - The highest priority for performance logging and attribution is the critical path involved in Model Loading from disk, Prompt Processing, Tokenization, Disk Cache, Expert Paging and finally token generation. In short any and all operations invovled in actually serving a model request to the end user.
-- The minimum representative performane test needs to intake 1K tokens and output 512 tokens with a plus or minus 15% allowance. Anything below that is not a representative measurement at all.
+- The minimum representative performane test needs to intake 1K tokens and output 1K tokens with a plus or minus 15% allowance. Anything below that is not a representative measurement at all.
 
 ## Maximize the Use of the GPU versus CPU
 

--- a/crates/model-serving/src/qwen3_5/model/forward_graph.rs
+++ b/crates/model-serving/src/qwen3_5/model/forward_graph.rs
@@ -6,7 +6,8 @@ use crate::{PerformanceAttribution, PerformanceOperation};
 use super::model::Qwen3_5Model;
 use super::{Qwen3_5ExecutionError, RequestDecoderStateStack};
 
-const PREFILL_ASYNC_SUBMISSION_LAYER_INTERVAL: usize = 8;
+// Bounded submissions overlap host graph construction without per-layer scheduler overhead.
+const FORWARD_ASYNC_SUBMISSION_LAYER_INTERVAL: usize = 3;
 
 /// Target-model graph outputs needed to seed MTP drafting from a verified target forward.
 pub struct Qwen3_5TargetForwardOutput {
@@ -239,8 +240,7 @@ impl Qwen3_5Model {
                 paged_prefill_execution_mode,
                 performance_attribution,
             )?;
-            if token_count > 1
-                && (layer_index + 1).is_multiple_of(PREFILL_ASYNC_SUBMISSION_LAYER_INTERVAL)
+            if (layer_index + 1).is_multiple_of(FORWARD_ASYNC_SUBMISSION_LAYER_INTERVAL)
                 && layer_index + 1 < decoder_layer_count
             {
                 self.runtime.async_eval_arrays(&[&hidden_states])?;

--- a/crates/model-serving/tests/model_artifact_qualification/qwen3_5_moe/mtp/benchmark.rs
+++ b/crates/model-serving/tests/model_artifact_qualification/qwen3_5_moe/mtp/benchmark.rs
@@ -2,8 +2,8 @@ use std::path::Path;
 use std::time::{Duration, Instant};
 
 use astronomical_ipc_protocol::{
-    ChatGenerationCommand, ChatGenerationSettings, ChatMessage, ChatToolChoice, MtpRuntimeState,
-    RequestId,
+    ChatGenerationCommand, ChatGenerationSettings, ChatMessage, ChatToolChoice, ExpertMemoryMode,
+    MtpRuntimeState, RequestId,
 };
 use astronomical_model_serving::{
     GeneratedToken, InferenceEngine, Qwen3_5ArtifactValidator, Qwen3_5Engine,
@@ -15,7 +15,7 @@ use super::IMAGE_PAD_TOKEN_ID;
 use super::engine_support::load_mtp_test_engine;
 
 const BENCHMARK_INPUT_TOKEN_COUNT: usize = 1_024;
-const BENCHMARK_OUTPUT_TOKEN_COUNT: u16 = 512;
+const BENCHMARK_OUTPUT_TOKEN_COUNT: u16 = 1_024;
 const BENCHMARK_SOURCE_TEXT: &str = include_str!(
     "../../../../../../apps/inference-worker/tests/fixtures/model_metrics_5000_romeo_and_juliet_words.txt"
 );
@@ -29,6 +29,55 @@ async fn should_keep_representative_mtp_generation_faster_and_exact() {
     )
     .await
     .expect("the representative MTP release gate should finish within 115 seconds");
+}
+
+#[tokio::test]
+#[ignore = "loads the fully resident target model for representative decode measurement"]
+async fn should_measure_representative_fully_resident_target_only_decode() {
+    tokio::time::timeout(
+        Duration::from_secs(60),
+        run_representative_fully_resident_target_only_decode(),
+    )
+    .await
+    .expect("representative fully resident decode should finish within 60 seconds");
+}
+
+async fn run_representative_fully_resident_target_only_decode() {
+    let _direct_mlx_guard = crate::common::direct_mlx_test_guard().await;
+    let model_directory = super::super::qwen3_6_35b_a3b_oq4e_mtp_model_directory();
+    let benchmark_prompt_cases = prepare_benchmark_prompt_cases(&model_directory);
+    eprintln!(
+        "[oq4e-resident-decode] status=start input_tokens={} output_tokens={} ETA_seconds=60",
+        BENCHMARK_INPUT_TOKEN_COUNT, BENCHMARK_OUTPUT_TOKEN_COUNT,
+    );
+    let (mut target_only_engine, _temporary_log_directory, _performance_attribution_log_path) =
+        load_mtp_test_engine(&model_directory, false).await;
+    target_only_engine
+        .load()
+        .await
+        .expect("the representative fully resident target-only engine should load");
+    target_only_engine
+        .disable_adaptive_ram_growth_memory_guard_for_tests()
+        .await
+        .expect("the representative resident benchmark should disable adaptive guarding");
+    let target_only_measurement = run_one_generation(
+        &mut target_only_engine,
+        RequestId::new(40_100),
+        &benchmark_prompt_cases[0],
+        BENCHMARK_OUTPUT_TOKEN_COUNT,
+    )
+    .await;
+    assert_eq!(
+        target_only_measurement.generated_token_ids.len(),
+        usize::from(BENCHMARK_OUTPUT_TOKEN_COUNT),
+        "the resident decode measurement must use the complete output budget"
+    );
+    eprintln!(
+        "[oq4e-resident-decode] status=success input_tokens={} output_tokens={} target_only_tok_per_second={:.2}",
+        BENCHMARK_INPUT_TOKEN_COUNT,
+        BENCHMARK_OUTPUT_TOKEN_COUNT,
+        target_only_measurement.tokens_per_second(),
+    );
 }
 
 async fn run_representative_mtp_release_gate() {
@@ -274,10 +323,15 @@ async fn run_one_generation(
         maximum_output_tokens,
     )
     .with_image_pad_token_id(IMAGE_PAD_TOKEN_ID);
-    engine
+    let generation_start = engine
         .start_generation(inference_request)
         .await
         .expect("the representative benchmark request should start");
+    assert_eq!(
+        generation_start.expert_memory_mode(),
+        Some(ExpertMemoryMode::Resident),
+        "the representative benchmark must isolate fully resident generation"
+    );
 
     let mut measurement = BenchmarkMeasurement::default();
     let mut first_generated_token_at = None;
@@ -297,7 +351,7 @@ async fn run_one_generation(
                 measurement.generated_token_ids.push(token_id);
                 if measurement.generated_token_ids.len().is_multiple_of(16) {
                     eprintln!(
-                        "[oq4e-mtp-release] status=progress phase={} generated_tokens={}/{}",
+                        "[oq4e-generation-benchmark] status=progress phase={} generated_tokens={}/{}",
                         benchmark_prompt_case.phase_name,
                         measurement.generated_token_ids.len(),
                         maximum_output_tokens,

--- a/docs/performance-optimizations-lessons.md
+++ b/docs/performance-optimizations-lessons.md
@@ -66,7 +66,7 @@
 - Materialize model-invariant scalar arrays once at model load instead of recreating and casting them in every forward pass.
 - Compare independently assembled bfloat16 inference paths with one representable logit-step tolerance plus identical greedy-token checks. Requiring bit-identical logits can force unnecessary 32-bit floating-point work despite equivalent model decisions.
 - Shapeless compilation does not make input-derived static constants dynamic. Use rank-zero broadcast constants; an input-shaped zero froze gated-delta decay to the first prefill length and broke later tail chunks.
-- Submit dependent prefill graphs asynchronously in bounded layer groups. This overlaps Rust graph construction with graphics-processor evaluation without synchronizing every layer.
+- Submit dependent forward graphs asynchronously in bounded layer groups for prompt processing and one-token generation. This overlaps Rust graph construction with graphics-processor evaluation without synchronizing every layer; measure the interval because excessive submissions add scheduler overhead.
 - Treat mamba_ssm_dtype: float32 as a decay-computation contract, not a disk-storage contract. Qwen3.5-family artifacts can store A_log and other model parameters as FP16, BF16, or FP32 independently from activation dtype. Retain source storage without conversion and promote only the decay operation that requires FP32 arithmetic; eager whole-model promotion increases residency and changes the artifact’s precision contract.
 - Keep OptiQ metadata validation aligned with MLX affine quantization: bit widths 2, 3, 4, 5, 6, and 8 and group sizes 32, 64, and 128 are supported. Metadata may include embedding and output-head measurements; when present, verify them against config instead of rejecting them as unexpected.
 
@@ -190,7 +190,7 @@
 - Gate previous-token expert prefetch by measured useful versus wasted payload. Partial route overlap can still amplify reads substantially even when adjacent tokens share several experts.
 - Distinguish fixed layer-order weight prefetch from route-aware expert paging. Layer order can stage a complete sparse-expert layer while earlier layers compute, but it cannot reveal later router selections. At low routing density, staging the complete layer transfers mostly unused expert payload; keep direct route-driven reads unless a benchmark proves that the transfer is hidden and the larger retained payload is safe.
 - Tensor-major aligned expert packs preserve both source and destination contiguity for adjacent sorted expert IDs. Emit one direct Metal input/output range per adjacent expert run and tensor, rather than one range per expert. For a three-tensor native BF16 layer, loading all 256 experts becomes three commands rather than 768 with no extra payload bytes.
-- Treat one-layer range and command measurements as diagnostics only. Qualify an expert-paging performance change through the production path with 1,024 input tokens, 512 generated tokens, the intended memory ceiling, output parity, and peak memory evidence.
+- Treat one-layer range and command measurements as diagnostics only. Qualify an expert-paging performance change through the production path with 1,024 input tokens, 1,024 generated tokens, the intended memory ceiling, output parity, and peak memory evidence.
 - Compare prompt-processing throughput only at equivalent expert residency. A compact mixed-bit checkpoint can retain every sparse expert layer under the live MLX ceiling while an 8-bit variant pages missing layers from storage during each prefill; that is a different execution path, not an architecture-level prefill advantage.
 - Native multi-token prediction prepares predictor history during prefill and accelerates only accepted greedy decode drafts. Do not treat its presence as evidence of faster prompt processing.
 
@@ -206,7 +206,7 @@
 - Project predictor history updates in their real forward boundaries. Combining two sequential one-token updates into one two-token estimate can undercount slab growth when the first update fills the current capacity and the second allocates a complete growth step.
 - Keep the MTP history entry created from the confirmed current token when its draft is rejected. Only the draft is unconfirmed; rolling back the predictor entry discards committed history and misaligns later proposals.
 - Qualify MTP with representative output lengths. A short all-accepted sample can hide later rejection-state defects, two-token target-forward numerical drift, and acceptance rates too low to repay proposal and verification work.
-- Use approximately 1,000 input tokens and at least 512 generated tokens for model-generation throughput claims. Shorter probes may diagnose mechanics but are not performance evidence.
+- Use approximately 1,000 input tokens and 1,000 generated tokens for model-generation throughput claims. Shorter probes may diagnose mechanics but are not performance evidence.
 - Treat exact greedy parity and throughput as independent release gates. Mathematically equivalent two-token verification can use different multi-token kernels and accumulate a different decoder state from repeated one-token decode, so verification alone does not prove exact production parity.
 - Prefill MTP history with each target hidden row paired to the following prompt token. Starting prediction with empty history discards the prompt context that trained the prediction head.
 - Roll append-only attention state back by moving its logical frontier. Retaining complete key/value slabs for every MTP checkpoint creates context-sized copy-on-write work; only overwritten recurrent and convolution state needs tensor snapshots.
@@ -233,7 +233,7 @@
 - Start steady-state generation timing after the first output token. A cumulative clock that includes prompt processing creates artificial acceleration as more output tokens amortize prefill.
 - The first layer pass mixes page faults, kernel compilation, and execution. Repeat with warm weights and pipelines before judging steady state.
 - Mutate one reference behavior at a time. This identified expert sorting and Metal dispatch without guessing.
-- Use 1,024 input tokens and 512 output tokens for representative generation measurements. Keep shorter probes only as development diagnostics.
+- Use 1,024 input tokens and 1,024 output tokens for representative generation measurements. Keep shorter probes only as development diagnostics.
 
 ## C++ and Rust build boundary
 


### PR DESCRIPTION
## Summary

- Submit dependent Qwen forward graphs every three decoder layers during one-token generation as well as prompt processing.
- Add a fully resident 1,024-input-token and 1,024-output-token qualification and enforce the representative output length.
- Record the bounded asynchronous submission lesson in the performance guidance.

## Evidence

- Repeated controlled fully resident qualification improved generation throughput by approximately 9 to 11 percent.
- The optimized macOS application build and post-build validation passed.
- scripts/verify-before-commit.sh passed immediately before commit and push.

## Known Qualification

The existing MTP exact-output parity gate remains red for accepted two-token verification. This change does not alter MTP acceptance semantics.