### PR TITLE
feat: serve executable Laguna models through REST

### DIFF
--- a/apps/inference-worker/tests/common/mod.rs
+++ b/apps/inference-worker/tests/common/mod.rs
@@ -65,6 +65,8 @@ pub(crate) fn discovered_model_artifact(
         max_input_tokens: CONTEXT_WINDOW.saturating_sub(max_output_tokens),
         max_output_tokens,
         has_vision: true,
+        supports_reasoning: true,
+        supports_tool_calls: true,
         model_size_bytes: 0,
     }
 }

--- a/apps/inference-worker/tests/model_artifact_qualification/deployment_litmus_model.rs
+++ b/apps/inference-worker/tests/model_artifact_qualification/deployment_litmus_model.rs
@@ -47,6 +47,8 @@ fn should_order_the_smallest_available_model_first_for_deployment_litmus() {
             max_input_tokens: 241_664,
             max_output_tokens: 20_480,
             has_vision: true,
+            supports_reasoning: true,
+            supports_tool_calls: true,
             model_size_bytes: 9,
         },
         DiscoveredModel {
@@ -58,6 +60,8 @@ fn should_order_the_smallest_available_model_first_for_deployment_litmus() {
             max_input_tokens: 241_664,
             max_output_tokens: 20_480,
             has_vision: true,
+            supports_reasoning: true,
+            supports_tool_calls: true,
             model_size_bytes: 3,
         },
         DiscoveredModel {
@@ -69,6 +73,8 @@ fn should_order_the_smallest_available_model_first_for_deployment_litmus() {
             max_input_tokens: 241_664,
             max_output_tokens: 20_480,
             has_vision: true,
+            supports_reasoning: true,
+            supports_tool_calls: true,
             model_size_bytes: 3,
         },
     ];

--- a/apps/inference-worker/tests/model_artifact_qualification/laguna/artifact.rs
+++ b/apps/inference-worker/tests/model_artifact_qualification/laguna/artifact.rs
@@ -163,6 +163,27 @@ fn qualify_pinned_artifact(pinned_artifact: PinnedLagunaArtifact) {
         classify_model_directory(&model_directory).expect("the pinned config should be readable"),
         Some(ModelFamily::Laguna)
     );
+    let development_config =
+        astronomical_config::AstronomicalConfig::load_from_development_location()
+            .expect("Development configuration should load for executable discovery");
+    let publicly_discovered_model = astronomical_config::discover_models(
+        development_config.model_directories(),
+        development_config.max_output_tokens(),
+    )
+    .expect("executable model discovery should complete")
+    .into_iter()
+    .flat_map(|directory_scan| directory_scan.discovered_models)
+    .find(|discovered_model| {
+        discovered_model.model_family == ModelFamily::Laguna
+            && discovered_model.model_id == pinned_artifact.public_model_id()
+            && discovered_model.revision == pinned_artifact.revision
+    })
+    .expect("the pinned Laguna artifact should be publicly discoverable");
+    assert_eq!(
+        fs::canonicalize(publicly_discovered_model.model_directory)
+            .expect("the discovered Laguna path should canonicalize"),
+        model_directory
+    );
     let validated_artifact = LagunaArtifactValidator::new()
         .validate(&model_directory)
         .expect("the pinned Laguna artifact should validate before model construction");
@@ -296,6 +317,11 @@ pub(super) fn bounded_romeo_and_juliet_source() -> &'static str {
 
 pub(super) fn compact_romeo_and_juliet_source() -> &'static str {
     romeo_and_juliet_source_with_character_limit(MAXIMUM_COMPACT_QUALIFICATION_SOURCE_CHARACTERS)
+}
+
+/// Returns the complete repository fixture for long public prompt journeys.
+pub(super) const fn full_romeo_and_juliet_source() -> &'static str {
+    ROMEO_AND_JULIET_SOURCE
 }
 
 fn romeo_and_juliet_source_with_character_limit(maximum_characters: usize) -> &'static str {

--- a/apps/inference-worker/tests/model_artifact_qualification/laguna/attribution.rs
+++ b/apps/inference-worker/tests/model_artifact_qualification/laguna/attribution.rs
@@ -1,0 +1,120 @@
+//! Public long-prompt residency and switchable attribution qualification.
+
+use std::fs;
+use std::path::Path;
+use std::time::Duration;
+
+use serde_json::json;
+use tokio::time::timeout;
+
+use super::artifact::{LAGUNA_XS, full_romeo_and_juliet_source, resolve_pinned_artifact_directory};
+use crate::model_artifact_qualification::model_artifact_rest_qualification::{
+    assert_successful_streaming_chat_response, get_endpoint,
+    launch_model_artifact_rest_server_for_model, post_chat_completion,
+    stop_model_artifact_rest_server,
+};
+
+const JOURNEY_TIMEOUT: Duration = Duration::from_secs(115);
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "proves resident long-prompt serving and attribution enable/disable behavior"]
+async fn should_serve_a_resident_laguna_xs_long_prompt_with_switchable_attribution() {
+    timeout(JOURNEY_TIMEOUT, run_attribution_journey())
+        .await
+        .expect("the Laguna attribution journey must finish within 115 seconds");
+}
+
+async fn run_attribution_journey() {
+    run_one_attribution_mode(true).await;
+    run_one_attribution_mode(false).await;
+}
+
+async fn run_one_attribution_mode(performance_attribution_enabled: bool) {
+    let model_directory = resolve_pinned_artifact_directory(LAGUNA_XS);
+    let isolated_home = tempfile::tempdir().expect("an isolated Development home should exist");
+    write_configuration(
+        isolated_home.path(),
+        &model_directory,
+        performance_attribution_enabled,
+    );
+    let public_model_id = LAGUNA_XS.public_model_id();
+    let rest_server = launch_model_artifact_rest_server_for_model(
+        public_model_id,
+        model_directory,
+        Some(isolated_home.path()),
+        None,
+    )
+    .await;
+    let request_body = json!({
+        "model": public_model_id,
+        "messages": [{
+            "role": "user",
+            "content": format!(
+                "Use the supplied Romeo and Juliet source. Identify the play in one word.\n\n{}",
+                full_romeo_and_juliet_source()
+            )
+        }],
+        "stream": true,
+        "temperature": 0,
+        "max_tokens": 1
+    })
+    .to_string();
+    eprintln!("[laguna-attribution] phase=request enabled={performance_attribution_enabled}");
+    let response = post_chat_completion(rest_server.server_address, request_body).await;
+    assert_successful_streaming_chat_response(&response);
+    let status_response = get_endpoint(rest_server.server_address, "/v1/status").await;
+    let status_body = status_response
+        .split("\r\n\r\n")
+        .nth(1)
+        .unwrap_or(status_response.as_str());
+    let status_document: serde_json::Value = serde_json::from_str(status_body)
+        .unwrap_or_else(|_| panic!("GET /v1/status should return JSON: {status_response}"));
+    assert_eq!(status_document["status"], "ready");
+    assert_eq!(status_document["expert_memory_mode"], "resident");
+    assert!(
+        status_document["mlx_memory_snapshot"]["active_memory_bytes"]
+            .as_u64()
+            .unwrap_or(0)
+            > 0
+    );
+    stop_model_artifact_rest_server(rest_server).await;
+
+    let attribution_path = isolated_home
+        .path()
+        .join(".astronomical-dev/logs/performance-attribution.jsonl");
+    if performance_attribution_enabled {
+        let attribution_log = fs::read_to_string(attribution_path)
+            .expect("enabled attribution should write bounded reports");
+        assert!(
+            attribution_log
+                .lines()
+                .any(|line| line.contains(r#""report_kind":"generation""#))
+        );
+    } else {
+        assert!(
+            !attribution_path.exists(),
+            "disabled attribution must not create its report file"
+        );
+    }
+}
+
+fn write_configuration(home_directory: &Path, model_directory: &Path, attribution_enabled: bool) {
+    let state_directory = home_directory.join(".astronomical-dev");
+    fs::create_dir_all(&state_directory).expect("the isolated state should be created");
+    fs::write(
+        state_directory.join("config.json"),
+        serde_json::to_vec(&json!({
+            "model_directories": [model_directory],
+            "max_output_tokens": 8,
+            "persistent_prompt_cache_enabled": false,
+            "performance_attribution_enabled": attribution_enabled,
+            "mtp_enabled": false,
+            "chunking": {
+                "prompt_processing_chunk_size_optimizer_enabled": false,
+                "fixed_prompt_processing_chunk_size_tokens": 2048
+            }
+        }))
+        .expect("the isolated configuration should serialize"),
+    )
+    .expect("the isolated configuration should write");
+}

--- a/apps/inference-worker/tests/model_artifact_qualification/laguna/http.rs
+++ b/apps/inference-worker/tests/model_artifact_qualification/laguna/http.rs
@@ -1,0 +1,134 @@
+//! Public HTTP Chat and Responses acceptance journeys for pinned Laguna artifacts.
+
+use std::net::SocketAddr;
+use std::time::Duration;
+
+use serde_json::json;
+use tokio::time::timeout;
+
+use super::artifact::{
+    LAGUNA_S, LAGUNA_XS, PinnedLagunaArtifact, compact_romeo_and_juliet_source,
+    resolve_pinned_artifact_directory,
+};
+use crate::model_artifact_qualification::model_artifact_rest_qualification::{
+    assert_successful_streaming_chat_response, assert_successful_streaming_responses_response,
+    get_endpoint, launch_model_artifact_rest_server_for_model, post_chat_completion,
+    post_responses_completion, stop_model_artifact_rest_server,
+};
+
+const JOURNEY_TIMEOUT: Duration = Duration::from_secs(115);
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "serves pinned Laguna XS through public Chat and Responses"]
+async fn should_stream_romeo_and_juliet_from_laguna_xs_chat_and_responses() {
+    timeout(JOURNEY_TIMEOUT, run_public_generation_journey(LAGUNA_XS))
+        .await
+        .expect("the Laguna XS public journey must finish within 115 seconds");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "serves pinned Laguna S through public Chat and Responses"]
+async fn should_stream_romeo_and_juliet_from_laguna_s_chat_and_responses() {
+    timeout(JOURNEY_TIMEOUT, run_public_generation_journey(LAGUNA_S))
+        .await
+        .expect("the Laguna S public journey must finish within 115 seconds");
+}
+
+async fn run_public_generation_journey(artifact: PinnedLagunaArtifact) {
+    let model_directory = resolve_pinned_artifact_directory(artifact);
+    let public_model_id = artifact.public_model_id();
+    let isolated_development_home = crate::common::isolated_development_home_from_user_config();
+    eprintln!("[laguna-http] phase=launch model={public_model_id}");
+    let rest_server = launch_model_artifact_rest_server_for_model(
+        public_model_id,
+        model_directory,
+        Some(isolated_development_home.path()),
+        None,
+    )
+    .await;
+    let server_address = rest_server.server_address;
+    assert_laguna_is_advertised(server_address, public_model_id).await;
+    let source_excerpt = compact_romeo_and_juliet_source();
+
+    eprintln!("[laguna-http] phase=chat model={public_model_id}");
+    let chat_response = post_chat_completion(
+        server_address,
+        json!({
+            "model": public_model_id,
+            "messages": [{
+                "role": "user",
+                "content": format!("Use the supplied Romeo and Juliet source. Name the two households.\n\n{source_excerpt}"),
+            }],
+            "stream": true,
+            "temperature": 0,
+            "max_tokens": 4,
+        })
+        .to_string(),
+    )
+    .await;
+    assert_successful_streaming_chat_response(&chat_response);
+
+    eprintln!("[laguna-http] phase=responses model={public_model_id}");
+    let responses_response = post_responses_completion(
+        server_address,
+        json!({
+            "model": public_model_id,
+            "input": format!("Use the supplied Romeo and Juliet source. Name the two households.\n\n{source_excerpt}"),
+            "stream": true,
+            "max_output_tokens": 4,
+        })
+        .to_string(),
+    )
+    .await;
+    assert_successful_streaming_responses_response(&responses_response);
+    assert_laguna_is_advertised(server_address, public_model_id).await;
+    stop_model_artifact_rest_server(rest_server).await;
+    eprintln!("[laguna-http] phase=done model={public_model_id}");
+}
+
+pub(super) fn opencode_shaped_chat_request_body(
+    public_model_id: &str,
+    romeo_and_juliet_source: &str,
+    maximum_output_tokens: u16,
+) -> String {
+    json!({
+        "model": public_model_id,
+        "messages": [{
+            "role": "user",
+            "content": format!("Use the supplied Romeo and Juliet source. Name the two households.\n\n{romeo_and_juliet_source}"),
+        }],
+        "tools": [{
+            "type": "function",
+            "function": {
+                "name": "search_play",
+                "description": "Search the supplied play.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"query": {"type": "string"}},
+                    "required": ["query"]
+                }
+            }
+        }],
+        "tool_choice": "auto",
+        "stream": true,
+        "temperature": 0,
+        "max_tokens": maximum_output_tokens,
+    })
+    .to_string()
+}
+
+pub(super) async fn assert_laguna_is_advertised(server_address: SocketAddr, public_model_id: &str) {
+    let models_response = get_endpoint(server_address, "/v1/models").await;
+    let response_body = models_response
+        .split("\r\n\r\n")
+        .nth(1)
+        .unwrap_or(models_response.as_str());
+    let models_document: serde_json::Value = serde_json::from_str(response_body)
+        .unwrap_or_else(|_| panic!("GET /v1/models should return JSON: {models_response}"));
+    assert!(
+        models_document["data"]
+            .as_array()
+            .is_some_and(|models| models.iter().any(|model| model["id"] == public_model_id)),
+        "Laguna {public_model_id} must be advertised: {models_document}"
+    );
+}

