### PR TITLE
chore: ignore local release command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 # Agent harness local state
 .opencode/*
 !.opencode/command/
+.opencode/command/release-stable.md
 AGENTS.override.md
 
 # Local UI screenshot captures


### PR DESCRIPTION
## Linked issue

Fixes #262

## Change

Ignore the operator-only stable release command so it cannot block the documented clean-worktree release precondition. Release scripts and generated artifacts are unchanged.