### PR TITLE
fix: allow Pages deployment to complete

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -22,7 +22,7 @@ jobs:
   deploy:
     name: Publish GitHub Pages site
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
## Summary

- retain a bounded GitHub Pages deployment job while increasing its allowance from five to ten minutes
- allow GitHub Pages enough time to publish the signed Astronomical 0.2.2 appcast

## Evidence

The first activation run archived and uploaded the site successfully, then GitHub canceled `actions/deploy-pages` at the five-minute job limit while deployment was still in progress.

Failed deployment: https://github.com/aosama/astronomical/actions/runs/32150957627

## Verification

- `scripts/verify-before-commit.sh`