--- a/apps/inference-worker/tests/model_artifact_qualification/laguna/http_restore.rs
+++ b/apps/inference-worker/tests/model_artifact_qualification/laguna/http_restore.rs
@@ -1,0 +1,104 @@
+//! Repeated public HTTP generation restores an exact Laguna prompt prefix.
+
+use std::fs;
+use std::time::Duration;
+
+use serde_json::json;
+use tokio::time::timeout;
+
+use super::artifact::{
+    LAGUNA_XS, bounded_romeo_and_juliet_source, resolve_pinned_artifact_directory,
+};
+use super::http::assert_laguna_is_advertised;
+use crate::model_artifact_qualification::model_artifact_rest_qualification::{
+    assert_successful_streaming_chat_response, launch_model_artifact_rest_server_for_model,
+    post_chat_completion, stop_model_artifact_rest_server,
+};
+use crate::model_artifact_qualification::persistent_prompt_cache_rest_support::get_json_endpoint;
+
+const JOURNEY_TIMEOUT: Duration = Duration::from_secs(115);
+const PROMPT_CACHE_BLOCK_TOKEN_COUNT: u32 = 256;
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "serves pinned Laguna XS twice and proves public SSD restore"]
+async fn should_restore_a_repeated_romeo_request_through_http_and_remain_ready() {
+    timeout(JOURNEY_TIMEOUT, run_repeated_http_restore())
+        .await
+        .expect("the Laguna HTTP restore journey must finish within 115 seconds");
+}
+
+async fn run_repeated_http_restore() {
+    let model_directory = resolve_pinned_artifact_directory(LAGUNA_XS);
+    let public_model_id = LAGUNA_XS.public_model_id();
+    let isolated_development_home =
+        tempfile::tempdir().expect("an isolated Laguna cache home should be created");
+    write_cache_enabled_config(isolated_development_home.path(), &model_directory);
+    let rest_server = launch_model_artifact_rest_server_for_model(
+        public_model_id,
+        model_directory,
+        Some(isolated_development_home.path()),
+        None,
+    )
+    .await;
+    let server_address = rest_server.server_address;
+    assert_laguna_is_advertised(server_address, public_model_id).await;
+    let source_excerpt = bounded_romeo_and_juliet_source();
+    let request_body = json!({
+        "model": public_model_id,
+        "messages": [{
+            "role": "user",
+            "content": format!("Use the supplied Romeo and Juliet source. Name the two households and the tragic ending.\n\n{source_excerpt}"),
+        }],
+        "stream": true,
+        "temperature": 0,
+        "max_tokens": 8,
+    })
+    .to_string();
+
+    eprintln!("[laguna-http-restore] phase=cold");
+    let cold_response = post_chat_completion(server_address, request_body.clone()).await;
+    assert_successful_streaming_chat_response(&cold_response);
+    let cold_cache_stats = get_json_endpoint(server_address, "/v1/cache/stats").await;
+    assert_eq!(cold_cache_stats["persistent_prompt_cache_tokens_saved"], 0);
+
+    eprintln!("[laguna-http-restore] phase=warm");
+    let warm_response = post_chat_completion(server_address, request_body).await;
+    assert_successful_streaming_chat_response(&warm_response);
+    let warm_cache_stats = get_json_endpoint(server_address, "/v1/cache/stats").await;
+    assert!(
+        warm_cache_stats["persistent_prompt_cache_tokens_saved"]
+            .as_u64()
+            .unwrap_or(0)
+            >= u64::from(PROMPT_CACHE_BLOCK_TOKEN_COUNT),
+        "the repeated request must restore one cache block: {warm_cache_stats}"
+    );
+    let status_document = get_json_endpoint(server_address, "/v1/status").await;
+    assert_eq!(status_document["status"], "ready");
+    stop_model_artifact_rest_server(rest_server).await;
+}
+
+fn write_cache_enabled_config(isolated_home: &std::path::Path, model_directory: &std::path::Path) {
+    let configuration_directory = isolated_home.join(".astronomical-dev");
+    fs::create_dir_all(&configuration_directory)
+        .expect("the isolated configuration directory should be created");
+    let configuration_document = json!({
+        "model_directories": [model_directory],
+        "max_output_tokens": 8,
+        "persistent_prompt_cache_enabled": true,
+        "prompt_cache_max_size_gb": 80,
+        "performance_attribution_enabled": true,
+        "mtp_enabled": false,
+        "chunking": {
+            "prompt_processing_chunk_size_optimizer_enabled": false,
+            "fixed_prompt_processing_chunk_size_tokens": 8192,
+            "prompt_cache_block_tokens": PROMPT_CACHE_BLOCK_TOKEN_COUNT,
+            "prompt_cache_common_prefix_stride_blocks": 1
+        }
+    });
+    fs::write(
+        configuration_directory.join("config.json"),
+        serde_json::to_vec_pretty(&configuration_document)
+            .expect("the isolated configuration should serialize"),
+    )
+    .expect("the isolated configuration should write");
+}

