### PR TITLE
docs: define speculative decoding defaults

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,3 +89,8 @@
 
 - In this code base, the user of the GPU should be adopted to the maximum extent possible, it has been observed that the more computations that can be offloaded to the GPU, the better the performance will be.
 - Do not assume that a certain GPU operation will be slower or will not yield more performance than the CPU.
+
+## Speculative Decoding Whether MTP or DFlash are First Class Citizens
+
+- The desired default behavior is that MTP or DFlash is enabled by default for models that support those.
+- There shouldnt be any defaults that disable MTP or Dflash or any type of speculative decoding for models that support those.


### PR DESCRIPTION
## Problem

Repository guidance did not explicitly state the desired default behavior for supported speculative decoding paths. This left MTP and DFlash defaults open to accidental disabling.

## Change

- Add project guidance that supported MTP or DFlash paths should be enabled by default.
- Keep the change limited to AGENTS.md; no runtime behavior or production code changes are included.

## Verification

- scripts/verify-before-commit.sh passed before commit and again before push, including dependency notices, formatting, hermetic tests, and REST API tests.
- No runtime tests were added because this is documentation-only; the repository verification gate passed.

## Safety

- [x] No credentials, personal paths, prompts, model inventories, proprietary artifacts, or machine logs are included.
- [x] No model precision or output semantics are changed.
- [x] No production performance or memory behavior is changed.
- [x] No unreviewed source reuse was introduced.