### PR TITLE
fix: unblock GitHub Pages deployment

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -34,10 +34,24 @@ jobs:
           persist-credentials: false
       - name: Configure GitHub Pages
         uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
-      - name: Upload static site
-        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
+      - name: Archive static site
+        run: |
+          echo "::group::Archive static site"
+          tar \
+            --dereference --hard-dereference \
+            --directory site \
+            -cvf "$RUNNER_TEMP/artifact.tar" \
+            --exclude=.git \
+            --exclude=.github \
+            .
+          echo "::endgroup::"
+      - name: Upload static site artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          path: site
+          name: github-pages
+          path: ${{ runner.temp }}/artifact.tar
+          retention-days: 1
+          if-no-files-found: error
       - name: Deploy GitHub Pages
         id: deployment
         uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4


### PR DESCRIPTION
GitHub Pages currently fails before deployment because repository action policy rejects the transitive actions/upload-artifact@v4 dependency used by upload-pages-artifact. This change reproduces the Pages artifact archive step directly and uploads it with a full SHA-pinned actions/upload-artifact reference. The deploy action, permissions, artifact name, and retention remain unchanged. Verification completed with scripts/verify-before-commit.sh, actionlint, shellcheck, and a local archive probe.