--- a/apps/inference-worker/tests/model_artifact_qualification/laguna/malformed.rs
+++ b/apps/inference-worker/tests/model_artifact_qualification/laguna/malformed.rs
@@ -1,0 +1,212 @@
+//! Deep Laguna load failure preserves the previously healthy public model.
+
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, RwLock};
+use std::time::Duration;
+
+use astronomical_supervisor::{
+    GenerationPerformanceLog, ResolvedRuntimeConfigResolver, WorkerHandle,
+    build_development_application_with_reload,
+};
+use serde_json::json;
+use tokio::net::TcpListener;
+use tokio::sync::oneshot;
+use tokio::time::{sleep, timeout};
+
+use super::artifact::{
+    LAGUNA_XS, compact_romeo_and_juliet_source, resolve_pinned_artifact_directory,
+};
+use crate::model_artifact_qualification::model_artifact_rest_qualification::{
+    assert_successful_streaming_chat_response, get_endpoint, post_chat_completion,
+};
+
+const JOURNEY_TIMEOUT: Duration = Duration::from_secs(115);
+const MALFORMED_MODEL_ID: &str = "Laguna-Deep-Malformed";
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "proves an exact public Laguna load failure preserves a healthy loaded model"]
+async fn should_return_model_load_failed_and_reuse_the_healthy_laguna_model() {
+    timeout(JOURNEY_TIMEOUT, run_malformed_swap_journey())
+        .await
+        .expect("the malformed Laguna journey must finish within 115 seconds");
+}
+
+async fn run_malformed_swap_journey() {
+    let healthy_directory = resolve_pinned_artifact_directory(LAGUNA_XS);
+    let malformed_home = tempfile::tempdir().expect("a malformed fixture home should be created");
+    let malformed_directory = malformed_home.path().join(MALFORMED_MODEL_ID);
+    create_shallow_valid_deep_invalid_artifact(&healthy_directory, &malformed_directory);
+    let isolated_home = tempfile::tempdir().expect("an isolated Development home should exist");
+    write_two_model_config(
+        isolated_home.path(),
+        &healthy_directory,
+        &malformed_directory,
+    );
+    let worker_executable_path = PathBuf::from(
+        std::env::var("CARGO_BIN_EXE_astronomical-inference-worker")
+            .expect("Cargo should provide the worker executable"),
+    );
+    let resolver = ResolvedRuntimeConfigResolver::for_development_home_directory(
+        isolated_home.path().to_path_buf(),
+        worker_executable_path.clone(),
+    );
+    let resolved_config = resolver
+        .load()
+        .expect("shallow discovery should advertise both Laguna artifacts");
+    assert!(
+        resolved_config
+            .discovered_models
+            .iter()
+            .any(|model| model.model_id == MALFORMED_MODEL_ID)
+    );
+    let model_directories = Arc::clone(&resolved_config.model_directories);
+    let log_directory = isolated_home.path().join("logs");
+    std::fs::create_dir_all(&log_directory).expect("the log directory should be created");
+    let worker_handle = WorkerHandle::launch_with_startup_configuration(
+        &worker_executable_path,
+        Duration::from_secs(60),
+        GenerationPerformanceLog::open(&log_directory).expect("the performance log should open"),
+        model_directories,
+        8,
+        resolved_config.worker_startup_configuration(),
+    )
+    .await
+    .expect("the production worker should launch");
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("the listener should bind");
+    let server_address = listener
+        .local_addr()
+        .expect("the listener should expose its address");
+    let (shutdown_sender, shutdown_receiver) = oneshot::channel();
+    let application = build_development_application_with_reload(
+        worker_handle.clone(),
+        Arc::new(RwLock::new(resolved_config)),
+        isolated_home.path().to_path_buf(),
+    );
+    let server_task = tokio::spawn(async move {
+        axum::serve(listener, application)
+            .with_graceful_shutdown(async {
+                let _ = shutdown_receiver.await;
+            })
+            .await
+    });
+    for readiness_attempt in 1..=70 {
+        if get_endpoint(server_address, "/ready")
+            .await
+            .starts_with("HTTP/1.1 200 OK")
+        {
+            eprintln!("[laguna-malformed] ready attempt={readiness_attempt}");
+            break;
+        }
+        sleep(Duration::from_secs(1)).await;
+    }
+
+    let healthy_request = request_body(LAGUNA_XS.public_model_id());
+    let healthy_response = post_chat_completion(server_address, healthy_request.clone()).await;
+    assert_successful_streaming_chat_response(&healthy_response);
+    let malformed_response =
+        post_chat_completion(server_address, request_body(MALFORMED_MODEL_ID)).await;
+    assert!(
+        malformed_response.starts_with("HTTP/1.1 503 Service Unavailable"),
+        "{malformed_response}"
+    );
+    assert!(
+        malformed_response.contains(r#""code":"model_load_failed""#),
+        "{malformed_response}"
+    );
+    let reused_response = post_chat_completion(server_address, healthy_request).await;
+    assert_successful_streaming_chat_response(&reused_response);
+
+    let _shutdown_sent = shutdown_sender.send(());
+    server_task
+        .await
+        .expect("the server task should not panic")
+        .expect("the server should stop");
+    worker_handle
+        .shutdown()
+        .await
+        .expect("the worker should terminate");
+}
+
+fn create_shallow_valid_deep_invalid_artifact(
+    healthy_directory: &Path,
+    malformed_directory: &Path,
+) {
+    std::fs::create_dir_all(malformed_directory.join(".cache/huggingface/download"))
+        .expect("malformed fixture directories should be created");
+    for directory_entry in
+        std::fs::read_dir(healthy_directory).expect("the healthy artifact should be readable")
+    {
+        let entry_path = directory_entry
+            .expect("artifact entries should be readable")
+            .path();
+        if !entry_path.is_file() {
+            continue;
+        }
+        let file_name = entry_path
+            .file_name()
+            .expect("artifact files should have names");
+        let destination_path = malformed_directory.join(file_name);
+        if entry_path
+            .extension()
+            .and_then(|extension| extension.to_str())
+            == Some("safetensors")
+        {
+            std::fs::hard_link(&entry_path, destination_path)
+                .expect("malformed fixture shards should reuse healthy payloads");
+        } else {
+            std::fs::copy(&entry_path, destination_path)
+                .expect("malformed fixture sidecars should be copied");
+        }
+    }
+    let config_path = malformed_directory.join("config.json");
+    let mut config_document: serde_json::Value = serde_json::from_slice(
+        &std::fs::read(&config_path).expect("the copied config should be readable"),
+    )
+    .expect("the copied config should contain JSON");
+    if let Some(language_config) = config_document.get_mut("text_config") {
+        language_config["hidden_size"] = json!(0);
+    } else {
+        config_document["hidden_size"] = json!(0);
+    }
+    std::fs::write(
+        config_path,
+        serde_json::to_vec(&config_document).expect("the malformed config should serialize"),
+    )
+    .expect("the malformed config should be written");
+    std::fs::write(
+        malformed_directory.join(".cache/huggingface/download/config.json.metadata"),
+        format!("{}\n", LAGUNA_XS.revision),
+    )
+    .expect("the immutable revision metadata should be written");
+}
+
+fn write_two_model_config(home_directory: &Path, healthy: &Path, malformed: &Path) {
+    let state_directory = home_directory.join(".astronomical-dev");
+    std::fs::create_dir_all(&state_directory).expect("the isolated state should be created");
+    std::fs::write(
+        state_directory.join("config.json"),
+        serde_json::to_vec(&json!({
+            "model_directories": [healthy, malformed],
+            "max_output_tokens": 8,
+            "mtp_enabled": false
+        }))
+        .expect("the isolated configuration should serialize"),
+    )
+    .expect("the isolated configuration should write");
+}
+
+fn request_body(model_id: &str) -> String {
+    json!({
+        "model": model_id,
+        "messages": [{"role": "user", "content": format!(
+            "Use the supplied Romeo and Juliet source. Name the households.\n\n{}",
+            compact_romeo_and_juliet_source()
+        )}],
+        "stream": true,
+        "temperature": 0,
+        "max_tokens": 2
+    })
+    .to_string()
+}

--- a/apps/inference-worker/tests/model_artifact_qualification/laguna/mod.rs
+++ b/apps/inference-worker/tests/model_artifact_qualification/laguna/mod.rs
@@ -1,4 +1,10 @@
 mod artifact;
+mod attribution;
 mod cancel;
 mod generate;
+mod http;
+mod http_restore;
+mod malformed;
+mod rest_prefill_cancellation;
 mod restore;
+mod swap;

--- a/apps/inference-worker/tests/model_artifact_qualification/laguna/rest_prefill_cancellation.rs
+++ b/apps/inference-worker/tests/model_artifact_qualification/laguna/rest_prefill_cancellation.rs
@@ -1,0 +1,119 @@
+//! Public cancellation during Laguna prefill leaves the worker reusable.
+
+use std::time::{Duration, Instant};
+
+use serde_json::json;
+use tokio::time::{sleep, timeout};
+
+use super::artifact::{
+    LAGUNA_S, compact_romeo_and_juliet_source, full_romeo_and_juliet_source,
+    resolve_pinned_artifact_directory,
+};
+use super::http::opencode_shaped_chat_request_body;
+use crate::model_artifact_qualification::model_artifact_rest_qualification::{
+    assert_successful_streaming_chat_response, get_endpoint,
+    launch_model_artifact_rest_server_for_model, post_chat_completion,
+    stop_model_artifact_rest_server,
+};
+
+const JOURNEY_TIMEOUT: Duration = Duration::from_secs(119);
+const STATUS_POLL_INTERVAL: Duration = Duration::from_millis(100);
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "cancels pinned Laguna S during public prefill and reuses the worker"]
+async fn should_acknowledge_laguna_s_rest_prefill_cancellation_and_reuse_worker() {
+    timeout(JOURNEY_TIMEOUT, run_cancellation_journey())
+        .await
+        .expect("the Laguna S cancellation journey must finish within 119 seconds");
+}
+
+async fn run_cancellation_journey() {
+    let model_directory = resolve_pinned_artifact_directory(LAGUNA_S);
+    let public_model_id = LAGUNA_S.public_model_id();
+    let isolated_home = crate::common::isolated_development_home_from_user_config();
+    let rest_server = launch_model_artifact_rest_server_for_model(
+        public_model_id,
+        model_directory,
+        Some(isolated_home.path()),
+        None,
+    )
+    .await;
+    let server_address = rest_server.server_address;
+    let reusable_request_body = json!({
+        "model": public_model_id,
+        "messages": [{"role": "user", "content": format!(
+            "Use the supplied Romeo and Juliet source. Name the households.\n\n{}",
+            compact_romeo_and_juliet_source()
+        )}],
+        "stream": true,
+        "temperature": 0,
+        "max_tokens": 2,
+    })
+    .to_string();
+    let warm_response = post_chat_completion(server_address, reusable_request_body.clone()).await;
+    assert_successful_streaming_chat_response(&warm_response);
+
+    let long_request_body =
+        opencode_shaped_chat_request_body(public_model_id, full_romeo_and_juliet_source(), 8);
+    let long_request_task = tokio::spawn(post_chat_completion(server_address, long_request_body));
+    wait_for_incomplete_prefill(server_address).await;
+    eprintln!("[laguna-rest-cancel] phase=disconnect");
+    long_request_task.abort();
+    let _aborted_request = long_request_task.await;
+    let cancellation_started_at = Instant::now();
+    wait_until_ready(server_address).await;
+    eprintln!(
+        "[laguna-rest-cancel] phase=acknowledged elapsed_millis={}",
+        cancellation_started_at.elapsed().as_millis()
+    );
+
+    let reused_response = post_chat_completion(server_address, reusable_request_body).await;
+    assert_successful_streaming_chat_response(&reused_response);
+    stop_model_artifact_rest_server(rest_server).await;
+}
+
+async fn wait_for_incomplete_prefill(server_address: std::net::SocketAddr) {
+    let mut poll_attempt = 0_u32;
+    loop {
+        poll_attempt = poll_attempt.saturating_add(1);
+        let status_document = status_document(server_address).await;
+        let processed_tokens = status_document["progress"]["processed_tokens"]
+            .as_u64()
+            .unwrap_or(0);
+        let total_tokens = status_document["progress"]["total_tokens"]
+            .as_u64()
+            .unwrap_or(0);
+        if processed_tokens > 0 && processed_tokens < total_tokens {
+            return;
+        }
+        if poll_attempt.is_multiple_of(20) {
+            eprintln!("[laguna-rest-cancel] phase=wait-prefill poll={poll_attempt}");
+        }
+        sleep(STATUS_POLL_INTERVAL).await;
+    }
+}
+
+async fn wait_until_ready(server_address: std::net::SocketAddr) {
+    let mut poll_attempt = 0_u32;
+    loop {
+        poll_attempt = poll_attempt.saturating_add(1);
+        let status_document = status_document(server_address).await;
+        if status_document["status"] == "ready" && status_document["activity"] == "idle" {
+            return;
+        }
+        if poll_attempt.is_multiple_of(20) {
+            eprintln!("[laguna-rest-cancel] phase=wait-ready poll={poll_attempt}");
+        }
+        sleep(STATUS_POLL_INTERVAL).await;
+    }
+}
+
+async fn status_document(server_address: std::net::SocketAddr) -> serde_json::Value {
+    let status_response = get_endpoint(server_address, "/v1/status").await;
+    let response_body = status_response
+        .split("\r\n\r\n")
+        .nth(1)
+        .unwrap_or(status_response.as_str());
+    serde_json::from_str(response_body)
+        .unwrap_or_else(|_| panic!("GET /v1/status should return JSON: {status_response}"))
+}

