### PR TITLE
Prepare Astronomical 0.2.5 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,7 +39,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "astronomical-config"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "libc",
  "serde",
@@ -51,7 +51,7 @@ dependencies = [
 
 [[package]]
 name = "astronomical-experimental-aligned-expert-packs"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "astronomical-config",
  "astronomical-model-serving",
@@ -66,7 +66,7 @@ dependencies = [
 
 [[package]]
 name = "astronomical-inference-worker"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "astronomical-config",
  "astronomical-ipc-protocol",
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "astronomical-ipc-protocol"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "base64 0.23.1",
  "bytes",
@@ -104,7 +104,7 @@ dependencies = [
 
 [[package]]
 name = "astronomical-model-serving"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "astronomical-config",
  "astronomical-ipc-protocol",
@@ -127,7 +127,7 @@ dependencies = [
 
 [[package]]
 name = "astronomical-rest-contract"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "base64 0.23.1",
  "serde",
@@ -137,7 +137,7 @@ dependencies = [
 
 [[package]]
 name = "astronomical-runtime-integration"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "bindgen",
  "libc",
@@ -148,7 +148,7 @@ dependencies = [
 
 [[package]]
 name = "astronomical-supervisor"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "astronomical-config",
  "astronomical-ipc-protocol",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ license = "Apache-2.0"
 publish = false
 repository = "https://github.com/aosama/astronomical"
 rust-version = "1.97.1"
-version = "0.2.4"
+version = "0.2.5"
 
 [workspace.dependencies]
 async-openai = { version = "0.41.3", default-features = false, features = ["byot", "chat-completion"] }


### PR DESCRIPTION
## Goal

Prepare the workspace version used by the signed Astronomical 0.2.5 macOS release and Sparkle update.

## Scope

- Bump all Astronomical workspace packages from 0.2.4 to 0.2.5.
- Preserve dependency versions and runtime behavior.

## Evidence

- Cargo metadata resolves every workspace package at 0.2.5.
- The bounded pre-commit verification suite passes, including hermetic and REST API journeys.

## Acceptance criteria

- Required CI passes.
- The version commit merges to main before the v0.2.5 tag is created.
- Signed release preparation uses the exact tagged main commit.