### PR TITLE
fix: preserve multi-model routing with SpecPrefill

### DIFF
--- a/apps/inference-worker/src/qwen3_5_model_startup.rs
+++ b/apps/inference-worker/src/qwen3_5_model_startup.rs
@@ -69,6 +69,8 @@ pub(crate) fn initialize_qwen3_5_model(
         }
     };
     let artifact_model_id = validated_artifact.model_id().to_owned();
+    let loaded_model_speculative_prefill_configuration =
+        speculative_prefill.for_loaded_model(&artifact_model_id);
     let artifact_model_revision = validated_artifact.revision().to_owned();
     let artifact_payload_bytes = validated_artifact.total_payload_bytes();
     let artifact_shard_count = validated_artifact.shard_count();
@@ -174,7 +176,7 @@ pub(crate) fn initialize_qwen3_5_model(
         DEFAULT_FULL_ATTENTION_KV_STATE_GROWTH_TOKENS,
         true,
         mtp_enabled,
-        speculative_prefill,
+        loaded_model_speculative_prefill_configuration,
         model_loading_performance_attribution,
         performance_attribution_log,
     )

--- a/apps/supervisor/src/application.rs
+++ b/apps/supervisor/src/application.rs
@@ -99,14 +99,6 @@ impl ApplicationState {
             .collect();
         let resolved_model_id =
             astronomical_config::resolve_model_id(requested_model_id, &known_model_ids);
-        if self
-            .configured_speculative_prefill_target_model_id()
-            .is_some_and(|configured_target_model_id| {
-                configured_target_model_id != resolved_model_id
-            })
-        {
-            return None;
-        }
         let is_ready_model = ready_model_id == Some(resolved_model_id);
         let is_discovered_model = self
             .discovered_models

--- a/apps/supervisor/src/openai_models_endpoint.rs
+++ b/apps/supervisor/src/openai_models_endpoint.rs
@@ -78,23 +78,12 @@ fn advertised_models_for_application_state(
         let worker_health_snapshot = application_state
             .generation_executor
             .worker_health_snapshot();
-        let configured_target_model_id =
-            application_state.configured_speculative_prefill_target_model_id();
-        let can_advertise_ready_model =
-            configured_target_model_id
-                .as_deref()
-                .map_or(true, |configured_target_model_id| {
-                    worker_health_snapshot.ready_model_id.as_deref()
-                        == Some(configured_target_model_id)
-                });
         return match (
             worker_health_snapshot.status.is_ready(),
             worker_health_snapshot.ready_model_id,
             worker_health_snapshot.ready_model_capabilities,
         ) {
-            (true, Some(ready_model_id), Some(ready_model_capabilities))
-                if can_advertise_ready_model =>
-            {
+            (true, Some(ready_model_id), Some(ready_model_capabilities)) => {
                 Ok(vec![openai_model_from_ready_worker_capabilities(
                     ready_model_id,
                     model_advertisement_created_at_unix_seconds,
@@ -119,7 +108,7 @@ fn advertised_models_for_application_state(
 fn discovered_models_for_application_state(
     application_state: &ApplicationState,
 ) -> Vec<DiscoveredModel> {
-    let discovered_models = application_state
+    application_state
         .reloadable_config
         .as_ref()
         .and_then(|reloadable_config| {
@@ -128,16 +117,7 @@ fn discovered_models_for_application_state(
                 .ok()
                 .map(|resolved_runtime_config| resolved_runtime_config.discovered_models.clone())
         })
-        .unwrap_or_else(|| application_state.discovered_models.clone());
-    let Some(configured_target_model_id) =
-        application_state.configured_speculative_prefill_target_model_id()
-    else {
-        return discovered_models;
-    };
-    discovered_models
-        .into_iter()
-        .filter(|discovered_model| discovered_model.model_id == configured_target_model_id)
-        .collect()
+        .unwrap_or_else(|| application_state.discovered_models.clone())
 }
 
 fn openai_model_from_ready_worker_capabilities(

--- a/apps/supervisor/tests/rest_api/config_reload/reload_status.rs
+++ b/apps/supervisor/tests/rest_api/config_reload/reload_status.rs
@@ -179,7 +179,7 @@ async fn should_update_status_config_warning_after_successful_reload() {
 }
 
 #[tokio::test]
-async fn should_reject_rest_model_override_when_speculative_prefill_target_is_bound() {
+async fn should_keep_all_discovered_models_listed_and_routable_with_speculative_prefill() {
     const CONFIGURED_TARGET_MODEL_ID: &str = "astronomical/application-test-model";
     const UNCONFIGURED_MODEL_ID: &str = "astronomical/another-test-model";
 
@@ -227,9 +227,25 @@ async fn should_reject_rest_model_override_when_speculative_prefill_target_is_bo
     let model_list_text = String::from_utf8(model_list_body.to_vec())
         .expect("the model-list response should be UTF-8");
     assert!(model_list_text.contains(CONFIGURED_TARGET_MODEL_ID));
-    assert!(!model_list_text.contains(UNCONFIGURED_MODEL_ID));
+    assert!(model_list_text.contains(UNCONFIGURED_MODEL_ID));
 
-    let override_response = application
+    let configured_target_response = application
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/chat/completions")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(format!(
+                    r#"{{"model":"{CONFIGURED_TARGET_MODEL_ID}","messages":[{{"role":"user","content":"hello"}}],"stream":true}}"#
+                )))
+                .expect("the configured-target request should be well formed"),
+        )
+        .await
+        .expect("the configured-target request should receive a response");
+    assert_eq!(configured_target_response.status(), StatusCode::OK);
+
+    let ordinary_model_response = application
         .oneshot(
             Request::builder()
                 .method("POST")
@@ -238,23 +254,21 @@ async fn should_reject_rest_model_override_when_speculative_prefill_target_is_bo
                 .body(Body::from(format!(
                     r#"{{"model":"{UNCONFIGURED_MODEL_ID}","messages":[{{"role":"user","content":"hello"}}],"stream":true}}"#
                 )))
-                .expect("the model-override request should be well formed"),
+                .expect("the ordinary-model request should be well formed"),
         )
         .await
-        .expect("the model-override request should receive a response");
-    assert_eq!(override_response.status(), StatusCode::BAD_REQUEST);
-    let override_body = to_bytes(override_response.into_body(), 8 * 1024)
-        .await
-        .expect("the model-override response should be readable");
-    let override_body_text =
-        String::from_utf8(override_body.to_vec()).expect("the error response should be UTF-8");
-    assert!(override_body_text.contains(r#""code":"model_not_found""#));
-    assert!(
-        received_generation_commands
-            .lock()
-            .expect("the scripted command log should not be poisoned")
-            .is_empty()
+        .expect("the ordinary-model request should receive a response");
+    assert_eq!(ordinary_model_response.status(), StatusCode::OK);
+
+    let received_generation_commands = received_generation_commands
+        .lock()
+        .expect("the scripted command log should not be poisoned");
+    assert_eq!(received_generation_commands.len(), 2);
+    assert_eq!(
+        received_generation_commands[0].model,
+        CONFIGURED_TARGET_MODEL_ID
     );
+    assert_eq!(received_generation_commands[1].model, UNCONFIGURED_MODEL_ID);
 }
 
 fn discovered_model_for(model_id: &str) -> astronomical_config::DiscoveredModel {

--- a/crates/ipc-protocol/src/protocol_message.rs
+++ b/crates/ipc-protocol/src/protocol_message.rs
@@ -193,6 +193,16 @@ pub struct WorkerSpeculativePrefillConfiguration {
     pub importance_pooling_kernel_token_count: u32,
 }
 
+impl WorkerSpeculativePrefillConfiguration {
+    /// Returns this policy enabled only when the loaded model is its configured target.
+    pub fn for_loaded_model(&self, loaded_model_id: &str) -> Self {
+        let mut loaded_model_speculative_prefill_configuration = self.clone();
+        loaded_model_speculative_prefill_configuration.enabled =
+            self.enabled && self.target_model_id.as_deref() == Some(loaded_model_id);
+        loaded_model_speculative_prefill_configuration
+    }
+}
+
 /// Fully resolved worker-owned startup settings.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(deny_unknown_fields)]

--- a/crates/ipc-protocol/tests/hermetic/mod.rs
+++ b/crates/ipc-protocol/tests/hermetic/mod.rs
@@ -3,3 +3,4 @@ mod chat_generation;
 mod chat_generation_validation;
 mod chat_generation_validation_limits;
 mod minimal_protocol;
+mod speculative_prefill_configuration;

--- a/crates/ipc-protocol/tests/hermetic/speculative_prefill_configuration.rs
+++ b/crates/ipc-protocol/tests/hermetic/speculative_prefill_configuration.rs
@@ -1,0 +1,41 @@
+use std::path::PathBuf;
+
+use astronomical_ipc_protocol::WorkerSpeculativePrefillConfiguration;
+
+#[test]
+fn should_enable_speculative_prefill_for_its_configured_target_model() {
+    let speculative_prefill_configuration = speculative_prefill_configuration_for_tests();
+
+    let target_model_speculative_prefill_configuration =
+        speculative_prefill_configuration.for_loaded_model("astronomical/target-model");
+
+    assert_eq!(
+        target_model_speculative_prefill_configuration,
+        speculative_prefill_configuration
+    );
+}
+
+#[test]
+fn should_disable_speculative_prefill_for_an_unconfigured_model() {
+    let speculative_prefill_configuration = speculative_prefill_configuration_for_tests();
+
+    let ordinary_model_speculative_prefill_configuration =
+        speculative_prefill_configuration.for_loaded_model("astronomical/ordinary-model");
+
+    assert!(!ordinary_model_speculative_prefill_configuration.enabled);
+}
+
+fn speculative_prefill_configuration_for_tests() -> WorkerSpeculativePrefillConfiguration {
+    WorkerSpeculativePrefillConfiguration {
+        enabled: true,
+        target_model_id: Some("astronomical/target-model".to_owned()),
+        draft_model_id: Some("astronomical/draft-model".to_owned()),
+        draft_model_directory: Some(PathBuf::from("/tmp/fictional-draft-model")),
+        minimum_prompt_tokens: 8_192,
+        keep_percentage: 20,
+        selection_chunck_token_count: 32,
+        mandatory_trailing_token_count: 512,
+        lookahead_token_count: 8,
+        importance_pooling_kernel_token_count: 13,
+    }
+}


### PR DESCRIPTION
## Summary

- Keep every discovered model advertised and routable when SpecPrefill is configured.
- Enable the worker SpecPrefill policy only when the loaded model matches its configured target.
- Add REST acceptance coverage and focused worker-configuration tests for target and non-target models.

## Verification

- scripts/verify-before-commit.sh
- scripts/make-astronomical-app.sh