### PR TITLE
Run commit verification once before committing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@
 
 - Keep full workspace verification and formatting verification only before committing and pushing when the user asks you to commit. This codebase is slow to format check and do a full workspace/test runs.
 
-- Before every requested commit or push run scripts/verify-before-commit.sh; never substitute cargo test --workspace --all-targets because it runs broad integration binaries serially.
+- Before every requested commit run scripts/verify-before-commit.sh; never substitute cargo test --workspace --all-targets because it runs broad integration binaries serially.
 
 - Run cargo fmt or similar commands only before committing, i.e. when the user asks you to commit then you do the cargo fmt
 


### PR DESCRIPTION
## Linked issue

Fixes #238

## Problem

The agent instruction required the complete local commit gate before both committing and pushing, causing an unchanged committed tree to receive the same verification twice.

## Change

Require `scripts/verify-before-commit.sh` before each requested commit, without a separate duplicate pre-push run.

## Verification

- `scripts/verify-before-commit.sh` — 16/16 checks passed before commit.
- The committed diff contains only the one-line `AGENTS.md` policy update.

## Safety

- [x] No credentials, personal paths, prompts, model inventories, proprietary artifacts, or machine logs are included.
- [x] Model precision and output semantics are unaffected.
- [x] The inference critical path, performance, and memory behavior are unaffected.
- [x] No source reuse or third-party licensing changes are included.