--- a/apps/inference-worker/tests/model_artifact_qualification/laguna/swap.rs
+++ b/apps/inference-worker/tests/model_artifact_qualification/laguna/swap.rs
@@ -1,0 +1,170 @@
+//! Same-worker Qwen to Laguna XS to Laguna S to Qwen public swap journey.
+
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::sync::{Arc, RwLock};
+use std::time::Duration;
+
+use astronomical_supervisor::{
+    GenerationPerformanceLog, ResolvedRuntimeConfigResolver, WorkerHandle,
+    build_development_application_with_reload,
+};
+use serde_json::json;
+use tokio::net::TcpListener;
+use tokio::sync::oneshot;
+use tokio::task::JoinHandle;
+use tokio::time::{sleep, timeout};
+
+use super::artifact::{
+    LAGUNA_S, LAGUNA_XS, compact_romeo_and_juliet_source, resolve_pinned_artifact_directory,
+};
+use super::http::assert_laguna_is_advertised;
+use crate::model_artifact_qualification::model_artifact_rest_qualification::{
+    assert_successful_streaming_chat_response, get_endpoint, post_chat_completion,
+};
+
+const JOURNEY_TIMEOUT: Duration = Duration::from_secs(115);
+
+struct MultiModelRestServer {
+    worker_handle: WorkerHandle,
+    server_address: SocketAddr,
+    shutdown_sender: oneshot::Sender<()>,
+    server_task: JoinHandle<Result<(), std::io::Error>>,
+    _isolated_home: tempfile::TempDir,
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "swaps Qwen, Laguna XS, Laguna S, then Qwen on one public worker"]
+async fn should_swap_qwen_then_laguna_xs_then_laguna_s_then_qwen_on_one_worker() {
+    timeout(JOURNEY_TIMEOUT, run_family_swap_journey())
+        .await
+        .expect("the complete family swap must finish within 115 seconds");
+}
+
+async fn run_family_swap_journey() {
+    let qwen_model = crate::common::configured_discovered_models()
+        .into_iter()
+        .filter(|model| model.model_family == astronomical_config::ModelFamily::Qwen3_5)
+        .min_by_key(|model| model.model_size_bytes)
+        .expect("Development roots should contain one executable Qwen model");
+    let model_directories = HashMap::from([
+        (qwen_model.model_id.clone(), qwen_model.model_directory),
+        (
+            LAGUNA_XS.public_model_id().to_owned(),
+            resolve_pinned_artifact_directory(LAGUNA_XS),
+        ),
+        (
+            LAGUNA_S.public_model_id().to_owned(),
+            resolve_pinned_artifact_directory(LAGUNA_S),
+        ),
+    ]);
+    let rest_server = launch_multi_model_server(model_directories).await;
+    assert_laguna_is_advertised(rest_server.server_address, LAGUNA_XS.public_model_id()).await;
+    for (model_id, phase) in [
+        (qwen_model.model_id.as_str(), "qwen"),
+        (LAGUNA_XS.public_model_id(), "laguna-xs"),
+        (LAGUNA_S.public_model_id(), "laguna-s"),
+        (qwen_model.model_id.as_str(), "qwen-return"),
+    ] {
+        eprintln!("[laguna-swap] phase={phase} model={model_id}");
+        let request_body = json!({
+            "model": model_id,
+            "messages": [{
+                "role": "user",
+                "content": format!(
+                    "Use the supplied Romeo and Juliet source. Name the households.\n\n{}",
+                    compact_romeo_and_juliet_source()
+                )
+            }],
+            "stream": true,
+            "temperature": 0,
+            "max_tokens": 2,
+        })
+        .to_string();
+        let response = post_chat_completion(rest_server.server_address, request_body).await;
+        assert_successful_streaming_chat_response(&response);
+    }
+    stop_multi_model_server(rest_server).await;
+}
+
+async fn launch_multi_model_server(
+    model_directories: HashMap<String, PathBuf>,
+) -> MultiModelRestServer {
+    let worker_executable_path = PathBuf::from(
+        std::env::var("CARGO_BIN_EXE_astronomical-inference-worker")
+            .expect("Cargo should provide the worker executable"),
+    );
+    let isolated_home = crate::common::isolated_development_home_from_user_config();
+    let resolver = ResolvedRuntimeConfigResolver::for_development_home_directory(
+        isolated_home.path().to_path_buf(),
+        worker_executable_path.clone(),
+    );
+    let resolved_config = resolver
+        .load()
+        .expect("the isolated family-swap configuration should resolve");
+    let performance_log_directory = isolated_home.path().join("logs");
+    std::fs::create_dir_all(&performance_log_directory)
+        .expect("the isolated performance directory should be created");
+    let worker_handle = WorkerHandle::launch_with_startup_configuration(
+        &worker_executable_path,
+        Duration::from_secs(60),
+        GenerationPerformanceLog::open(&performance_log_directory)
+            .expect("the performance log should open"),
+        Arc::new(model_directories),
+        20_480,
+        resolved_config.worker_startup_configuration(),
+    )
+    .await
+    .expect("the family-swap worker should launch");
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("the family-swap listener should bind");
+    let server_address = listener
+        .local_addr()
+        .expect("the listener should expose its address");
+    let (shutdown_sender, shutdown_receiver) = oneshot::channel();
+    let application = build_development_application_with_reload(
+        worker_handle.clone(),
+        Arc::new(RwLock::new(resolved_config)),
+        isolated_home.path().to_path_buf(),
+    );
+    let server_task = tokio::spawn(async move {
+        axum::serve(listener, application)
+            .with_graceful_shutdown(async {
+                let _ = shutdown_receiver.await;
+            })
+            .await
+    });
+    for readiness_attempt in 1..=70 {
+        if get_endpoint(server_address, "/ready")
+            .await
+            .starts_with("HTTP/1.1 200 OK")
+        {
+            eprintln!("[laguna-swap] ready attempt={readiness_attempt}");
+            break;
+        }
+        sleep(Duration::from_secs(1)).await;
+    }
+    MultiModelRestServer {
+        worker_handle,
+        server_address,
+        shutdown_sender,
+        server_task,
+        _isolated_home: isolated_home,
+    }
+}
+
+async fn stop_multi_model_server(rest_server: MultiModelRestServer) {
+    let _shutdown_sent = rest_server.shutdown_sender.send(());
+    rest_server
+        .server_task
+        .await
+        .expect("the REST task should not panic")
+        .expect("the REST server should stop cleanly");
+    rest_server
+        .worker_handle
+        .shutdown()
+        .await
+        .expect("the family-swap worker should terminate");
+}

--- a/apps/inference-worker/tests/model_artifact_qualification/model_artifact_rest_qualification.rs
+++ b/apps/inference-worker/tests/model_artifact_qualification/model_artifact_rest_qualification.rs
@@ -505,7 +505,7 @@ pub(super) fn assert_successful_streaming_chat_response(chat_response: &str) {
     );
 }
 
