### PR TITLE
Improve worker failure diagnostics

### DIFF
--- a/apps/supervisor/src/worker_containment.rs
+++ b/apps/supervisor/src/worker_containment.rs
@@ -100,9 +100,11 @@ async fn cancel_worker_request(
                     request_id: failed_request_id,
                     ..
                 } if failed_request_id == request_id => return Ok(()),
-                _ => {
+                unexpected_worker_event => {
                     return Err(WorkerControlError::UnexpectedCancellationEvent {
                         request_id: request_id.value(),
+                        unexpected_worker_event_summary: unexpected_worker_event
+                            .diagnostic_summary(),
                     });
                 }
             }
@@ -120,15 +122,33 @@ pub(super) async fn contain_worker_failure(
     active_generation: &mut Option<ActiveGeneration>,
     operation_error: WorkerControlError,
 ) {
-    tracing::error!(error = %operation_error, "worker failed; terminating local worker process");
+    let worker_process_id = worker_process.process_id();
+    tracing::error!(
+        error = %operation_error,
+        worker_process_id = ?worker_process_id,
+        "worker failed; terminating local worker process"
+    );
     fail_active_generation(
         active_generation,
         ChatGenerationStreamErrorCode::WorkerUnavailable,
     );
     publish_activity(health_snapshot, WorkerActivity::Idle);
     clear_active_request_progress(health_snapshot);
-    if let Err(cleanup_error) = worker_process.force_terminate().await {
-        tracing::error!(error = %cleanup_error, "failed to terminate local worker process");
+    match worker_process.force_terminate().await {
+        Ok(worker_termination_outcome) => {
+            tracing::error!(
+                worker_process_id = ?worker_process_id,
+                worker_termination_outcome = ?worker_termination_outcome,
+                "local worker process terminated after failure"
+            );
+        }
+        Err(cleanup_error) => {
+            tracing::error!(
+                error = %cleanup_error,
+                worker_process_id = ?worker_process_id,
+                "failed to terminate local worker process"
+            );
+        }
     }
     publish_health(
         health_snapshot,

--- a/apps/supervisor/src/worker_control_error.rs
+++ b/apps/supervisor/src/worker_control_error.rs
@@ -80,10 +80,14 @@ pub enum WorkerControlError {
     TerminateWorker(#[source] io::Error),
 
     /// The worker emitted an unexpected event while cancellation cleanup was waiting for an ack.
-    #[error("worker emitted an unexpected event while cancelling request {request_id}")]
+    #[error(
+        "worker emitted an unexpected event while cancelling request {request_id}: {unexpected_worker_event_summary}"
+    )]
     UnexpectedCancellationEvent {
         /// The request being cancelled.
         request_id: u64,
+        /// A bounded event-kind and request-correlation summary without model payloads.
+        unexpected_worker_event_summary: String,
     },
 
     /// The worker closed its IPC output before the supervisor received the expected event.

--- a/apps/supervisor/tests/fixtures/scripted_worker.rs
+++ b/apps/supervisor/tests/fixtures/scripted_worker.rs
@@ -29,6 +29,7 @@ async fn run_fixture() -> Result<(), Box<dyn Error + Send + Sync>> {
     let mut active_request_id = None;
     let mut cancellation_acknowledgement_delay = Duration::ZERO;
     let mut should_acknowledge_cancellation = true;
+    let mut should_emit_unexpected_cancellation_event = false;
     let ready_model_id = std::env::var(READY_MODEL_ID_ENVIRONMENT_VARIABLE)
         .unwrap_or_else(|_| DEFAULT_READY_MODEL_ID.to_owned());
     event_writer
@@ -101,6 +102,11 @@ async fn run_fixture() -> Result<(), Box<dyn Error + Send + Sync>> {
                         active_request_id = Some(request_id);
                         cancellation_acknowledgement_delay = Duration::from_secs(4);
                         should_acknowledge_cancellation = true;
+                    }
+                    "astronomical/unexpected-cancellation-event-fixture" => {
+                        active_request_id = Some(request_id);
+                        should_acknowledge_cancellation = true;
+                        should_emit_unexpected_cancellation_event = true;
                     }
                     "astronomical/activity-transition-fixture" => {
                         send_activity_transition(request_id, &mut event_writer).await?;
@@ -323,6 +329,20 @@ async fn run_fixture() -> Result<(), Box<dyn Error + Send + Sync>> {
                 }
                 tokio::time::sleep(cancellation_acknowledgement_delay).await;
                 cancellation_acknowledgement_delay = Duration::ZERO;
+                if should_emit_unexpected_cancellation_event {
+                    should_emit_unexpected_cancellation_event = false;
+                    event_writer
+                        .send_event(&WorkerEvent::Completed {
+                            request_id: RequestId::new(2),
+                            prompt_token_count: 1,
+                            generated_token_count: 0,
+                            reasoning_token_count: 0,
+                            cached_token_count: 0,
+                            reason: ChatGenerationCompletionReason::Cancelled,
+                        })
+                        .await?;
+                    continue;
+                }
                 event_writer
                     .send_event(&WorkerEvent::Completed {
                         request_id,

--- a/apps/supervisor/tests/hermetic/worker_cancellation.rs
+++ b/apps/supervisor/tests/hermetic/worker_cancellation.rs
@@ -4,7 +4,7 @@ use astronomical_ipc_protocol::{
     ChatGenerationCommand, ChatGenerationSettings, ChatMessage, ChatToolChoice, RequestId,
 };
 use astronomical_supervisor::{
-    ChatGenerationExecutor, ChatGenerationStreamEvent, WorkerHealthStatus,
+    ChatGenerationExecutor, ChatGenerationStreamEvent, WorkerControlError, WorkerHealthStatus,
 };
 use tokio::time::{Instant, sleep, timeout};
 
@@ -80,6 +80,44 @@ async fn should_keep_worker_ready_when_prefill_cancellation_acknowledgement_is_d
         .shutdown()
         .await
         .expect("shutdown should succeed");
+}
+
+#[tokio::test]
+async fn should_record_the_unexpected_event_that_contains_a_cancellation_mismatch() {
+    let worker_executable_path = std::env::var("CARGO_BIN_EXE_astronomical-supervisor-test-worker")
+        .expect("Cargo should provide the test worker path");
+    let worker_executor = launch_test_executor(worker_executable_path)
+        .await
+        .expect("the worker should launch");
+    wait_for_health(&worker_executor, WorkerHealthStatus::Ready).await;
+    let stream_receiver = worker_executor
+        .start_chat_generation(command_for_model(
+            "astronomical/unexpected-cancellation-event-fixture",
+        ))
+        .await
+        .expect("the fixture should start the cancellable request");
+
+    drop(stream_receiver);
+    timeout(
+        Duration::from_secs(5),
+        wait_for_health(&worker_executor, WorkerHealthStatus::Unavailable),
+    )
+    .await
+    .expect("the unexpected cancellation event should contain the worker");
+
+    let diagnostic_error = WorkerControlError::UnexpectedCancellationEvent {
+        request_id: 1,
+        unexpected_worker_event_summary: "completed request_id=2".to_owned(),
+    };
+    assert_eq!(
+        diagnostic_error.to_string(),
+        "worker emitted an unexpected event while cancelling request 1: completed request_id=2"
+    );
+
+    worker_executor
+        .shutdown()
+        .await
+        .expect("shutdown after cancellation containment should be idempotent");
 }
 
 fn command_for_model(model_id: &str) -> ChatGenerationCommand {

--- a/crates/ipc-protocol/src/protocol_message.rs
+++ b/crates/ipc-protocol/src/protocol_message.rs
@@ -431,3 +431,42 @@ pub enum WorkerEvent {
         persistent_prompt_cache_visual_embedding_rows_loaded: u64,
     },
 }
+
+impl WorkerEvent {
+    /// Returns a bounded diagnostic summary without exposing model-generated payloads.
+    #[must_use]
+    pub fn diagnostic_summary(&self) -> String {
+        match self {
+            Self::Idle { .. } => "idle".to_owned(),
+            Self::MlxMemorySample { .. } => "mlx_memory_sample".to_owned(),
+            Self::MlxMemoryLimitChanged { .. } => "mlx_memory_limit_changed".to_owned(),
+            Self::MlxMemoryLimitRejected { .. } => "mlx_memory_limit_rejected".to_owned(),
+            Self::ExpertMemoryModeChanged { .. } => "expert_memory_mode_changed".to_owned(),
+            Self::GenerationFinalized { request_id, .. } => {
+                format!("generation_finalized request_id={}", request_id.value())
+            }
+            Self::Ready { .. } => "ready".to_owned(),
+            Self::Output { request_id, .. } => {
+                format!("output request_id={}", request_id.value())
+            }
+            Self::PrefillProgress { request_id, .. } => {
+                format!("prefill_progress request_id={}", request_id.value())
+            }
+            Self::GenerationProgress { request_id, .. } => {
+                format!("generation_progress request_id={}", request_id.value())
+            }
+            Self::PromptWorkReuse { request_id, .. } => {
+                format!("prompt_work_reuse request_id={}", request_id.value())
+            }
+            Self::Completed { request_id, .. } => {
+                format!("completed request_id={}", request_id.value())
+            }
+            Self::Failed { request_id, .. } => {
+                format!("failed request_id={}", request_id.value())
+            }
+            Self::ModelSwapped { .. } => "model_swapped".to_owned(),
+            Self::ModelSwapFailed { .. } => "model_swap_failed".to_owned(),
+            Self::PersistentPromptCacheStats { .. } => "persistent_prompt_cache_stats".to_owned(),
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- include bounded event and request correlation details for cancellation protocol mismatches
- log worker process identity and termination outcome during failure containment
- cover unexpected cancellation events with a hermetic worker fixture

## Verification

- scripts/verify-before-commit.sh
- 20 repeated parallel supervisor worker-launch test runs
- macOS application build and post-build validation