### PR TITLE
fix: honor per-request Qwen3.5 thinking budgets

### DIFF
--- a/crates/model-serving/src/lib.rs
+++ b/crates/model-serving/src/lib.rs
@@ -91,9 +91,10 @@ pub use qwen3_5::{
     ValidatedQwen3_5Artifact, discover_sampler_config, discover_token_ids,
     plan_qwen3_5_visual_embedding_suffix, qwen3_5_decoder_cache_layout,
     qwen3_5_language_tensor_profiles, qwen3_5_mtp_tensor_profiles,
-    qwen3_5_quantized_mtp_tensor_names, qwen3_5_resident_language_tensor_profiles,
-    qwen3_5_vision_tensor_profiles, resolve_sampling_seed, translate_qwen3_5_preparation_error,
-    translate_request_output_error, validate_context_token_count,
+    qwen3_5_quantized_mtp_tensor_names, qwen3_5_request_enables_thinking,
+    qwen3_5_resident_language_tensor_profiles, qwen3_5_vision_tensor_profiles,
+    resolve_sampling_seed, translate_qwen3_5_preparation_error, translate_request_output_error,
+    validate_context_token_count,
 };
 #[cfg(feature = "direct-mlx")]
 pub use qwen3_5::{

--- a/crates/model-serving/src/qwen3_5/mod.rs
+++ b/crates/model-serving/src/qwen3_5/mod.rs
@@ -51,8 +51,8 @@ pub use text::{
     Qwen3_5OutputParserError, Qwen3_5PromptError, Qwen3_5PromptRenderer, Qwen3_5RequestOutput,
     Qwen3_5RequestOutputError, Qwen3_5SamplerConfig, Qwen3_5SamplingStrategy, Qwen3_5TokenDecoder,
     Qwen3_5TokenIds, Qwen3_5Tokenizer, Qwen3_5TokenizerError, Qwen3_5ToolCall,
-    discover_sampler_config, discover_token_ids, resolve_sampling_seed,
-    translate_qwen3_5_preparation_error, translate_request_output_error,
+    discover_sampler_config, discover_token_ids, qwen3_5_request_enables_thinking,
+    resolve_sampling_seed, translate_qwen3_5_preparation_error, translate_request_output_error,
     validate_context_token_count,
 };
 pub use vision::{

--- a/crates/model-serving/src/qwen3_5/text/mod.rs
+++ b/crates/model-serving/src/qwen3_5/text/mod.rs
@@ -17,7 +17,8 @@ pub use inference_request::{Qwen3_5InferenceRequest, Qwen3_5SamplingStrategy};
 pub use output_parser::{Qwen3_5OutputEvent, Qwen3_5OutputParser, Qwen3_5ToolCall};
 pub use output_parser_error::Qwen3_5OutputParserError;
 pub use processor::{
-    Qwen3_5GenerationProcessor, translate_qwen3_5_preparation_error, translate_request_output_error,
+    Qwen3_5GenerationProcessor, qwen3_5_request_enables_thinking,
+    translate_qwen3_5_preparation_error, translate_request_output_error,
 };
 pub use prompt::{Qwen3_5PromptError, Qwen3_5PromptRenderer};
 pub use request_output::{Qwen3_5RequestOutput, Qwen3_5RequestOutputError};

--- a/crates/model-serving/src/qwen3_5/text/processor.rs
+++ b/crates/model-serving/src/qwen3_5/text/processor.rs
@@ -106,11 +106,15 @@ impl ModelGenerationProcessor for Qwen3_5GenerationProcessor {
         } else {
             PerformanceAttribution::disabled()
         };
+        let request_enable_thinking = qwen3_5_request_enables_thinking(
+            self.enable_thinking,
+            chat_generation_command.settings.thinking_budget,
+        );
         let inference_request = self
             .tokenizer
             .prepare_chat_with_performance_attribution(
                 chat_generation_command,
-                self.enable_thinking,
+                request_enable_thinking,
                 &mut performance_attribution,
             )
             .map_err(|validation_error| {
@@ -136,7 +140,7 @@ impl ModelGenerationProcessor for Qwen3_5GenerationProcessor {
                     Qwen3_5RequestOutput::new(
                         &self.tokenizer,
                         &chat_generation_command.tools,
-                        self.enable_thinking,
+                        request_enable_thinking,
                     )
                 },
             )
@@ -170,12 +174,7 @@ impl ModelGenerationProcessor for Qwen3_5GenerationProcessor {
         let output_events = request_output
             .push_token(generated_token_id)
             .map_err(translate_request_output_error)?;
-        translate_output_events(
-            &self.tokenizer,
-            self.enable_thinking,
-            request_output,
-            output_events,
-        )
+        translate_output_events(&self.tokenizer, request_output, output_events)
     }
 
     fn finish_request_output(
@@ -185,14 +184,24 @@ impl ModelGenerationProcessor for Qwen3_5GenerationProcessor {
         let output_events = request_output
             .finish()
             .map_err(translate_request_output_error)?;
-        let (public_outputs, _model_feedback_token_ids) = translate_output_events(
-            &self.tokenizer,
-            self.enable_thinking,
-            request_output,
-            output_events,
-        )?
-        .into_parts();
+        let (public_outputs, _model_feedback_token_ids) =
+            translate_output_events(&self.tokenizer, request_output, output_events)?.into_parts();
         Ok(public_outputs)
+    }
+}
+
+/// Resolves per-request thinking mode without changing the model capability flag.
+#[must_use]
+pub const fn qwen3_5_request_enables_thinking(
+    model_supports_thinking: bool,
+    thinking_budget: Option<u16>,
+) -> bool {
+    if !model_supports_thinking {
+        return false;
+    }
+    match thinking_budget {
+        Some(0) => false,
+        Some(_) | None => true,
     }
 }
 
@@ -217,7 +226,6 @@ pub fn translate_qwen3_5_preparation_error(
 
 fn translate_output_events(
     tokenizer: &Qwen3_5Tokenizer,
-    enable_thinking: bool,
     request_output: &mut Qwen3_5RequestOutput,
     output_events: Vec<Qwen3_5OutputEvent>,
 ) -> Result<ModelGeneratedTokenTranslation, ModelGenerationOutputError> {
@@ -240,6 +248,7 @@ fn translate_output_events(
                 });
             }
             Qwen3_5OutputEvent::ModelVisibleCorrection { correction_text } => {
+                let enable_thinking = request_output.enable_thinking();
                 let correction_token_ids = tokenizer
                     .encode_model_visible_correction(&correction_text, enable_thinking)
                     .map_err(|tokenizer_error| ModelGenerationOutputError::Fatal {

--- a/crates/model-serving/src/qwen3_5/text/request_output.rs
+++ b/crates/model-serving/src/qwen3_5/text/request_output.rs
@@ -12,6 +12,7 @@ use crate::MalformedModelOutputDiagnostic;
 pub struct Qwen3_5RequestOutput {
     output_parser: Qwen3_5OutputParser,
     token_decoder: Qwen3_5TokenDecoder,
+    enable_thinking: bool,
 }
 
 impl Qwen3_5RequestOutput {
@@ -30,7 +31,14 @@ impl Qwen3_5RequestOutput {
         Ok(Self {
             output_parser,
             token_decoder: tokenizer.incremental_decoder(),
+            enable_thinking,
         })
+    }
+
+    /// Returns whether this request's parser uses the reasoning-prefixed state.
+    #[must_use]
+    pub const fn enable_thinking(&self) -> bool {
+        self.enable_thinking
     }
 
     /// Decodes and parses one generated model token at a stable engine boundary.

--- a/crates/model-serving/tests/qwen3_5_hermetic/processor.rs
+++ b/crates/model-serving/tests/qwen3_5_hermetic/processor.rs
@@ -2,8 +2,18 @@ use astronomical_ipc_protocol::ChatGenerationFailureReason;
 use astronomical_model_serving::{
     MalformedModelOutputDiagnostic, ModelGenerationOutputError, Qwen3_5ImageProcessingError,
     Qwen3_5OutputParserError, Qwen3_5RequestOutputError, Qwen3_5TokenizerError,
-    translate_qwen3_5_preparation_error, translate_request_output_error,
+    qwen3_5_request_enables_thinking, translate_qwen3_5_preparation_error,
+    translate_request_output_error,
 };
+
+#[test]
+fn should_disable_thinking_for_a_zero_budget_without_removing_model_capability() {
+    assert!(!qwen3_5_request_enables_thinking(true, Some(0)));
+    assert!(qwen3_5_request_enables_thinking(true, Some(512)));
+    assert!(qwen3_5_request_enables_thinking(true, None));
+    assert!(!qwen3_5_request_enables_thinking(false, None));
+    assert!(!qwen3_5_request_enables_thinking(false, Some(512)));
+}
 
 #[test]
 fn should_map_a_tokenizer_error_as_fatal_not_malformed() {

--- a/crates/model-serving/tests/qwen3_5_hermetic/prompt.rs
+++ b/crates/model-serving/tests/qwen3_5_hermetic/prompt.rs
@@ -24,6 +24,25 @@ fn should_render_one_user_turn_with_the_pinned_ornith_thinking_prefix() {
 }
 
 #[test]
+fn should_render_one_user_turn_with_a_closed_thinking_block_when_thinking_is_disabled() {
+    let rendered_prompt = Qwen3_5PromptRenderer::render(
+        &[ChatMessage::User {
+            content: "Inspect src.".to_owned(),
+            images: Vec::new(),
+        }],
+        &[],
+        false,
+        &[],
+    )
+    .expect("a bounded user-only Ornith conversation should render");
+
+    assert_eq!(
+        rendered_prompt,
+        "<|im_start|>user\nInspect src.<|im_end|>\n<|im_start|>assistant\n<think>\n\n</think>\n\n"
+    );
+}
+
+#[test]
 fn should_render_vision_markers_with_the_correct_image_pad_token_count_per_image() {
     let rendered_prompt = Qwen3_5PromptRenderer::render(
         &[ChatMessage::User {
@@ -177,5 +196,18 @@ fn should_render_model_visible_correction_as_tool_response_then_reopen_assistant
     assert_eq!(
         rendered_correction,
         "<|im_end|>\n<|im_start|>user\n<tool_response>\nThe previous tool call requested undeclared function 'open_brain', but no tool with that exact name exists. Please correct the tool call by using one of the exact declared tool names.\n</tool_response><|im_end|>\n<|im_start|>assistant\n<think>\n"
+    );
+}
+
+#[test]
+fn should_render_model_visible_correction_with_closed_thinking_when_thinking_is_disabled() {
+    let rendered_correction = Qwen3_5PromptRenderer::render_model_visible_correction(
+        "Please correct the tool call.",
+        false,
+    );
+
+    assert_eq!(
+        rendered_correction,
+        "<|im_end|>\n<|im_start|>user\n<tool_response>\nPlease correct the tool call.\n</tool_response><|im_end|>\n<|im_start|>assistant\n<think>\n\n</think>\n\n"
     );
 }

--- a/docs/performance-optimizations-lessons.md
+++ b/docs/performance-optimizations-lessons.md
@@ -5,6 +5,8 @@
 - Rust and C++ are not automatically faster than Python. Python only submits graphs to Apple’s MLX array framework; graph shape and selected Metal kernels dominate.
 - Compare the exact model implementation selected by model_type. Qwen3.5-MoE uses qwen3_5_moe, not the similar qwen3_next model.
 - Match Machine Learning framework for Apple silicon (MLX) version, model files, prompt, tokenizer, sampling, prefill_chunck_tokens, cache state, and build profile before comparing.
+- Measure long-context parity after the runtime chat template is rendered, and pass the same thinking-mode setting to both the prompt renderer and output parser; counting only source text or disabling thinking in metadata produces unlike workloads.
+- Source-matched sanitize behavior is part of model arithmetic. Stock MLX-LM 0.31.3 double-shifts already-converted Qwen3.5 and Qwen3.6 normalization weights when MTP tensors are present, corrupting target-only output; apply the checkpoint producer's sanitize correction while keeping MTP construction disabled.
 - Use release builds for performance. Debug builds remain useful for correctness only.
 
 ## Mixture-of-experts routing


### PR DESCRIPTION
## Summary

- Resolve Qwen3.5 thinking mode per request instead of using only the model capability flag.
- Use the resolved mode consistently for prompt rendering, output parsing, and model-visible tool corrections.
- Add hermetic coverage for disabled, enabled, and unsupported thinking modes.
- Document the requirement to keep prompt rendering and output parsing aligned.

## Why

A model can support reasoning while an individual request disables it with a zero thinking budget. Previously, prompt preparation and output parsing continued to use the model-level capability flag, which could leave the request in an inconsistent reasoning state.

## Validation

- scripts/verify-before-commit.sh passed.
- Rust formatting and dependency notice checks passed.
- Hermetic and REST API test suites passed.
- The focused Qwen3.5 hermetic suite passed 158 tests.