-fn assert_successful_streaming_responses_response(responses_response: &str) {
+pub(super) fn assert_successful_streaming_responses_response(responses_response: &str) {
     assert!(
         responses_response.starts_with("HTTP/1.1 200 OK"),
         "unexpected Responses response: {responses_response}"

--- a/apps/supervisor/src/application.rs
+++ b/apps/supervisor/src/application.rs
@@ -40,7 +40,7 @@ pub(crate) struct ApplicationState {
     /// Static config warning surfaced once at daemon startup so the menu bar app
     /// can flash a callout for an ignored fixed prompt-processing chunk size.
     pub(crate) config_warning: Option<Arc<str>>,
-    /// All Qwen3.5-MoE-family models discovered from config directories at startup.
+    /// Executable models discovered from configured directories at startup.
     pub(crate) discovered_models: Vec<DiscoveredModel>,
     /// Reloadable runtime config shared by the config-reload endpoint and the
     /// status/models endpoints. Present only when the application was built with
@@ -72,6 +72,21 @@ impl Clone for ApplicationState {
 }
 
 impl ApplicationState {
+    /// Returns one consistent model-discovery snapshot for listing and routing.
+    pub(crate) fn discovered_models_snapshot(&self) -> Vec<DiscoveredModel> {
+        self.reloadable_config
+            .as_ref()
+            .and_then(|reloadable_config| {
+                reloadable_config
+                    .read()
+                    .ok()
+                    .map(|resolved_runtime_config| {
+                        resolved_runtime_config.discovered_models.clone()
+                    })
+            })
+            .unwrap_or_else(|| self.discovered_models.clone())
+    }
+
     pub(crate) fn configured_speculative_prefill_target_model_id(&self) -> Option<String> {
         self.reloadable_config
             .as_ref()
@@ -92,16 +107,15 @@ impl ApplicationState {
         requested_model_id: &str,
         ready_model_id: Option<&str>,
     ) -> Option<String> {
-        let known_model_ids: Vec<&str> = self
-            .discovered_models
+        let discovered_models = self.discovered_models_snapshot();
+        let known_model_ids: Vec<&str> = discovered_models
             .iter()
             .map(|discovered_model| discovered_model.model_id.as_str())
             .collect();
         let resolved_model_id =
             astronomical_config::resolve_model_id(requested_model_id, &known_model_ids);
         let is_ready_model = ready_model_id == Some(resolved_model_id);
-        let is_discovered_model = self
-            .discovered_models
+        let is_discovered_model = discovered_models
             .iter()
             .any(|discovered_model| discovered_model.model_id == resolved_model_id);
         (is_ready_model || is_discovered_model).then(|| resolved_model_id.to_owned())

--- a/apps/supervisor/src/openai_models_endpoint.rs
+++ b/apps/supervisor/src/openai_models_endpoint.rs
@@ -22,8 +22,6 @@ const OPENAI_CHAT_REASONING_FORMAT: &str =
 const OPENAI_FUNCTION_CALL_FORMAT: &str = "openai_function_call";
 const CHAT_COMPLETIONS_ENDPOINT_PATH: &str = "/v1/chat/completions";
 const RESPONSES_ENDPOINT_PATH: &str = "/v1/responses";
-const DISCOVERED_QWEN_MODELS_SUPPORT_REASONING: bool = true;
-const DISCOVERED_QWEN_MODELS_SUPPORT_TOOL_CALLS: bool = true;
 
 /// Lists every model the supervisor can currently advertise safely.
 pub(crate) async fn list_models(State(application_state): State<ApplicationState>) -> Response {
@@ -73,7 +71,7 @@ fn advertised_models_for_application_state(
     application_state: &ApplicationState,
     model_advertisement_created_at_unix_seconds: u64,
 ) -> Result<Vec<OpenAiModel>, OpenAiModelValidationError> {
-    let discovered_models = discovered_models_for_application_state(application_state);
+    let discovered_models = application_state.discovered_models_snapshot();
     if discovered_models.is_empty() {
         let worker_health_snapshot = application_state
             .generation_executor
@@ -105,21 +103,6 @@ fn advertised_models_for_application_state(
         .collect()
 }
 
-fn discovered_models_for_application_state(
-    application_state: &ApplicationState,
-) -> Vec<DiscoveredModel> {
-    application_state
-        .reloadable_config
-        .as_ref()
-        .and_then(|reloadable_config| {
-            reloadable_config
-                .read()
-                .ok()
-                .map(|resolved_runtime_config| resolved_runtime_config.discovered_models.clone())
-        })
-        .unwrap_or_else(|| application_state.discovered_models.clone())
-}
-
 fn openai_model_from_ready_worker_capabilities(
     ready_model_id: String,
     model_advertisement_created_at_unix_seconds: u64,
@@ -147,8 +130,7 @@ fn openai_model_from_discovered_model(
     discovered_model: &DiscoveredModel,
     model_advertisement_created_at_unix_seconds: u64,
 ) -> Result<OpenAiModel, OpenAiModelValidationError> {
-    // Current discovered Qwen3.5-MoE-family models all use the same structured-chat
-    // processor, which enables reasoning and validated OpenAI function calls.
+    // Family discovery owns behavior; this layer owns only the common API shape.
     OpenAiModel::from_parts(OpenAiModelParts {
         model_id: discovered_model.model_id.clone(),
         created: model_advertisement_created_at_unix_seconds,
@@ -159,10 +141,10 @@ fn openai_model_from_discovered_model(
         input_modalities: input_modalities_for_model(discovered_model.has_vision),
         output_modalities: vec![TEXT_OUTPUT_MODALITY.to_owned()],
         supports_streaming: true,
-        supports_reasoning: DISCOVERED_QWEN_MODELS_SUPPORT_REASONING,
-        reasoning_format: reasoning_format_for_model(DISCOVERED_QWEN_MODELS_SUPPORT_REASONING),
-        supports_tool_calls: DISCOVERED_QWEN_MODELS_SUPPORT_TOOL_CALLS,
-        tool_call_format: tool_call_format_for_model(DISCOVERED_QWEN_MODELS_SUPPORT_TOOL_CALLS),
+        supports_reasoning: discovered_model.supports_reasoning,
+        reasoning_format: reasoning_format_for_model(discovered_model.supports_reasoning),
+        supports_tool_calls: discovered_model.supports_tool_calls,
+        tool_call_format: tool_call_format_for_model(discovered_model.supports_tool_calls),
         supported_endpoints: supported_generation_endpoint_paths(),
     })
 }

--- a/apps/supervisor/tests/rest_api/application/contracts.rs
+++ b/apps/supervisor/tests/rest_api/application/contracts.rs
@@ -278,6 +278,8 @@ async fn should_report_ready_status_idle_activity_and_model_id_for_a_ready_worke
             max_input_tokens: 241_664,
             max_output_tokens: 20_480,
             has_vision: true,
+            supports_reasoning: true,
+            supports_tool_calls: true,
             model_size_bytes: 18_420_000_000,
         }],
     );

--- a/apps/supervisor/tests/rest_api/config_reload/reload_status.rs
+++ b/apps/supervisor/tests/rest_api/config_reload/reload_status.rs
@@ -407,6 +407,65 @@ async fn should_keep_all_discovered_models_listed_and_routable_with_speculative_
     assert_eq!(received_generation_commands[1].model, UNCONFIGURED_MODEL_ID);
 }
 
+#[tokio::test]
+async fn should_use_the_same_reloaded_discovery_snapshot_for_listing_and_routing() {
+    const RELOADED_MODEL_ID: &str = "astronomical/reloaded-laguna";
+    let config_home_directory = tempfile::tempdir()
+        .expect("a config home should be created")
+        .keep();
+    write_config_file(&config_home_directory, r#"{}"#);
+    let reloadable_config = Arc::new(RwLock::new(sample_resolved_config()));
+    let scripted_executor = ScriptedExecutor::ready(Vec::new());
+    let received_generation_commands = scripted_executor.received_generation_commands();
+    let application = build_development_application_with_reload(
+        scripted_executor,
+        Arc::clone(&reloadable_config),
+        config_home_directory,
+    );
+    let mut reloaded_laguna = discovered_model_for(RELOADED_MODEL_ID);
+    reloaded_laguna.model_family = astronomical_config::ModelFamily::Laguna;
+    reloadable_config
+        .write()
+        .expect("the reloadable config should remain writable")
+        .discovered_models = vec![reloaded_laguna];
+
+    let model_list_response = application
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/v1/models")
+                .body(Body::empty())
+                .expect("the model-list request should be well formed"),
+        )
+        .await
+        .expect("the model-list request should receive a response");
+    let model_list_body = to_bytes(model_list_response.into_body(), 16 * 1024)
+        .await
+        .expect("the model-list response should be readable");
+    assert!(String::from_utf8_lossy(&model_list_body).contains(RELOADED_MODEL_ID));
+
+    let generation_response = application
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/chat/completions")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(format!(
+                    r#"{{"model":"{RELOADED_MODEL_ID}","messages":[{{"role":"user","content":"hello"}}],"stream":true}}"#
+                )))
+                .expect("the Laguna request should be well formed"),
+        )
+        .await
+        .expect("the Laguna request should receive a response");
+
+    assert_eq!(generation_response.status(), StatusCode::OK);
+    let received_generation_commands = received_generation_commands
+        .lock()
+        .expect("the scripted command log should remain readable");
+    assert_eq!(received_generation_commands.len(), 1);
+    assert_eq!(received_generation_commands[0].model, RELOADED_MODEL_ID);
+}
+
 fn discovered_model_for(model_id: &str) -> astronomical_config::DiscoveredModel {
     astronomical_config::DiscoveredModel {
         model_id: model_id.to_owned(),
@@ -417,6 +476,8 @@ fn discovered_model_for(model_id: &str) -> astronomical_config::DiscoveredModel 
         max_input_tokens: 1_024,
         max_output_tokens: 128,
         has_vision: false,
+        supports_reasoning: true,
+        supports_tool_calls: true,
         model_size_bytes: 0,
     }
 }

--- a/apps/supervisor/tests/rest_api/openai_chat_endpoint_negative.rs
+++ b/apps/supervisor/tests/rest_api/openai_chat_endpoint_negative.rs
@@ -254,6 +254,8 @@ fn discovered_model() -> DiscoveredModel {
         max_input_tokens: 1_024,
         max_output_tokens: 128,
         has_vision: false,
+        supports_reasoning: true,
+        supports_tool_calls: true,
         model_size_bytes: 0,
     }
 }

--- a/apps/supervisor/tests/rest_api/openai_models_endpoint.rs
+++ b/apps/supervisor/tests/rest_api/openai_models_endpoint.rs
@@ -134,6 +134,39 @@ async fn should_list_text_only_input_modality_for_a_discovered_model_without_vis
 }
 
 #[tokio::test]
+async fn should_project_family_derived_reasoning_and_tool_capabilities() {
+    let mut discovered_model = discovered_model_with_vision_support(false);
+    discovered_model.supports_reasoning = false;
+    discovered_model.supports_tool_calls = false;
+    let application = build_application_with_config_warning_and_discovered_models(
+        ScriptedExecutor::ready(Vec::new()),
+        None,
+        vec![discovered_model],
+    );
+
+    let models_response = application
+        .oneshot(
+            Request::builder()
+                .uri("/v1/models")
+                .body(Body::empty())
+                .expect("the model-list request should be valid"),
+        )
+        .await
+        .expect("the application should return a model list");
+    let models_body = to_bytes(models_response.into_body(), 8 * 1024)
+        .await
+        .expect("the model-list body should be readable");
+    let model_list_document: serde_json::Value =
+        serde_json::from_slice(&models_body).expect("the model-list body should contain JSON");
+    let advertised_model = &model_list_document["data"][0];
+
+    assert_eq!(advertised_model["supports_reasoning"], false);
+    assert!(advertised_model["reasoning_format"].is_null());
+    assert_eq!(advertised_model["supports_tool_calls"], false);
+    assert!(advertised_model["tool_call_format"].is_null());
+}
+
+#[tokio::test]
 async fn should_return_an_openai_model_not_found_error_for_an_unknown_model() {
     let application = build_application(ScriptedExecutor::ready(Vec::new()));
     let model_response = application
@@ -216,6 +249,8 @@ fn discovered_model_with_vision_support(has_vision: bool) -> DiscoveredModel {
         max_input_tokens: 241_664,
         max_output_tokens: 20_480,
         has_vision,
+        supports_reasoning: true,
+        supports_tool_calls: true,
         model_size_bytes: 0,
     }
 }

--- a/apps/supervisor/tests/rest_api/openai_responses_endpoint/request_rejection.rs
+++ b/apps/supervisor/tests/rest_api/openai_responses_endpoint/request_rejection.rs
@@ -99,6 +99,8 @@ async fn should_canonicalize_a_provider_prefixed_model_for_an_idle_worker() {
             max_input_tokens: 1_024,
             max_output_tokens: 128,
             has_vision: false,
+            supports_reasoning: true,
+            supports_tool_calls: true,
             model_size_bytes: 0,
         }],
     );

