### PR TITLE
Prepare Astronomical 0.2.7 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,7 +39,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "astronomical-config"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "libc",
  "serde",
@@ -52,7 +52,7 @@ dependencies = [
 
 [[package]]
 name = "astronomical-experimental-aligned-expert-packs"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "astronomical-config",
  "astronomical-model-serving",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "astronomical-inference-worker"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "astronomical-config",
  "astronomical-ipc-protocol",
@@ -91,7 +91,7 @@ dependencies = [
 
 [[package]]
 name = "astronomical-ipc-protocol"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "base64 0.23.1",
  "bytes",
@@ -105,7 +105,7 @@ dependencies = [
 
 [[package]]
 name = "astronomical-model-serving"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "astronomical-config",
  "astronomical-ipc-protocol",
@@ -128,7 +128,7 @@ dependencies = [
 
 [[package]]
 name = "astronomical-rest-contract"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "base64 0.23.1",
  "serde",
@@ -138,7 +138,7 @@ dependencies = [
 
 [[package]]
 name = "astronomical-runtime-integration"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "bindgen",
  "libc",
@@ -149,7 +149,7 @@ dependencies = [
 
 [[package]]
 name = "astronomical-supervisor"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "astronomical-config",
  "astronomical-ipc-protocol",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ license = "Apache-2.0"
 publish = false
 repository = "https://github.com/aosama/astronomical"
 rust-version = "1.97.1"
-version = "0.2.6"
+version = "0.2.7"
 
 [workspace.dependencies]
 async-openai = { version = "0.41.3", default-features = false, features = ["byot", "chat-completion"] }


### PR DESCRIPTION
## Goal

Prepare the workspace version used by the signed Astronomical 0.2.7 macOS patch release and Sparkle update.

## Scope

- bump all Astronomical workspace packages from 0.2.6 to 0.2.7
- preserve dependency versions and runtime behavior
- carry the `/v1/models` metadata fix merged through #194

## Evidence

- Cargo metadata resolves every workspace package at 0.2.7
- `scripts/verify-before-commit.sh` passes

## Acceptance criteria

- required CI passes
- the version commit merges to `main` before the `v0.2.7` tag is created
- signed release preparation uses the exact tagged `main` commit