### PR TITLE
Present shipped product capabilities on the homepage

### DIFF
--- a/site/home.css
+++ b/site/home.css
@@ -119,16 +119,78 @@
   color: var(--paper);
 }
 
-.manifesto {
-  display: grid;
-  grid-template-columns: 1fr 3fr;
-  gap: 50px;
-  padding-block: 150px;
-}
-
 .section-index { color: var(--orange); }
 
-.manifesto h2,
+.use,
+.capabilities {
+  padding-block: 120px;
+  border-top: 1px solid var(--line);
+}
+
+.use-grid,
+.capability-grid {
+  display: grid;
+  gap: 0;
+}
+
+.use-grid {
+  grid-template-columns: repeat(3, 1fr);
+  border: 1px solid var(--line);
+}
+
+.use-card,
+.capability-card {
+  display: flex;
+  min-height: 280px;
+  flex-direction: column;
+  padding: 34px;
+  border-right: 1px solid var(--line);
+}
+
+.use-card:last-child,
+.capability-card:nth-child(3n) {
+  border-right: 0;
+}
+
+.use-card > span,
+.capability-card > span {
+  color: var(--orange);
+  font-family: var(--mono);
+  font-size: 0.62rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.use-card strong,
+.capability-card strong {
+  margin-top: auto;
+  font-family: var(--display);
+  font-size: clamp(1.7rem, 2.4vw, 2.4rem);
+  letter-spacing: -0.045em;
+  line-height: 0.98;
+}
+
+.use-card p,
+.capability-card p {
+  max-width: 420px;
+  margin: 16px 0 0;
+  color: var(--paper-muted);
+}
+
+.capability-grid {
+  grid-template-columns: repeat(3, 1fr);
+  border: 1px solid var(--line);
+}
+
+.capability-card {
+  min-height: 300px;
+  border-bottom: 1px solid var(--line);
+}
+
+.capability-card:nth-last-child(-n + 3) {
+  border-bottom: 0;
+}
+
 .section-heading h2,
 .method h2,
 .closing h2 {
@@ -140,8 +202,7 @@
   line-height: 0.98;
 }
 
-.manifesto > div > p { max-width: 760px; margin-top: 28px; color: var(--paper-muted); font-size: 1.12rem; }
-.reports, .systems, .method { padding-block: 120px; border-top: 1px solid var(--line); }
+.reports, .method { padding-block: 120px; border-top: 1px solid var(--line); }
 
 .section-heading {
   display: flex;
@@ -153,28 +214,11 @@
 
 .section-heading > p { max-width: 390px; color: var(--paper-muted); }
 
-.feature-report {
-  display: grid;
-  grid-template-columns: 100px 1fr auto;
-  min-height: 390px;
-  border: 1px solid var(--line-strong);
-  background: var(--paper);
-  color: var(--ink);
-}
-
-.report-number { padding: 28px 24px; border-right: 1px solid rgba(16, 18, 15, 0.2); font-family: var(--mono); font-size: 0.72rem; writing-mode: vertical-rl; }
-.report-content { max-width: 800px; padding: 58px; }
 .report-kicker { color: #62645d; }
-.report-content h3, .report-card h3 { margin: 14px 0 18px; font-family: var(--display); font-size: clamp(2.3rem, 4vw, 4.4rem); letter-spacing: -0.055em; line-height: 0.98; }
-.report-content > p, .report-card > p { max-width: 700px; }
+.report-card h3 { margin: 14px 0 18px; font-family: var(--display); font-size: clamp(2.3rem, 4vw, 4.4rem); letter-spacing: -0.055em; line-height: 0.98; }
+.report-card > p { max-width: 700px; }
 
-.report-metrics { display: flex; gap: 46px; margin: 36px 0; padding-block: 24px; border-block: 1px solid rgba(16, 18, 15, 0.2); }
-.report-metrics div { display: flex; flex-direction: column; }
-.report-metrics strong { font-size: 1.35rem; }
-.report-metrics span { color: #62645d; font-family: var(--mono); font-size: 0.62rem; text-transform: uppercase; }
-
-.text-link, .report-sources a { display: inline-flex; align-items: center; gap: 16px; font-family: var(--mono); font-size: 0.72rem; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase; }
-.feature-report > .verdict { align-self: start; margin: 28px; }
+.text-link { display: inline-flex; align-items: center; gap: 16px; font-family: var(--mono); font-size: 0.72rem; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase; }
 .verdict { display: inline-flex; align-items: center; gap: 8px; white-space: nowrap; font-family: var(--mono); font-size: 0.62rem; letter-spacing: 0.06em; text-transform: uppercase; }
 .verdict i, .verdict > span { width: 7px; height: 7px; border-radius: 50%; background: currentColor; }
 .verdict-open { color: #8a5a30; }
@@ -190,13 +234,6 @@
 .report-card > .text-link { margin-top: auto; }
 .report-card-top { display: flex; justify-content: space-between; font-family: var(--mono); font-size: 0.65rem; }
 
-.systems-track { display: grid; grid-template-columns: repeat(5, 1fr); border: 1px solid var(--line); }
-.system-step { min-height: 300px; padding: 30px 24px; border-right: 1px solid var(--line); }
-.system-step:last-child { border-right: 0; }
-.system-step > span { color: var(--orange); font-family: var(--mono); font-size: 0.62rem; }
-.system-step strong { display: block; margin: 70px 0 12px; font-family: var(--display); font-size: 2rem; }
-.system-step p { color: var(--paper-muted); font-size: 0.88rem; }
-
 .method { display: grid; grid-template-columns: 1fr 1fr; gap: 90px; }
 .method-list { margin: 0; padding: 0; list-style: none; }
 .method-list li { display: grid; grid-template-columns: 48px 1fr; gap: 18px; padding: 24px 0; border-top: 1px solid var(--line); }
@@ -207,20 +244,26 @@
 .closing { padding-block: 160px; text-align: center; }
 .closing h2 { margin-inline: auto; max-width: 900px; }
 .closing > p:not(.eyebrow) { color: var(--paper-muted); font-size: 1.1rem; }
-.closing .button { margin-top: 24px; }
+.closing-actions { justify-content: center; }
 
 @media (max-width: 900px) {
   .fact-strip { grid-template-columns: repeat(2, 1fr); }
   .fact-strip-label { grid-column: 1 / -1; }
   .fact-strip > div { border-bottom: 1px solid var(--line); }
-  .manifesto { grid-template-columns: 1fr; padding-block: 100px; }
   .residency { padding-block: 100px; }
-  .feature-report { grid-template-columns: 70px 1fr; }
-  .feature-report > .verdict { display: none; }
-  .report-grid, .method { grid-template-columns: 1fr; }
+  .use-grid,
+  .capability-grid,
+  .report-grid,
+  .method { grid-template-columns: 1fr; }
+  .use-card,
+  .capability-card {
+    border-right: 0;
+    border-bottom: 1px solid var(--line);
+  }
+  .capability-card:nth-last-child(-n + 3) { border-bottom: 1px solid var(--line); }
+  .use-card:last-child,
+  .capability-card:last-child { border-bottom: 0; }
   .report-card + .report-card { border-left: 1px solid var(--line-strong); }
-  .systems-track { grid-template-columns: 1fr 1fr; }
-  .system-step { border-bottom: 1px solid var(--line); }
   .method { gap: 50px; }
 }
 
@@ -230,16 +273,10 @@
   .fact-strip-label { min-height: 90px !important; }
   .section-heading { display: block; }
   .section-heading > p { margin-top: 24px; }
-  .feature-report { display: block; }
-  .report-number { border-right: 0; border-bottom: 1px solid rgba(16, 18, 15, 0.2); writing-mode: initial; }
-  .report-content, .report-card { padding: 32px 25px; }
-  .report-metrics { flex-direction: column; gap: 16px; }
+  .report-card { padding: 32px 25px; }
   .report-grid { display: block; }
   .residency-flow { grid-template-columns: 1fr; gap: 16px; }
   .residency-arrow { transform: rotate(90deg); }
   .residency-state { min-height: 230px; }
   .residency-note { margin-top: 24px; }
-  .systems-track { grid-template-columns: 1fr; }
-  .system-step { min-height: 220px; }
-  .system-step strong { margin-top: 40px; }
 }

--- a/site/index.html
+++ b/site/index.html
@@ -4,11 +4,11 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Astronomical | Local models without the memory wall</title>
-    <meta name="description" content="Astronomical is a performance-first local language and vision model runner for Apple silicon. Read the engineering reports and measured evidence behind it.">
+    <meta name="description" content="Astronomical is a local Mac app for language, vision, and image models. Set one memory ceiling, install a curated model, and keep every request on this laptop.">
     <meta name="theme-color" content="#10120f">
     <meta property="og:type" content="website">
     <meta property="og:title" content="Astronomical | Local models without the memory wall">
-    <meta property="og:description" content="A performance-first local model runner for Apple silicon, built in the open with measured evidence.">
+    <meta property="og:description" content="A local Mac app for language, vision, and image models. One memory ceiling. Nothing leaves the laptop.">
     <meta property="og:url" content="https://aosama.github.io/astronomical/">
     <meta property="og:image" content="https://raw.githubusercontent.com/aosama/astronomical/main/.github/assets/astronomical-ram-ssd-streaming.jpeg">
     <meta name="twitter:card" content="summary_large_image">
@@ -24,8 +24,8 @@
         <span>Astronomical</span>
       </a>
       <nav class="site-nav" aria-label="Primary navigation">
+        <a href="#capabilities">Capabilities</a>
         <a href="#reports">Reports</a>
-        <a href="#method">Method</a>
         <a href="https://github.com/aosama/astronomical">Source</a>
       </nav>
     </header>
@@ -33,12 +33,12 @@
     <main id="main">
       <section class="hero shell">
         <div class="hero-copy">
-          <p class="eyebrow"><span class="signal-dot"></span> Local by design / Apple silicon</p>
+          <p class="eyebrow"><span class="signal-dot"></span> Local Mac app / Apple silicon</p>
           <h1>Run the model.<br><em>Not the memory bill.</em></h1>
-          <p class="hero-deck">Astronomical runs local language and vision models with a memory ceiling you control. Sparse experts move between memory and solid-state storage while active computation stays on the graphics processor.</p>
+          <p class="hero-deck">Astronomical is a local app for language, vision, and image models. You set one memory ceiling. Sparse experts move between memory and solid-state storage. Every request stays on this Mac.</p>
           <div class="hero-actions">
-            <a class="button button-primary" href="#reports">Read the evidence</a>
-            <a class="button button-secondary" href="https://github.com/aosama/astronomical">View source <span aria-hidden="true">↗</span></a>
+            <a class="button button-primary" href="https://github.com/aosama/astronomical/releases/latest">Get the Mac app</a>
+            <a class="button button-secondary" href="#capabilities">See what it can do</a>
           </div>
         </div>
 
@@ -56,17 +56,86 @@
         </div>
       </section>
 
-      <section class="fact-strip" aria-label="Architecture facts">
-        <div class="fact-strip-label">Architecture facts<br><span>not benchmark claims</span></div>
+      <section class="fact-strip" aria-label="Product facts">
+        <div class="fact-strip-label">Product facts<br><span>not benchmark claims</span></div>
         <div class="fact"><strong>1</strong><span>user memory ceiling</span></div>
-        <div class="fact"><strong>256</strong><span>experts per sparse layer</span></div>
-        <div class="fact"><strong>8</strong><span>experts selected per token</span></div>
-        <div class="fact"><strong>2,048</strong><span>tokens per reuse block</span></div>
+        <div class="fact"><strong>3</strong><span>chat, vision, images</span></div>
+        <div class="fact"><strong>0</strong><span>cloud accounts</span></div>
+        <div class="fact"><strong>Loopback</strong><span>OpenAI-compatible API</span></div>
+      </section>
+
+      <section class="use shell" id="use" aria-labelledby="use-title">
+        <div class="section-heading">
+          <div>
+            <p class="section-index">01 / On this Mac</p>
+            <h2 id="use-title">Install. Open Library. Point a local client.</h2>
+          </div>
+          <p>Astronomical is a menu-bar app with an embedded local console. It serves one user on Apple silicon, macOS 26 or later.</p>
+        </div>
+        <div class="use-grid">
+          <article class="use-card">
+            <span>Menu</span>
+            <strong>See the ceiling while you work</strong>
+            <p>The menu reports effective memory, expert residency, graphics-processor use, prompt progress, and prompt reuse.</p>
+          </article>
+          <article class="use-card">
+            <span>Observatory</span>
+            <strong>The local console</strong>
+            <p>Observatory lives on the same loopback address. Open Library, watch status, and send a chat without a separate monitoring stack.</p>
+          </article>
+          <article class="use-card">
+            <span>Local API</span>
+            <strong>Use the tools you already have</strong>
+            <p>Chat Completions, Responses, and image generation speak OpenAI-compatible JSON over loopback only. Astronomical loads the requested model on demand.</p>
+          </article>
+        </div>
+      </section>
+
+      <section class="capabilities shell" id="capabilities" aria-labelledby="capabilities-title">
+        <div class="section-heading">
+          <div>
+            <p class="section-index">02 / Capabilities</p>
+            <h2 id="capabilities-title">What the app can do today.</h2>
+          </div>
+          <p>These are shipped product surfaces. Speed still depends on the model, context, storage, and the memory you leave for the rest of the Mac.</p>
+        </div>
+        <div class="capability-grid">
+          <article class="capability-card">
+            <span>01</span>
+            <strong>Chat locally</strong>
+            <p>Send a conversation through Observatory or any local OpenAI-compatible client. Tool calls and Responses share that same loopback server.</p>
+          </article>
+          <article class="capability-card">
+            <span>02</span>
+            <strong>Vision in the same chat</strong>
+            <p>Attach an image to a request. A vision-capable model sees it on this Mac. The image does not leave the laptop.</p>
+          </article>
+          <article class="capability-card">
+            <span>03</span>
+            <strong>Generate an image</strong>
+            <p>A text prompt becomes one lossless PNG through the local image endpoint. Text and image models share the app, not a second service.</p>
+          </article>
+          <article class="capability-card">
+            <span>04</span>
+            <strong>Install from Library</strong>
+            <p>Observatory can download a curated public model onto this Mac. Astronomical verifies the payload before the model becomes discoverable.</p>
+          </article>
+          <article class="capability-card">
+            <span>05</span>
+            <strong>One memory ceiling</strong>
+            <p>Set the model RAM your laptop can spare. Astronomical keeps complete experts resident when they fit and streams selected experts from storage when the request needs room.</p>
+          </article>
+          <article class="capability-card">
+            <span>06</span>
+            <strong>No hidden quantization</strong>
+            <p>A tighter ceiling does not silently downgrade the model. Paging keeps the artifact's declared types. Unsupported files fail validation instead of being guessed from a name.</p>
+          </article>
+        </div>
       </section>
 
       <section class="residency shell" aria-labelledby="residency-title">
         <div class="residency-intro">
-          <p class="section-index">02 / Automatic expert residency</p>
+          <p class="section-index">03 / Automatic expert residency</p>
           <h2 id="residency-title">Fully in memory when it fits.<br><em>Paged when the request needs room.</em></h2>
         </div>
         <div class="residency-flow" aria-label="Automatic transition from resident expert layers to paged experts">
@@ -83,14 +152,6 @@
           </article>
         </div>
         <p class="residency-note"><strong>One memory ceiling. No manual mode switch.</strong> The same loaded model adapts to live context and runtime memory needs, then restores complete expert layers when capacity returns.</p>
-      </section>
-
-      <section class="manifesto shell" aria-labelledby="manifesto-title">
-        <p class="section-index">03 / The premise</p>
-        <div>
-          <h2 id="manifesto-title">Bigger local models should not require every weight to occupy memory at once.</h2>
-          <p>A mixture-of-experts model uses a small subset of its experts for each token. Astronomical follows that structure: keep useful weights close, stream selected experts when needed, and make every memory decision against one explicit ceiling.</p>
-        </div>
       </section>
 
       <section class="reports shell" id="reports" aria-labelledby="reports-title">
@@ -127,25 +188,9 @@
         </div>
       </section>
 
-      <section class="systems shell" aria-labelledby="systems-title">
-        <div class="section-heading">
-          <div>
-            <p class="section-index">05 / One system</p>
-            <h2 id="systems-title">Optimize the whole path.</h2>
-          </div>
-        </div>
-        <div class="systems-track" aria-label="Model request execution path">
-          <div class="system-step"><span>01</span><strong>Load</strong><p>Validate and map the model without guessing from its name.</p></div>
-          <div class="system-step"><span>02</span><strong>Prefill</strong><p>Tune prompt chunks against observed memory and throughput.</p></div>
-          <div class="system-step"><span>03</span><strong>Page</strong><p>Retain hot experts and fetch selected ranges when memory is tight.</p></div>
-          <div class="system-step"><span>04</span><strong>Generate</strong><p>Keep sampling and model execution on the graphics processor.</p></div>
-          <div class="system-step"><span>05</span><strong>Reuse</strong><p>Persist exact model state so repeated prefixes avoid repeated work.</p></div>
-        </div>
-      </section>
-
       <section class="method shell" id="method" aria-labelledby="method-title">
         <div class="method-intro">
-          <p class="section-index">06 / Evidence standard</p>
+          <p class="section-index">05 / Evidence standard</p>
           <h2 id="method-title">Fast is a measurement,<br>not an adjective.</h2>
         </div>
         <ol class="method-list">
@@ -160,7 +205,10 @@
         <p class="eyebrow">Built in the open</p>
         <h2>The laptop is the deployment target.</h2>
         <p>No cloud account. No model upload. No hidden precision downgrade.</p>
-        <a class="button button-primary" href="https://github.com/aosama/astronomical">Follow the work on GitHub <span aria-hidden="true">↗</span></a>
+        <div class="hero-actions closing-actions">
+          <a class="button button-primary" href="https://github.com/aosama/astronomical/releases/latest">Get the Mac app</a>
+          <a class="button button-secondary" href="https://github.com/aosama/astronomical">Follow the work on GitHub <span aria-hidden="true">↗</span></a>
+        </div>
       </section>
     </main>
 
@@ -169,8 +217,8 @@
         <img src="./assets/mark.svg" alt="" width="30" height="30">
         <span>Astronomical</span>
       </a>
-      <p>Local language and vision model serving for Apple silicon.</p>
-      <div><a href="https://github.com/aosama/astronomical">GitHub</a><a href="#reports">Reports</a><a href="#method">Method</a></div>
+      <p>Local language, vision, and image serving for Apple silicon.</p>
+      <div><a href="https://github.com/aosama/astronomical">GitHub</a><a href="#capabilities">Capabilities</a><a href="#reports">Reports</a></div>
     </footer>
   </body>
 </html>

--- a/site/reports/persistent-prompt-reuse/index.html
+++ b/site/reports/persistent-prompt-reuse/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Persistent prompt reuse with MTP | Astronomical Report R–002</title>
+    <title>Persistent prompt reuse with MTP | Astronomical Report R–001</title>
     <meta name="description" content="How Astronomical restored 2,048 repeated prompt tokens from persistent state while preserving generated-token parity on a Qwen3.6 MTP artifact.">
     <meta name="theme-color" content="#d8ff3e">
     <meta property="og:type" content="article">
@@ -31,7 +31,7 @@
     <main id="main" class="report-page report-page-acid">
       <header class="report-hero shell">
         <div class="report-meta">
-          <span>FIELD REPORT R–002</span>
+          <span>FIELD REPORT R–001</span>
           <span>5 AUGUST 2026</span>
           <span class="verdict verdict-verified"><i></i> Qualified</span>
         </div>
@@ -116,7 +116,7 @@
 
     <footer class="site-footer">
       <a class="brand" href="../../index.html"><img src="../../assets/mark.svg" alt="" width="30" height="30"><span>Astronomical</span></a>
-      <p>Local language and vision model serving for Apple silicon.</p>
+      <p>Local language, vision, and image serving for Apple silicon.</p>
       <div><a href="../../index.html#reports">All reports</a><a href="https://github.com/aosama/astronomical">GitHub</a></div>
     </footer>
   </body>


### PR DESCRIPTION
## Linked issue

Fixes #246

## Summary

- lead the homepage with the Mac application journey and a direct Stable download action
- present the shipped menu, Observatory, Library, local APIs, chat, vision, image generation, memory, and precision capabilities
- add responsive product and capability cards while removing obsolete homepage styles
- align the persistent prompt-reuse report with its R–001 homepage identity

## Verification

- desktop and 390-pixel mobile browser journeys
- local links, fragments, and duplicate identifiers validated
- no mobile horizontal overflow
- Lighthouse snapshot: 100 accessibility, best practices, search optimization, and agentic browsing
- `scripts/verify-before-commit.sh` — 16/16 steps passed

## Safety

- no credentials, personal paths, private endpoints, model inventories, or machine logs are included
- inference behavior, model precision, configuration, and application state are unchanged