### PR TITLE
Release Astronomical 0.2.15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,7 +39,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "astronomical-config"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "libc",
  "serde",
@@ -52,7 +52,7 @@ dependencies = [
 
 [[package]]
 name = "astronomical-experimental-aligned-expert-packs"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "astronomical-config",
  "astronomical-model-serving",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "astronomical-inference-worker"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "astronomical-config",
  "astronomical-ipc-protocol",
@@ -92,7 +92,7 @@ dependencies = [
 
 [[package]]
 name = "astronomical-ipc-protocol"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "base64 0.23.1",
  "bytes",
@@ -108,7 +108,7 @@ dependencies = [
 
 [[package]]
 name = "astronomical-model-serving"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "astronomical-config",
  "astronomical-ipc-protocol",
@@ -131,7 +131,7 @@ dependencies = [
 
 [[package]]
 name = "astronomical-rest-contract"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "base64 0.23.1",
  "serde",
@@ -141,7 +141,7 @@ dependencies = [
 
 [[package]]
 name = "astronomical-runtime-integration"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "bindgen",
  "fs4",
@@ -153,7 +153,7 @@ dependencies = [
 
 [[package]]
 name = "astronomical-supervisor"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "astronomical-config",
  "astronomical-ipc-protocol",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ license = "Apache-2.0"
 publish = false
 repository = "https://github.com/aosama/astronomical"
 rust-version = "1.97.1"
-version = "0.2.14"
+version = "0.2.15"
 
 [workspace.dependencies]
 async-openai = { version = "0.41.3", default-features = false, features = ["byot", "chat-completion"] }


### PR DESCRIPTION
## Linked issue

Refs #253

## Problem

Astronomical needs the 0.2.15 Stable version identity before its signed, notarized, and Sparkle-delivered release can be prepared.

## Change

Bump the workspace and all Astronomical workspace packages from `0.2.14` to `0.2.15`.

## Verification

- `scripts/release/tests/test-release-contracts.sh`
- `scripts/verify-before-commit.sh` — 16/16 checks passed

## Safety

- [x] No credentials, personal paths, prompts, model inventories, proprietary artifacts, or machine logs are included.
- [x] Model precision and output semantics are unchanged.
- [x] The inference critical path, performance, and memory behavior are unchanged by this version-only commit.
- [x] Source reuse and third-party licensing are unchanged.