### PR TITLE
chore: prepare Astronomical 0.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,7 +39,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "astronomical-config"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "libc",
  "serde",
@@ -51,7 +51,7 @@ dependencies = [
 
 [[package]]
 name = "astronomical-experimental-aligned-expert-packs"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "astronomical-config",
  "astronomical-model-serving",
@@ -66,7 +66,7 @@ dependencies = [
 
 [[package]]
 name = "astronomical-inference-worker"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "astronomical-config",
  "astronomical-ipc-protocol",
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "astronomical-ipc-protocol"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "base64 0.23.1",
  "bytes",
@@ -104,7 +104,7 @@ dependencies = [
 
 [[package]]
 name = "astronomical-model-serving"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "astronomical-config",
  "astronomical-ipc-protocol",
@@ -127,7 +127,7 @@ dependencies = [
 
 [[package]]
 name = "astronomical-rest-contract"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "base64 0.23.1",
  "serde",
@@ -137,7 +137,7 @@ dependencies = [
 
 [[package]]
 name = "astronomical-runtime-integration"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "bindgen",
  "libc",
@@ -148,7 +148,7 @@ dependencies = [
 
 [[package]]
 name = "astronomical-supervisor"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "astronomical-config",
  "astronomical-ipc-protocol",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ license = "Apache-2.0"
 publish = false
 repository = "https://github.com/aosama/astronomical"
 rust-version = "1.97.1"
-version = "0.2.1"
+version = "0.2.2"
 
 [workspace.dependencies]
 async-openai = { version = "0.41.3", default-features = false, features = ["byot", "chat-completion"] }


### PR DESCRIPTION
## Summary

- bump the Astronomical workspace release version to 0.2.2
- refresh workspace package versions in the lockfile
- prepare the merged secure-update and inference improvements for the first signed GitHub Release

## Verification

- `cargo check -p astronomical-supervisor --timings`
- `scripts/verify-before-commit.sh`