--- a/crates/config/src/model_discovery/classified_artifacts.rs
+++ b/crates/config/src/model_discovery/classified_artifacts.rs
@@ -57,7 +57,7 @@ fn scan_classified_artifacts(
         {
             classified_artifacts.push(ClassifiedModelArtifact {
                 model_id,
-                upstream_revision: model_revision(current_directory),
+                upstream_revision: immutable_model_revision(current_directory),
                 model_directory: current_directory.to_path_buf(),
                 model_family,
             });
@@ -125,7 +125,8 @@ fn model_identity(model_directory: &Path) -> Option<String> {
     Some(format!("{organization_name}/{repository_name}"))
 }
 
-fn model_revision(model_directory: &Path) -> Option<String> {
+/// Returns artifact provenance only when its source records an immutable revision candidate.
+pub(super) fn immutable_model_revision(model_directory: &Path) -> Option<String> {
     let local_metadata_path =
         model_directory.join(".cache/huggingface/download/config.json.metadata");
     if local_metadata_path

--- a/crates/config/src/model_discovery/laguna.rs
+++ b/crates/config/src/model_discovery/laguna.rs
@@ -1,6 +1,271 @@
-//! Family-owned shallow classification rules for Laguna artifacts.
+//! Family-owned shallow discovery rules for executable Laguna artifacts.
 
-/// Recognizes the Laguna family marker without claiming execution support.
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Component, Path};
+
+use serde::Deserialize;
+
+use super::classified_artifacts::immutable_model_revision;
+
+const MAXIMUM_INDEX_BYTES: u64 = 32 * 1024 * 1024;
+const MAXIMUM_TEXT_DOCUMENT_BYTES: u64 = 32 * 1024 * 1024;
+const MAXIMUM_TEMPLATE_BYTES: u64 = 512 * 1024;
+const MAXIMUM_TEMPLATE_SOURCE_COUNT: usize = 16;
+const MAXIMUM_TEMPLATE_INCLUDE_DEPTH: usize = 8;
+const SUPPORTED_PARSER_ID: &str = "poolside_v1";
+
+/// Family-derived metadata returned to neutral discovery orchestration.
+pub(super) struct LagunaDiscoveredModelMetadata {
+    pub revision: String,
+    pub context_window: u32,
+    pub max_input_tokens: u32,
+    pub max_output_tokens: u32,
+    pub has_vision: bool,
+    pub supports_reasoning: bool,
+    pub supports_tool_calls: bool,
+    pub model_size_bytes: u64,
+}
+
+/// Recognizes the authoritative Laguna family marker.
 pub(super) fn recognizes_model_type(model_type: Option<&str>) -> bool {
     model_type == Some("laguna")
+}
+
+/// Predicts whether startup can execute one Laguna artifact without reading weight payloads.
+pub(super) fn discover_model_metadata(
+    model_directory: &Path,
+    config_bytes: &[u8],
+    configured_max_output_tokens: u32,
+) -> Option<LagunaDiscoveredModelMetadata> {
+    let config_document: LagunaConfigDocument = serde_json::from_slice(config_bytes).ok()?;
+    if config_document.model_type != "laguna" {
+        return None;
+    }
+    let context_window = config_document
+        .text_config
+        .as_ref()
+        .unwrap_or(&config_document.language_fields)
+        .max_position_embeddings?;
+    if context_window < 2 || configured_max_output_tokens == 0 {
+        return None;
+    }
+    let max_output_tokens = configured_max_output_tokens.min(context_window - 1);
+
+    // Startup requires all three text sidecars. Discovery reads only bounded
+    // metadata needed to predict the supported public text contract.
+    read_bounded_file(
+        model_directory.join("tokenizer.json"),
+        MAXIMUM_TEXT_DOCUMENT_BYTES,
+    )?;
+    let tokenizer_config_bytes = read_bounded_file(
+        model_directory.join("tokenizer_config.json"),
+        MAXIMUM_TEXT_DOCUMENT_BYTES,
+    )?;
+    let generation_config_bytes = read_bounded_file(
+        model_directory.join("generation_config.json"),
+        MAXIMUM_TEXT_DOCUMENT_BYTES,
+    )?;
+    validate_template_sources(model_directory, &tokenizer_config_bytes)?;
+    let generation_config: LagunaGenerationConfigDocument =
+        serde_json::from_slice(&generation_config_bytes).ok()?;
+    let supports_reasoning = generation_config.reasoning_parser == SUPPORTED_PARSER_ID;
+    let supports_tool_calls = generation_config.tool_call_parser == SUPPORTED_PARSER_ID;
+    if !supports_reasoning || !supports_tool_calls {
+        return None;
+    }
+
+    let model_size_bytes = validate_indexed_payload(model_directory)?;
+    let revision = immutable_model_revision(model_directory)?;
+    if !is_immutable_revision(&revision) {
+        return None;
+    }
+
+    Some(LagunaDiscoveredModelMetadata {
+        revision,
+        context_window,
+        max_input_tokens: context_window - max_output_tokens,
+        max_output_tokens,
+        has_vision: false,
+        supports_reasoning,
+        supports_tool_calls,
+        model_size_bytes,
+    })
+}
+
+fn validate_indexed_payload(model_directory: &Path) -> Option<u64> {
+    let index_bytes = read_bounded_file(
+        model_directory.join("model.safetensors.index.json"),
+        MAXIMUM_INDEX_BYTES,
+    )?;
+    let index_document: LagunaShardIndexDocument = serde_json::from_slice(&index_bytes).ok()?;
+    if index_document.metadata.total_size == 0 || index_document.weight_map.is_empty() {
+        return None;
+    }
+    let mut shard_file_names = BTreeSet::new();
+    for shard_file_name in index_document.weight_map.values() {
+        if !is_safe_safetensors_file_name(shard_file_name) {
+            return None;
+        }
+        shard_file_names.insert(shard_file_name.as_str());
+    }
+    let mut model_size_bytes = 0_u64;
+    for shard_file_name in shard_file_names {
+        let shard_metadata = fs::metadata(model_directory.join(shard_file_name)).ok()?;
+        if !shard_metadata.is_file() || shard_metadata.len() == 0 {
+            return None;
+        }
+        model_size_bytes = model_size_bytes.checked_add(shard_metadata.len())?;
+    }
+    // Evinced indexes count either tensor payload bytes or serialized shard
+    // bytes. Payload bytes cannot exceed their complete serialized files.
+    if index_document.metadata.total_size > model_size_bytes {
+        return None;
+    }
+    Some(model_size_bytes)
+}
+
+fn is_safe_safetensors_file_name(shard_file_name: &str) -> bool {
+    let shard_path = Path::new(shard_file_name);
+    !shard_file_name.is_empty()
+        && !shard_file_name.contains('\\')
+        && !shard_path.is_absolute()
+        && shard_path
+            .extension()
+            .and_then(|extension| extension.to_str())
+            == Some("safetensors")
+        && shard_path
+            .components()
+            .all(|component| matches!(component, Component::Normal(_)))
+}
+
+fn validate_template_sources(model_directory: &Path, tokenizer_config_bytes: &[u8]) -> Option<()> {
+    let tokenizer_config: LagunaTokenizerConfigDocument =
+        serde_json::from_slice(tokenizer_config_bytes).ok()?;
+    if tokenizer_config.chat_template.is_empty()
+        || tokenizer_config.chat_template.len() as u64 > MAXIMUM_TEMPLATE_BYTES
+    {
+        return None;
+    }
+    let mut pending_includes = template_include_names(&tokenizer_config.chat_template)?
+        .into_iter()
+        .map(|include_name| (include_name, 1_usize, Vec::<String>::new()))
+        .collect::<Vec<_>>();
+    let mut included_names = BTreeSet::new();
+    let mut total_template_bytes = tokenizer_config.chat_template.len() as u64;
+    while let Some((include_name, depth, ancestors)) = pending_includes.pop() {
+        if depth > MAXIMUM_TEMPLATE_INCLUDE_DEPTH
+            || ancestors.contains(&include_name)
+            || !is_safe_template_include_name(&include_name)
+        {
+            return None;
+        }
+        if !included_names.insert(include_name.clone()) {
+            continue;
+        }
+        if included_names.len() + 1 > MAXIMUM_TEMPLATE_SOURCE_COUNT {
+            return None;
+        }
+        let include_bytes =
+            read_bounded_file(model_directory.join(&include_name), MAXIMUM_TEMPLATE_BYTES)?;
+        total_template_bytes = total_template_bytes.checked_add(include_bytes.len() as u64)?;
+        if total_template_bytes > MAXIMUM_TEMPLATE_BYTES {
+            return None;
+        }
+        let include_source = std::str::from_utf8(&include_bytes).ok()?;
+        let mut child_ancestors = ancestors;
+        child_ancestors.push(include_name);
+        for child_include_name in template_include_names(include_source)? {
+            pending_includes.push((child_include_name, depth + 1, child_ancestors.clone()));
+        }
+    }
+    Some(())
+}
+
+/// Finds the static single-quoted include syntax accepted by Laguna startup.
+fn template_include_names(template_source: &str) -> Option<Vec<String>> {
+    let mut include_names = Vec::new();
+    let mut remaining_source = template_source;
+    while let Some(directive_start) = remaining_source.find("{%") {
+        remaining_source = &remaining_source[directive_start + 2..];
+        let directive_end = remaining_source.find("%}")?;
+        let directive_body = remaining_source[..directive_end]
+            .trim()
+            .trim_start_matches('-')
+            .trim_end_matches('-')
+            .trim();
+        if let Some(include_expression) = directive_body.strip_prefix("include") {
+            let include_name = include_expression
+                .trim()
+                .strip_prefix('\'')?
+                .strip_suffix('\'')?;
+            if include_name.is_empty() || include_name.contains('\'') {
+                return None;
+            }
+            include_names.push(include_name.to_owned());
+        }
+        remaining_source = &remaining_source[directive_end + 2..];
+    }
+    Some(include_names)
+}
+
+fn is_safe_template_include_name(include_name: &str) -> bool {
+    let include_path = Path::new(include_name);
+    include_name.len() <= 255
+        && !include_name.contains('\\')
+        && !include_path.is_absolute()
+        && include_path
+            .components()
+            .all(|component| matches!(component, Component::Normal(_)))
+}
+
+fn read_bounded_file(file_path: impl AsRef<Path>, maximum_bytes: u64) -> Option<Vec<u8>> {
+    let file_path = file_path.as_ref();
+    let file_metadata = fs::metadata(file_path).ok()?;
+    if !file_metadata.is_file() || file_metadata.len() == 0 || file_metadata.len() > maximum_bytes {
+        return None;
+    }
+    let file_bytes = fs::read(file_path).ok()?;
+    (file_bytes.len() as u64 <= maximum_bytes).then_some(file_bytes)
+}
+
+fn is_immutable_revision(revision: &str) -> bool {
+    revision.len() == 40 && revision.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+#[derive(Deserialize)]
+struct LagunaConfigDocument {
+    model_type: String,
+    #[serde(default)]
+    text_config: Option<LagunaLanguageFields>,
+    #[serde(flatten)]
+    language_fields: LagunaLanguageFields,
+}
+
+#[derive(Default, Deserialize)]
+struct LagunaLanguageFields {
+    #[serde(default)]
+    max_position_embeddings: Option<u32>,
+}
+
+#[derive(Deserialize)]
+struct LagunaTokenizerConfigDocument {
+    chat_template: String,
+}
+
+#[derive(Deserialize)]
+struct LagunaGenerationConfigDocument {
+    reasoning_parser: String,
+    tool_call_parser: String,
+}
+
+#[derive(Deserialize)]
+struct LagunaShardIndexDocument {
+    metadata: LagunaShardIndexMetadata,
+    weight_map: std::collections::BTreeMap<String, String>,
+}
+
+#[derive(Deserialize)]
+struct LagunaShardIndexMetadata {
+    total_size: u64,
 }

--- a/crates/config/src/model_discovery/mod.rs
+++ b/crates/config/src/model_discovery/mod.rs
@@ -4,7 +4,6 @@ use std::path::{Path, PathBuf};
 
 use thiserror::Error;
 
-use self::model_family::classify_model_family;
 use crate::model_discovery_huggingface_cache::resolve_huggingface_cache_entry;
 
 mod classified_artifacts;
@@ -27,7 +26,7 @@ pub struct DiscoveredModel {
     pub model_id: String,
     /// The architecture family recognized from config.json.
     pub model_family: ModelFamily,
-    /// SHA-256 hash of config.json bytes (12 hex chars).
+    /// Family-owned artifact revision used by public identity and serving state.
     pub revision: String,
     /// Absolute path to the validated family artifact directory.
     pub model_directory: PathBuf,
@@ -39,6 +38,10 @@ pub struct DiscoveredModel {
     pub max_output_tokens: u32,
     /// Whether the checkpoint index declares physically present visual weights.
     pub has_vision: bool,
+    /// Whether family-owned text metadata declares a supported reasoning contract.
+    pub supports_reasoning: bool,
+    /// Whether family-owned text metadata declares a supported tool-call contract.
+    pub supports_tool_calls: bool,
     /// Unique safetensors shard payload bytes measured from the discovered files.
     pub model_size_bytes: u64,
 }
@@ -218,14 +221,34 @@ fn try_discover_model_with_id(
     // Read the one neutral family marker before dispatching artifact validation.
     let config_bytes = fs::read(model_directory.join("config.json")).ok()?;
     let config_value: serde_json::Value = serde_json::from_slice(&config_bytes).ok()?;
-    let model_type = config_value.get("model_type").and_then(|v| v.as_str());
-    let model_family = classify_model_family(model_type)?;
+    // The typed classifier rejects ambiguous duplicate family markers before
+    // the looser metadata document can participate in executable discovery.
+    let model_family = model_family::classify_model_directory(model_directory)
+        .ok()
+        .flatten()?;
     let family_metadata = match model_family {
         ModelFamily::Qwen3_5 => {
             qwen3_5::discover_model_metadata(model_directory, &config_value, max_output_tokens)?
         }
+        ModelFamily::Laguna => {
+            let laguna_metadata =
+                laguna::discover_model_metadata(model_directory, &config_bytes, max_output_tokens)?;
+            return Some(DiscoveredModel {
+                model_id: model_id.to_owned(),
+                model_family,
+                revision: laguna_metadata.revision,
+                model_directory: model_directory.to_path_buf(),
+                context_window: laguna_metadata.context_window,
+                max_input_tokens: laguna_metadata.max_input_tokens,
+                max_output_tokens: laguna_metadata.max_output_tokens,
+                has_vision: laguna_metadata.has_vision,
+                supports_reasoning: laguna_metadata.supports_reasoning,
+                supports_tool_calls: laguna_metadata.supports_tool_calls,
+                model_size_bytes: laguna_metadata.model_size_bytes,
+            });
+        }
         // Classification is intentionally broader than executable discovery.
-        ModelFamily::Laguna | ModelFamily::DeepSeekV4 => return None,
+        ModelFamily::DeepSeekV4 => return None,
     };
 
     // Derive revision from SHA-256 of config.json.
@@ -240,6 +263,8 @@ fn try_discover_model_with_id(
         max_input_tokens: family_metadata.max_input_tokens,
         max_output_tokens: family_metadata.max_output_tokens,
         has_vision: family_metadata.has_vision,
+        supports_reasoning: family_metadata.supports_reasoning,
+        supports_tool_calls: family_metadata.supports_tool_calls,
         model_size_bytes: family_metadata.model_size_bytes,
     })
 }

--- a/crates/config/src/model_discovery/model_family.rs
+++ b/crates/config/src/model_discovery/model_family.rs
@@ -110,8 +110,3 @@ struct ModelFamilyConfigDocument {
     #[serde(default)]
     model_type: Option<String>,
 }
-
-/// Classifies a model_type without claiming that the family is executable.
-pub(super) fn classify_model_family(model_type: Option<&str>) -> Option<ModelFamily> {
-    ModelFamily::from_model_type(model_type)
-}

--- a/crates/config/src/model_discovery/qwen3_5.rs
+++ b/crates/config/src/model_discovery/qwen3_5.rs
@@ -10,6 +10,8 @@ pub(super) struct Qwen3_5DiscoveredModelMetadata {
     pub max_input_tokens: u32,
     pub max_output_tokens: u32,
     pub has_vision: bool,
+    pub supports_reasoning: bool,
+    pub supports_tool_calls: bool,
     pub model_size_bytes: u64,
 }
 
@@ -80,6 +82,9 @@ pub(super) fn discover_model_metadata(
         max_input_tokens: context_window.saturating_sub(max_output_tokens),
         max_output_tokens,
         has_vision,
+        // The Qwen text processor owns both structured output contracts.
+        supports_reasoning: true,
+        supports_tool_calls: true,
         model_size_bytes: measure_model_safetensors_bytes(model_directory)?,
     })
 }

--- a/crates/config/tests/hermetic/model_discovery/laguna.rs
+++ b/crates/config/tests/hermetic/model_discovery/laguna.rs
@@ -1,0 +1,188 @@
+use std::fs;
+use std::path::Path;
+
+use astronomical_config::ModelFamily;
+
+use super::discover_configured_models;
+
+const IMMUTABLE_REVISION: &str = "0123456789abcdef0123456789abcdef01234567";
+
+#[test]
+fn should_advertise_one_complete_executable_laguna_artifact() {
+    let temporary_directory = tempfile::tempdir().expect("temporary directory should be created");
+    let model_directory = temporary_directory.path().join("Laguna-Fixture");
+    write_executable_laguna_artifact(&model_directory);
+
+    let directory_scans = discover_configured_models(&temporary_directory);
+    let discovered_model = directory_scans[0]
+        .discovered_models
+        .first()
+        .expect("the complete Laguna artifact should be advertised");
+
+    assert_eq!(directory_scans[0].discovered_models.len(), 1);
+    assert_eq!(discovered_model.model_family, ModelFamily::Laguna);
+    assert_eq!(discovered_model.revision, IMMUTABLE_REVISION);
+    assert_eq!(discovered_model.context_window, 65_536);
+    assert_eq!(discovered_model.max_input_tokens, 45_056);
+    assert_eq!(discovered_model.max_output_tokens, 20_480);
+    assert!(!discovered_model.has_vision);
+    assert!(discovered_model.supports_reasoning);
+    assert!(discovered_model.supports_tool_calls);
+    assert_eq!(discovered_model.model_size_bytes, 96);
+}
+
+#[test]
+fn should_require_every_laguna_discovery_boundary_before_advertising() {
+    for missing_relative_path in [
+        "tokenizer.json",
+        "tokenizer_config.json",
+        "generation_config.json",
+        "model.safetensors.index.json",
+        "model-00001.safetensors",
+        ".cache/huggingface/download/config.json.metadata",
+    ] {
+        let temporary_directory =
+            tempfile::tempdir().expect("temporary directory should be created");
+        let model_directory = temporary_directory.path().join("Laguna-Incomplete");
+        write_executable_laguna_artifact(&model_directory);
+        fs::remove_file(model_directory.join(missing_relative_path))
+            .expect("the selected required file should be removed");
+
+        assert!(
+            discover_configured_models(&temporary_directory)[0]
+                .discovered_models
+                .is_empty(),
+            "Laguna discovery must reject an artifact missing {missing_relative_path}"
+        );
+    }
+}
+
+#[test]
+fn should_reject_unsupported_text_contract_and_missing_template_include() {
+    let unsupported_parser_home =
+        tempfile::tempdir().expect("temporary directory should be created");
+    let unsupported_parser_directory = unsupported_parser_home.path().join("Unsupported-Parser");
+    write_executable_laguna_artifact(&unsupported_parser_directory);
+    fs::write(
+        unsupported_parser_directory.join("generation_config.json"),
+        r#"{"reasoning_parser":"unknown","tool_call_parser":"poolside_v1"}"#,
+    )
+    .expect("unsupported generation config should be written");
+    assert!(
+        discover_configured_models(&unsupported_parser_home)[0]
+            .discovered_models
+            .is_empty()
+    );
+
+    let missing_include_home = tempfile::tempdir().expect("temporary directory should be created");
+    let missing_include_directory = missing_include_home.path().join("Missing-Include");
+    write_executable_laguna_artifact(&missing_include_directory);
+    fs::write(
+        missing_include_directory.join("tokenizer_config.json"),
+        r#"{"chat_template":"{% include 'missing.jinja' %}"}"#,
+    )
+    .expect("include-bearing tokenizer config should be written");
+    assert!(
+        discover_configured_models(&missing_include_home)[0]
+            .discovered_models
+            .is_empty()
+    );
+}
+
+#[test]
+fn should_reject_unsafe_incomplete_or_zero_payload_laguna_indexes() {
+    for index_document in [
+        r#"{"metadata":{"total_size":96},"weight_map":{"model.embed_tokens.weight":"../outside.safetensors"}}"#,
+        r#"{"metadata":{"total_size":96},"weight_map":{"model.embed_tokens.weight":"missing.safetensors"}}"#,
+        r#"{"metadata":{"total_size":0},"weight_map":{}}"#,
+        r#"{"metadata":{"total_size":97},"weight_map":{"model.embed_tokens.weight":"model-00001.safetensors"}}"#,
+    ] {
+        let temporary_directory =
+            tempfile::tempdir().expect("temporary directory should be created");
+        let model_directory = temporary_directory.path().join("Laguna-Unsafe-Index");
+        write_executable_laguna_artifact(&model_directory);
+        fs::write(
+            model_directory.join("model.safetensors.index.json"),
+            index_document,
+        )
+        .expect("the selected unsafe index should be written");
+
+        assert!(
+            discover_configured_models(&temporary_directory)[0]
+                .discovered_models
+                .is_empty(),
+            "Laguna discovery must reject index {index_document}"
+        );
+    }
+}
+
+#[test]
+fn should_reject_nonimmutable_revision_and_zero_context() {
+    let mutable_revision_home = tempfile::tempdir().expect("temporary directory should be created");
+    let mutable_revision_directory = mutable_revision_home.path().join("Mutable-Revision");
+    write_executable_laguna_artifact(&mutable_revision_directory);
+    fs::write(
+        mutable_revision_directory.join(".cache/huggingface/download/config.json.metadata"),
+        "main\n",
+    )
+    .expect("mutable revision metadata should be written");
+    assert!(
+        discover_configured_models(&mutable_revision_home)[0]
+            .discovered_models
+            .is_empty()
+    );
+
+    let zero_context_home = tempfile::tempdir().expect("temporary directory should be created");
+    let zero_context_directory = zero_context_home.path().join("Zero-Context");
+    write_executable_laguna_artifact(&zero_context_directory);
+    fs::write(
+        zero_context_directory.join("config.json"),
+        r#"{"model_type":"laguna","text_config":{"max_position_embeddings":0}}"#,
+    )
+    .expect("zero-context model config should be written");
+    assert!(
+        discover_configured_models(&zero_context_home)[0]
+            .discovered_models
+            .is_empty()
+    );
+}
+
+fn write_executable_laguna_artifact(model_directory: &Path) {
+    fs::create_dir_all(model_directory.join(".cache/huggingface/download"))
+        .expect("Laguna fixture directories should be created");
+    fs::write(
+        model_directory.join("config.json"),
+        r#"{"model_type":"laguna","text_config":{"max_position_embeddings":65536}}"#,
+    )
+    .expect("Laguna model config should be written");
+    fs::write(
+        model_directory.join("tokenizer.json"),
+        r#"{"version":"1.0","model":{"type":"BPE"}}"#,
+    )
+    .expect("Laguna tokenizer should be written");
+    fs::write(
+        model_directory.join("tokenizer_config.json"),
+        r#"{"chat_template":"{{ messages }}"}"#,
+    )
+    .expect("Laguna tokenizer config should be written");
+    fs::write(
+        model_directory.join("generation_config.json"),
+        r#"{"reasoning_parser":"poolside_v1","tool_call_parser":"poolside_v1"}"#,
+    )
+    .expect("Laguna generation config should be written");
+    fs::write(
+        model_directory.join("model.safetensors.index.json"),
+        r#"{"metadata":{"total_size":96},"weight_map":{"model.embed_tokens.weight":"model-00001.safetensors"}}"#,
+    )
+    .expect("Laguna shard index should be written");
+    fs::write(
+        model_directory.join("model-00001.safetensors"),
+        vec![0_u8; 96],
+    )
+    .expect("Laguna model shard should be written");
+    fs::write(
+        model_directory.join(".cache/huggingface/download/config.json.metadata"),
+        format!("{IMMUTABLE_REVISION}\n"),
+    )
+    .expect("Laguna immutable revision should be written");
+}

--- a/crates/config/tests/hermetic/model_discovery/mod.rs
+++ b/crates/config/tests/hermetic/model_discovery/mod.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 
 mod classified_artifacts;
 mod family_classification;
+mod laguna;
 mod package_structure;
 mod qwen3_5;
 mod traversal;

--- a/docs/performance-optimizations-lessons.md
+++ b/docs/performance-optimizations-lessons.md
@@ -192,6 +192,7 @@
 
 ## Model lifecycle
 
+- Keep public model discovery shallow but predictive: bounded-read family metadata, validate required sidecars and safe shard references, and sum file metadata without opening or hashing multi-gigabyte weight payloads. Deep retained-descriptor validation remains model-load work, and a deep failure must preserve the already resident model.
 - Start the worker without constructing a processor or engine. Lazy first-request loading removes avoidable application-launch input/output, memory allocation, and graphics-processor residency.
 - Bound on-demand model loading and report a recoverable failure over inter-process communication. A bad discovered artifact must not stall the request queue or force a healthy idle worker to exit.
 - Preserve the model-load cause chain across the worker boundary and return a dedicated local application programming interface error. A generic worker-unavailable response hides correctable artifact or quantization failures and encourages unnecessary worker restarts.

--- a/repo-discovery-guide-for-agents.md
+++ b/repo-discovery-guide-for-agents.md
@@ -6,7 +6,7 @@ Agent orientation map for non-obvious repository facts; this is not user-facing 
 
 Read this guide before substantive work and spot-check 2-3 key facts. Update it when paths, entry points, conventions, or expensive gotchas change. Treat it as suspect when Last verified is more than 90 days old.
 
-Last verified: 2026-08-15 (spot-checked: prompt-processing optimizer/Qwen/engine ownership boundaries, Stable/Development instance isolation and Spotlight-excluded app build paths, Rust bounded expert streaming, phase-aware expert residency, native build graph, fixed-prefill qualification, worker compilation, centralized memory policy, native expert cache deletion)
+Last verified: 2026-08-16 (spot-checked: executable Laguna discovery and public REST routing, prompt-processing optimizer/Qwen/engine ownership boundaries, Stable/Development isolation, Rust bounded expert streaming, phase-aware expert residency, native build graph, centralized memory policy, native expert cache deletion)
 
 ## Project overview
 
@@ -33,8 +33,8 @@ Astronomical is an Apple Silicon local model server. The active architecture is 
 - InferenceEngineError::InvalidRequest is request-scoped at generation start, token advancement, and injected-token advancement: emit WorkerEvent::Failed and keep the loaded worker reusable. Truly fatal worker returns use a bounded Tokio runtime shutdown because Tokio standard-input reads cannot be cancelled and must not leave a half-dead process retaining MLX memory.
 - Qwen prefill capacity recovery classifies typed Machine Learning framework for Apple silicon errors from direct execution and Rust bounded expert loading. Both paths restore the request checkpoint before a request can be rejected.
 - Normal worker builds include direct-mlx. The supervisor resolves user configuration and sends worker-owned startup paths over typed IPC. The inference worker starts without a model directory and receives a selected directory only through SwapModel.
-- ModelFamily classifies Qwen3.5 and DeepSeek-V4 model types, but discovery returns only executable Qwen families. DeepSeek-V4 is intentionally absent from /v1/models and the worker factory rejects it before replacing a ready Qwen model.
-- Laguna owns strict artifact/text contracts plus descriptor-driven attention, sparse-expert residency and paging, prompt optimization, persistent prompt caching, and generation under `crates/model-serving/src/laguna/`. The worker can execute a directly selected validated Laguna artifact, but discovery keeps it unadvertised until the public serving layer lands.
+- ModelFamily classifies Qwen3.5, Laguna, and DeepSeek-V4 model types. Discovery advertises executable Qwen and Laguna artifacts; DeepSeek-V4 remains intentionally absent from `/v1/models` and is rejected before replacing a ready model.
+- Laguna owns strict artifact/text contracts plus descriptor-driven attention, sparse-expert residency and paging, prompt optimization, persistent prompt caching, and generation under `crates/model-serving/src/laguna/`. Family-owned shallow discovery requires bounded text sidecars, supported parser/template metadata, a safe complete nonzero shard index, a nonzero context, and an immutable revision before public listing and routing use the same discovered-model snapshot.
 - model_family_runtime owns the only concrete family enum boundary. inference_engine, engine_backed_worker, IPC, REST, and runtime-integration remain architecture-neutral; the worker selects a family once during model creation.
 - model_directories entries in the standard Astronomical configuration are recursive scan roots, not guaranteed leaf model directories. Ignored model qualification and measurement tests must resolve an exact model ID through Astronomical discovery and must not fall back to an external model-manager directory.
 - Qwen3_5MoEArtifactValidator discovers executable model shards and optional vision files from the index, accepts missing MTP-only files for target-only serving, validates optional OptiQ metadata when present, ignores unrelated files, and does not full-hash model payloads.
@@ -149,11 +149,11 @@ Astronomical is an Apple Silicon local model server. The active architecture is 
 
 ## What to verify
 
-- Whether the active OpenAI SSE path still streams real Qwen3.5 output.
+- Whether the active OpenAI SSE path still streams real Qwen3.5 and Laguna output through Chat and Responses.
 - Whether docs or code reintroduced alternate transports, periodic RSS/heartbeat policy, automatic replacement/backoff, or multi-layer worker management.
 - Whether REST/SSE DTOs and IPC DTOs remain bounded and separate, with image bytes compact on the Generate wire and oversized requests remaining non-fatal to the worker.
 - Whether the family runtime enum delegates Qwen3.5 chat preparation without changing Qwen3_5InferenceRequest behavior and worker startup constructs one EngineBackedWorker directly; do not restore pass-through prepared-chat or configured-worker wrappers.
-- Whether DeepSeek-V4 remains a typed unavailable stub only, excluded from discovery and the models endpoint until its real artifact implementation is intentionally onboarded.
+- Whether DeepSeek-V4 remains a typed unavailable stub excluded from discovery, while incomplete Laguna artifacts remain unadvertised and deep Laguna load failures preserve the healthy resident model.
 - Whether expert_paging remains free of concrete Qwen and DeepSeek tensor semantics, qwen3_5_moe retains Qwen layer plans and routing, and production expert streaming remains Rust bounded loading over ordinary MLX arrays.
 - Whether the centralized memory policy in memory/ (`MlxRamBudget`, `AllocationAdmission`, `ExpertMemoryAdmission`, `ResidencyAdmission`, `ForwardRecovery`, `LiveAllocationBudget`, `AdaptiveRamGrowthGuard`) handles all cross-component budget decisions without re-introducing scattered admission logic.
 - Whether phase-aware expert residency preserves a complete-layer prefill foundation, overlays routed decode demand within remaining capacity, reclaims partial pages first, and does not require the removed native cache.
@@ -171,4 +171,4 @@ Astronomical is an Apple Silicon local model server. The active architecture is 
 
 ## Maintenance snapshot
 
-Verified prompt-processing optimizer, Qwen integration, engine telemetry, and IPC ownership boundaries on 2026-08-15. Stable/Development isolation, complete-model fast path, Rust bounded expert streaming, phase-aware prefill/decode residency, centralized memory policy, and native expert-cache deletion were last spot-checked on 2026-08-14. Rust 1.97.1, edition 2024.
+Verified executable Laguna discovery, family-derived public capabilities, shared listing/routing snapshots, and public Chat/Responses, cache, cancellation, swap, malformed-load, and attribution journeys on 2026-08-16. Rust 1.97.1, edition 2024.


### PR DESCRIPTION
## Problem

Laguna can execute through the worker, but users cannot safely discover or serve it through the public API. Listing and routing also need one consistent executable-model snapshot so incomplete artifacts cannot become hidden request targets.

## Change

- Add bounded family-owned Laguna discovery for required text sidecars, supported parser/template metadata, safe complete shard references, nonzero payload and context, and immutable revision provenance.
- Use one `DiscoveredModel` snapshot for `/v1/models` and request routing, with family-derived reasoning, tools, modality, limits, revision, and payload metadata.
- Add public XS and S Chat and Responses qualification plus prompt-cache restore, cancellation/reuse, Qwen-to-XS-to-S-to-Qwen swap, resident long-prompt attribution, and exact malformed-load recovery journeys.
- Keep incomplete Laguna and DeepSeek artifacts unadvertised.
- Leave the Laguna registry rows absent because the remaining #107 license, registry, S cache, and S attribution cells are not yet complete.

Closes #106. Progresses #107.

## Verification

- Config discovery suite, including incomplete sidecars, unsafe/missing shards, unsupported parser/template metadata, zero payload/context, and mutable revision rejection
- Supervisor model-listing, family-capability, reload-snapshot, and routing journeys
- Pinned XS and S canonical artifact and executable-discovery qualification
- Pinned XS and S public streaming Chat and Responses
- Public XS cold/warm prompt-cache restore
- Public S mid-prefill cancellation and worker reuse
- Qwen → XS → S → Qwen generation on one worker
- Exact HTTP 503 `model_load_failed` for a shallow-valid/deep-invalid Laguna artifact, followed by healthy-model reuse
- Resident XS long-prompt generation with attribution enabled and disabled
- `scripts/test-direct-mlx.sh`
- Source-size guards
- `scripts/verify-before-commit.sh`
- Isolated Development application build and validation, including confirmation that Stable remained available

## Safety

- [x] No credentials, personal paths, prompts, model inventories, proprietary artifacts, or machine logs are included.
- [x] Model precision and output semantics are preserved or explicitly justified.
- [x] Performance and memory effects are measured when the critical path changes.
- [x] Source reuse and third-party licensing are accurately attributed.
