### PR TITLE
Replace 9B text-only model with vision-capable variant in download catalog

### DIFF
--- a/registry/download_catalog.json
+++ b/registry/download_catalog.json
@@ -14,30 +14,30 @@
         "supports_vision": true,
         "supports_tool_calls": true,
         "context_window": 262144,
-        "max_output_tokens": 8192
+        "max_output_tokens": 32768
       },
       "quantization_label": "oQ6e (6-bit enhanced)",
       "architecture_summary": "Qwen 3.5 MoE, 35B params, 3B active (A3B)",
       "upstream_license": "MIT"
     },
     {
-      "huggingface_id": "ornith-ai/Ornith-1.5-9B-MLX-4bit",
-      "revision": "a48173b246ac705be75c05bedf1a0666db522d53",
-      "display_name": "Ornith 1.5 9B",
+      "huggingface_id": "Shiftedx/ornith-1.5-9b-affine4-bf16recurrence-vision-mlx",
+      "revision": "750596c078284ae61aa1cd085c8d839909b686e5",
+      "display_name": "Ornith 1.5 9B Vision",
       "family": "qwen3_5",
-      "approximate_size_bytes": 5061168474,
+      "approximate_size_bytes": 6541441712,
       "public": true,
-      "description": "A lightweight 9B dense reasoning model with vision, tool use, and strong coding benchmarks. Fits comfortably on any Apple Silicon Mac.",
+      "description": "A lightweight 9B dense reasoning model with vision, tool use, and strong coding benchmarks. Affine 4-bit language with BF16 recurrence and BF16 vision tower.",
       "capabilities": {
         "supports_reasoning": true,
         "supports_vision": true,
         "supports_tool_calls": true,
         "context_window": 262144,
-        "max_output_tokens": 8192
+        "max_output_tokens": 32768
       },
-      "quantization_label": "4-bit MLX affine (group 64)",
-      "architecture_summary": "Qwen 3.5 dense, 9B params, 32 layers",
-      "upstream_license": "Apache-2.0"
+      "quantization_label": "4-bit affine (group 32) + BF16 recurrence + BF16 vision",
+      "architecture_summary": "Qwen 3.5 dense, 9B params, 32 layers, 27-layer vision tower",
+      "upstream_license": "MIT"
     },
     {
       "huggingface_id": "black-forest-labs/FLUX.2-klein-4B",

--- a/repo-discovery-guide-for-agents.md
+++ b/repo-discovery-guide-for-agents.md
@@ -6,7 +6,7 @@ Agent orientation map for non-obvious repository facts; this is not user-facing 
 
 Read this guide before substantive work and spot-check 2-3 key facts. Update it when paths, entry points, conventions, or expensive gotchas change. Treat it as suspect when Last verified is more than 90 days old.
 
-Last verified: 2026-08-22 (spot-checked: automatic model discovery precedence, bundled Library catalog, supervisor attribution, Observatory Library route)
+Last verified: 2026-08-23 (spot-checked: automatic model discovery precedence, bundled Library catalog, supervisor attribution, Observatory Library route)
 
 ## Project overview
 


### PR DESCRIPTION
## Linked issue

Fixes #245

## Summary

Replaces the text-only `ornith-ai/Ornith-1.5-9B-MLX-4bit` catalog entry with the vision-capable `Shiftedx/ornith-1.5-9b-affine4-bf16recurrence-vision-mlx`.

### Why

The old entry declared `supports_vision: true` despite having no vision tower — all 927 tensors were `language_model.*`. The new entry has a real BF16 vision tower (333 tensors in a separate sidecar) validated by Astronomical's artifact verification.

### Changes

**9B entry replaced:**
- `huggingface_id`: `ornith-ai/Ornith-1.5-9B-MLX-4bit` → `Shiftedx/ornith-1.5-9b-affine4-bf16recurrence-vision-mlx`
- `revision`: Updated to `750596c078284ae61aa1cd085c8d839909b686e5`
- `display_name`: `Ornith 1.5 9B` → `Ornith 1.5 9B Vision`
- `approximate_size_bytes`: Corrected to actual on-disk total (6,541,441,712 bytes)
- `description`: Updated to reflect affine 4-bit language with BF16 recurrence and BF16 vision tower
- `quantization_label`: `4-bit MLX affine (group 64)` → `4-bit affine (group 32) + BF16 recurrence + BF16 vision`
- `architecture_summary`: Added `27-layer vision tower`
- `upstream_license`: `Apache-2.0` → `MIT` (matching the model card)

**Both Ornith entries updated:**
- `max_output_tokens`: `8192` → `32768` — 32K suits productivity work (slide decks, documents, tool-use chains). The old 8K value had no authoritative source. Runtime computes `min(65535, context_window - 1) = 65535`; the catalog field is a Library UI display hint only.

**Other:**
- `repo-discovery-guide-for-agents.md`: Verification date updated to 2026-08-23

### Verification

- 649 hermetic tests pass
- 185 REST API tests pass
- 13 download catalog contract tests pass
- 8 qwen3_5 model discovery tests pass
- All 16 commit verification steps pass
- Model loaded and served successfully via `astronomicald`
- Text chat verified ("Paris" for "capital of France")
- Vision chat verified ("Red" for 64×64 red PNG)
- `/v1/models` returns `input_modalities: ["text", "image"]`
- `/v1/library/catalog` returns correct entry fields