### PR TITLE
fix: preserve worker telemetry during cancellation

### DIFF
--- a/apps/supervisor/src/worker_containment.rs
+++ b/apps/supervisor/src/worker_containment.rs
@@ -8,6 +8,7 @@ use crate::chat_generation_executor::try_send_stream_event;
 use crate::worker_health::{
     clear_active_request_progress, clear_latest_mlx_memory_snapshot, publish_activity,
     publish_expert_memory_mode, publish_health, publish_latest_mlx_memory_snapshot,
+    publish_persistent_prompt_cache_stats,
 };
 use crate::worker_loop_types::ActiveGeneration;
 use crate::{
@@ -105,6 +106,20 @@ async fn cancel_worker_request(
                             health_snapshot,
                             expert_residency,
                         );
+                    }
+                }
+                WorkerEvent::PersistentPromptCacheStats { .. } => {
+                    // Cache publication can finish after the client drops the
+                    // stream. Keep the worker reusable and record the telemetry.
+                    publish_persistent_prompt_cache_stats(health_snapshot, worker_event);
+                }
+                WorkerEvent::MlxMemorySample {
+                    mlx_memory_snapshot,
+                } => {
+                    if let Some(mlx_memory_snapshot) = mlx_memory_snapshot {
+                        publish_latest_mlx_memory_snapshot(health_snapshot, mlx_memory_snapshot);
+                    } else {
+                        clear_latest_mlx_memory_snapshot(health_snapshot);
                     }
                 }
                 WorkerEvent::Completed {

--- a/apps/supervisor/tests/fixtures/scripted_worker.rs
+++ b/apps/supervisor/tests/fixtures/scripted_worker.rs
@@ -17,6 +17,13 @@ use scripted_worker_chat::{send_accepted_chat, send_activity_transition, send_si
 const READY_MODEL_ID_ENVIRONMENT_VARIABLE: &str = "ASTRONOMICAL_TEST_WORKER_READY_MODEL_ID";
 const DEFAULT_READY_MODEL_ID: &str = "astronomical/test-worker";
 
+/// Selects the memory telemetry emitted before a cancellation acknowledgement.
+enum CancellationMlxTelemetry {
+    None,
+    Publish,
+    Clear,
+}
+
 #[tokio::main]
 async fn main() -> ExitCode {
     match run_fixture().await {
@@ -35,6 +42,8 @@ async fn run_fixture() -> Result<(), Box<dyn Error + Send + Sync>> {
     let mut cancellation_acknowledgement_delay = Duration::ZERO;
     let mut should_acknowledge_cancellation = true;
     let mut should_emit_unexpected_cancellation_event = false;
+    let mut should_emit_cache_stats_before_cancellation_acknowledgement = false;
+    let mut cancellation_mlx_telemetry = CancellationMlxTelemetry::None;
     let ready_model_id = std::env::var(READY_MODEL_ID_ENVIRONMENT_VARIABLE)
         .unwrap_or_else(|_| DEFAULT_READY_MODEL_ID.to_owned());
     event_writer
@@ -112,6 +121,28 @@ async fn run_fixture() -> Result<(), Box<dyn Error + Send + Sync>> {
                         active_request_id = Some(request_id);
                         should_acknowledge_cancellation = true;
                         should_emit_unexpected_cancellation_event = true;
+                    }
+                    "astronomical/cache-stats-during-cancellation-fixture" => {
+                        active_request_id = Some(request_id);
+                        should_acknowledge_cancellation = true;
+                        should_emit_cache_stats_before_cancellation_acknowledgement = true;
+                    }
+                    "astronomical/mlx-memory-during-cancellation-fixture" => {
+                        active_request_id = Some(request_id);
+                        should_acknowledge_cancellation = true;
+                        cancellation_mlx_telemetry = CancellationMlxTelemetry::Publish;
+                    }
+                    "astronomical/mlx-memory-clear-during-cancellation-fixture" => {
+                        active_request_id = Some(request_id);
+                        should_acknowledge_cancellation = true;
+                        // Seed a visible snapshot so the cancellation event can
+                        // prove that `None` clears previously published memory.
+                        event_writer
+                            .send_event(&WorkerEvent::MlxMemorySample {
+                                mlx_memory_snapshot: Some(cancellation_memory_snapshot(33_000)),
+                            })
+                            .await?;
+                        cancellation_mlx_telemetry = CancellationMlxTelemetry::Clear;
                     }
                     "astronomical/activity-transition-fixture" => {
                         send_activity_transition(request_id, &mut event_writer).await?;
@@ -382,6 +413,46 @@ async fn run_fixture() -> Result<(), Box<dyn Error + Send + Sync>> {
                         .await?;
                     continue;
                 }
+                if should_emit_cache_stats_before_cancellation_acknowledgement {
+                    should_emit_cache_stats_before_cancellation_acknowledgement = false;
+                    event_writer
+                        .send_event(&WorkerEvent::PersistentPromptCacheStats {
+                            persistent_prompt_cache_hits: 1,
+                            persistent_prompt_cache_misses: 0,
+                            persistent_prompt_cache_tokens_saved: 2_048,
+                            persistent_prompt_cache_block_token_count: 2_048,
+                            persistent_prompt_cache_sequence_state_block_count: 1,
+                            persistent_prompt_cache_boundary_state_snapshot_count: 1,
+                            persistent_prompt_cache_visual_embedding_count: 0,
+                            persistent_prompt_cache_total_size_bytes: 4_096,
+                            persistent_prompt_cache_visual_embedding_total_size_bytes: 0,
+                            persistent_prompt_cache_maximum_size_bytes: 50_000_000_000,
+                            persistent_prompt_cache_visual_embedding_hits: 0,
+                            persistent_prompt_cache_visual_embedding_misses: 0,
+                            persistent_prompt_cache_visual_embedding_rows_loaded: 0,
+                        })
+                        .await?;
+                }
+                match std::mem::replace(
+                    &mut cancellation_mlx_telemetry,
+                    CancellationMlxTelemetry::None,
+                ) {
+                    CancellationMlxTelemetry::None => {}
+                    CancellationMlxTelemetry::Publish => {
+                        event_writer
+                            .send_event(&WorkerEvent::MlxMemorySample {
+                                mlx_memory_snapshot: Some(cancellation_memory_snapshot(44_000)),
+                            })
+                            .await?;
+                    }
+                    CancellationMlxTelemetry::Clear => {
+                        event_writer
+                            .send_event(&WorkerEvent::MlxMemorySample {
+                                mlx_memory_snapshot: None,
+                            })
+                            .await?;
+                    }
+                }
                 event_writer
                     .send_event(&WorkerEvent::Completed {
                         request_id,
@@ -427,4 +498,18 @@ async fn run_fixture() -> Result<(), Box<dyn Error + Send + Sync>> {
         }
     }
     Ok(())
+}
+
+/// Builds deterministic memory telemetry for cancellation-containment tests.
+fn cancellation_memory_snapshot(active_memory_bytes: u64) -> WorkerMlxMemorySnapshot {
+    WorkerMlxMemorySnapshot {
+        source: MlxMemorySnapshotSource::Finalized,
+        active_memory_bytes,
+        allocator_cache_memory_bytes: 2_000,
+        peak_memory_bytes: active_memory_bytes + 1_000,
+        expert_payload_bytes: 20_000,
+        model_core_payload_bytes: 10_000,
+        context_state_payload_bytes: 5_000,
+        speculative_prefill_draft_memory_bytes: 0,
+    }
 }

--- a/apps/supervisor/tests/hermetic/worker_cancellation.rs
+++ b/apps/supervisor/tests/hermetic/worker_cancellation.rs
@@ -120,6 +120,115 @@ async fn should_record_the_unexpected_event_that_contains_a_cancellation_mismatc
         .expect("shutdown after cancellation containment should be idempotent");
 }
 
+#[tokio::test]
+async fn should_keep_worker_ready_when_cancellation_publishes_prompt_cache_stats() {
+    let worker_executable_path = std::env::var("CARGO_BIN_EXE_astronomical-supervisor-test-worker")
+        .expect("Cargo should provide the test worker path");
+    let worker_executor = launch_test_executor(worker_executable_path)
+        .await
+        .expect("the worker should launch");
+    wait_for_health(&worker_executor, WorkerHealthStatus::Ready).await;
+    let stream_receiver = worker_executor
+        .start_chat_generation(command_for_model(
+            "astronomical/cache-stats-during-cancellation-fixture",
+        ))
+        .await
+        .expect("the fixture should start the cancellable request");
+
+    drop(stream_receiver);
+    sleep(Duration::from_millis(200)).await;
+
+    let health_snapshot = worker_executor.worker_health_snapshot();
+    assert_eq!(
+        health_snapshot.status,
+        WorkerHealthStatus::Ready,
+        "prompt-cache stats during cancellation must not disable the worker"
+    );
+    let published_cache_stats =
+        astronomical_supervisor::PersistentPromptCacheSummary::from_worker_event(
+            health_snapshot.persistent_prompt_cache_stats.as_ref(),
+        );
+    assert_eq!(published_cache_stats.hits, 1);
+    assert_eq!(published_cache_stats.tokens_saved, 2_048);
+
+    let mut followup_stream = worker_executor
+        .start_chat_generation(command_for_model("astronomical/test-worker"))
+        .await
+        .expect("the same worker should accept a request after cache-stats cancellation");
+    assert!(matches!(
+        receive_event(&mut followup_stream).await,
+        ChatGenerationStreamEvent::Completed { .. }
+    ));
+
+    worker_executor
+        .shutdown()
+        .await
+        .expect("shutdown should succeed");
+}
+
+#[tokio::test]
+async fn should_keep_worker_ready_when_cancellation_publishes_mlx_memory() {
+    let worker_executable_path = std::env::var("CARGO_BIN_EXE_astronomical-supervisor-test-worker")
+        .expect("Cargo should provide the test worker path");
+    let worker_executor = launch_test_executor(worker_executable_path)
+        .await
+        .expect("the worker should launch");
+    wait_for_health(&worker_executor, WorkerHealthStatus::Ready).await;
+    let stream_receiver = worker_executor
+        .start_chat_generation(command_for_model(
+            "astronomical/mlx-memory-during-cancellation-fixture",
+        ))
+        .await
+        .expect("the fixture should start the cancellable request");
+
+    drop(stream_receiver);
+    wait_for_active_memory(&worker_executor, Some(44_000)).await;
+
+    assert_eq!(
+        worker_executor.worker_health_snapshot().status,
+        WorkerHealthStatus::Ready,
+        "MLX memory telemetry during cancellation must not disable the worker"
+    );
+    assert_worker_accepts_followup_request(&worker_executor).await;
+
+    worker_executor
+        .shutdown()
+        .await
+        .expect("shutdown should succeed");
+}
+
+#[tokio::test]
+async fn should_keep_worker_ready_when_cancellation_clears_mlx_memory() {
+    let worker_executable_path = std::env::var("CARGO_BIN_EXE_astronomical-supervisor-test-worker")
+        .expect("Cargo should provide the test worker path");
+    let worker_executor = launch_test_executor(worker_executable_path)
+        .await
+        .expect("the worker should launch");
+    wait_for_health(&worker_executor, WorkerHealthStatus::Ready).await;
+    let stream_receiver = worker_executor
+        .start_chat_generation(command_for_model(
+            "astronomical/mlx-memory-clear-during-cancellation-fixture",
+        ))
+        .await
+        .expect("the fixture should start the cancellable request");
+    wait_for_active_memory(&worker_executor, Some(33_000)).await;
+
+    drop(stream_receiver);
+    wait_for_active_memory(&worker_executor, None).await;
+
+    assert_eq!(
+        worker_executor.worker_health_snapshot().status,
+        WorkerHealthStatus::Ready,
+        "cleared MLX memory telemetry during cancellation must not disable the worker"
+    );
+    assert_worker_accepts_followup_request(&worker_executor).await;
+
+    worker_executor
+        .shutdown()
+        .await
+        .expect("shutdown should succeed");
+}
+
 fn command_for_model(model_id: &str) -> ChatGenerationCommand {
     ChatGenerationCommand {
         request_id: RequestId::new(1),
@@ -147,6 +256,40 @@ async fn receive_event(
         .await
         .expect("the fixture should respond before the timeout")
         .expect("the stream should contain another event")
+}
+
+async fn assert_worker_accepts_followup_request(
+    worker_executor: &astronomical_supervisor::WorkerHandle,
+) {
+    let mut followup_stream = worker_executor
+        .start_chat_generation(command_for_model("astronomical/test-worker"))
+        .await
+        .expect("the same worker should accept a request after cancellation telemetry");
+    assert!(matches!(
+        receive_event(&mut followup_stream).await,
+        ChatGenerationStreamEvent::Completed { .. }
+    ));
+}
+
+async fn wait_for_active_memory(
+    worker_executor: &astronomical_supervisor::WorkerHandle,
+    expected_active_memory_bytes: Option<u64>,
+) {
+    let memory_deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        let observed_active_memory_bytes = worker_executor
+            .worker_health_snapshot()
+            .latest_mlx_memory_snapshot
+            .map(|memory_snapshot| memory_snapshot.active_memory_bytes);
+        if observed_active_memory_bytes == expected_active_memory_bytes {
+            return;
+        }
+        assert!(
+            Instant::now() < memory_deadline,
+            "worker memory remained {observed_active_memory_bytes:?}"
+        );
+        sleep(Duration::from_millis(20)).await;
+    }
 }
 
 async fn wait_for_health(


### PR DESCRIPTION
## Problem

Cancellation acknowledgement can arrive after the worker publishes final prompt-cache or MLX memory telemetry. Treating those valid process-scoped events as protocol violations makes a healthy worker unavailable after a client disconnects.

## Change

- Accept and publish prompt-cache statistics while waiting for cancellation acknowledgement.
- Publish or clear the latest MLX memory snapshot from cancellation telemetry.
- Keep the worker ready and reusable after each telemetry form.

## Verification

- Focused cancellation suite: 6 passed.
- `scripts/check-source-size.sh`
- `scripts/test-source-size-check.sh`
- `scripts/verify-before-commit.sh`

## Safety

- [x] No credentials, personal paths, prompts, model inventories, proprietary artifacts, or machine logs are included.
- [x] Model precision and output semantics are unchanged.
- [x] The change is outside model execution performance and memory allocation policy.
- [x] No source reuse or third-party licensing changes are introduced.
