### PR TITLE
release: activate Astronomical 0.2.8 updates

### DIFF
--- a/site/appcast.xml
+++ b/site/appcast.xml
@@ -4,28 +4,30 @@ IMPORTANT: This file was signed by Sparkle. Any modifications to this file requi
     <channel>
         <title>Astronomical</title>
         <item>
-            <title>0.2.7</title>
-            <pubDate>Thu, 20 Aug 2026 12:37:55 -0400</pubDate>
-            <sparkle:version>248</sparkle:version>
-            <sparkle:shortVersionString>0.2.7</sparkle:shortVersionString>
+            <title>0.2.8</title>
+            <pubDate>Thu, 20 Aug 2026 20:04:10 -0400</pubDate>
+            <sparkle:version>257</sparkle:version>
+            <sparkle:shortVersionString>0.2.8</sparkle:shortVersionString>
             <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
             <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
             <description sparkle:format="markdown"><![CDATA[## Highlights
 
-- Restores `GET /v1/models` when discovered or actively serving models publish independent maximum input and output token capabilities.
-- Restores the documented discovery-to-selection journey for clients that enumerate local models before loading one.
-- Adds repeatable production-discovery and ready-worker endpoint coverage so model capability metadata remains available across future releases.
+- Adds native text-to-image generation with the pinned FLUX.2 Klein 4B model profile on Apple Silicon.
+- Adds the OpenAI-compatible `POST /v1/images/generations` endpoint with deterministic seed controls and lossless RGB PNG output from 64 × 64 through 1,024 × 1,024 pixels.
+- Adds automatic chat-to-image model swapping while retaining one resident model, shared bounded request admission, cancellation, and reusable worker capacity.
+- Adds adaptive image-generation memory admission and operation-level performance attribution across model loading, text conditioning, denoising, VAE decoding, and PNG encoding.
+- Adds independent reference qualification, repeated deterministic generation checks, and chat-to-image-to-chat lifecycle coverage for the pinned model revision.
 
 ## Compatibility
 
-Astronomical 0.2.7 supports Apple Silicon Macs running macOS 26 or later. The DMG is signed, Apple-notarized, and stapled for Gatekeeper verification. The update archive and feed remain protected by Sparkle Ed25519 signatures.
+Astronomical 0.2.8 supports Apple Silicon Macs running macOS 26 or later. The DMG is signed, Apple-notarized, and stapled for Gatekeeper verification. The update archive and feed remain protected by Sparkle Ed25519 signatures.
 
-Existing model directories, configuration, prompt caches, and logs remain in place when updating from 0.2.6.
+Existing model directories, configuration, prompt caches, and logs remain in place when updating from 0.2.7.
 ]]></description>
-            <enclosure url="https://github.com/aosama/astronomical/releases/download/v0.2.7/Astronomical-0.2.7-macOS-arm64.dmg" length="12446622" type="application/octet-stream" sparkle:edSignature="NSbR0lYz/b7ry0DjuGGkjEIsHGnMe/FNWWk9rr4pE4/MVBS5kb75g0evA8qSCd9SvEyUn1XQMxLdfAbN+uZTBg=="></enclosure>
+            <enclosure url="https://github.com/aosama/astronomical/releases/download/v0.2.8/Astronomical-0.2.8-macOS-arm64.dmg" length="13258386" type="application/octet-stream" sparkle:edSignature="rpA+17AyMpTqk5Y0wJ0Xyklm6jNu5Sx8jQf26N8y5j9epiww24yxdkAErxUIZQTkSYGOi/9PqwL7UTULRWEzAw=="></enclosure>
         </item>
     </channel>
 </rss><!-- sparkle-signatures:
-edSignature: UzErrMA7s5kKVSC926CmXwbsQfJX4F0Uj0+5MWPrdmAhrT0LTwOekWPffqSdRWEdmLp/fsH+RRySf9lVNuZ6Cg==
-length: 1992
+edSignature: T3trl8AMn2XJq/1Nsn+VhYnYnUS9gg7YqxKHdqRScabtpfJj4V8/AhTnduQYLrgC6USLEeUUwP5osTJ418pXDA==
+length: 2371
 -->


### PR DESCRIPTION
## Goal

Activate the signed Sparkle update feed for Astronomical 0.2.8 after publication of the notarized GitHub Release.

## Evidence

- GitHub Release: https://github.com/aosama/astronomical/releases/tag/v0.2.8
- DMG SHA-256: `e7e33cc7eff892249219236fbc026c72267dd065079dd2993f4a25db98dfa9fc`
- Apple notarization, stapling, Gatekeeper assessment, Sparkle signing, and the drag-to-Applications validation journey passed
- the required pre-commit verification suite passed

## Scope

- replace the signed 0.2.7 appcast entry with the signed 0.2.8 entry
- preserve the Sparkle-generated enclosure and feed signatures without manual modification

## Acceptance criteria

- required checks pass
- the signed appcast is deployed through GitHub Pages
- the public feed resolves to the published 0.2.8 artifact with matching size and signature metadata