### PR TITLE
release: activate v0.2.18 update feed

### DIFF
--- a/site/appcast.xml
+++ b/site/appcast.xml
@@ -4,36 +4,31 @@ IMPORTANT: This file was signed by Sparkle. Any modifications to this file requi
     <channel>
         <title>Astronomical</title>
         <item>
-            <title>0.2.17</title>
-            <pubDate>Tue, 25 Aug 2026 06:52:18 -0400</pubDate>
-            <sparkle:version>347</sparkle:version>
-            <sparkle:shortVersionString>0.2.17</sparkle:shortVersionString>
+            <title>0.2.18</title>
+            <pubDate>Thu, 27 Aug 2026 07:41:49 -0400</pubDate>
+            <sparkle:version>353</sparkle:version>
+            <sparkle:shortVersionString>0.2.18</sparkle:shortVersionString>
             <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
             <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
-            <description sparkle:format="markdown"><![CDATA[# Astronomical 0.2.17
+            <description sparkle:format="markdown"><![CDATA[# Astronomical 0.2.18
 
-Astronomical now lets users disable automatic Qwen multi-token prediction per model and, when they opt in, seed Qwen reasoning from instance-state `thinking.md`.
+Astronomical now keeps fully seated expert layers resident when the prefill leftover budget tightens.
 
 ## Improvements
 
-- Compatible Qwen multi-token prediction remains automatic unless a model sets `acceleration.mtp.enabled` to false, which keeps that model target-only.
-- Status reports configured, default, and effective multi-token prediction policy after a worker applies the change.
-- Qwen thinking-channel seeding remains default-off. When enabled, Qwen requests may read a bounded instance-state `thinking.md` file, escape reserved prompt markers, and emit the authored seed first in reasoning output on Chat Completions and Responses.
-- Missing, empty, unreadable, oversized, or non-Qwen requests do not change generation. Seed content is bounded to 1,000,000 bytes.
-- Accepted multi-token prefixes retain predictor state. Model weights, quantization, and numerical precision are unchanged.
+- Complete expert layers that are already seated in memory remain seated when the prefill leftover budget tightens. Previously, a tightening leftover budget could evict fully resident expert layers mid-prefill and force re-paging, which slowed prompt processing on memory-constrained machines.
+- Model weights, quantization, and numerical precision are unchanged.
 
 ## Compatibility
 
-This release preserves existing Stable configuration, downloaded models, prompt-cache state, and model precision.
-
-Omitted MTP configuration keeps automatic compatible multi-token prediction. Thinking-channel seeding remains disabled unless the user enables the experimental runtime flag and authors `thinking.md`.
+This release preserves existing Stable configuration, downloaded models, prompt-cache state, and model precision. No configuration migration is required.
 
 The macOS ARM64 distribution is signed with Apple Developer ID, notarized by Apple, stapled, and delivered through a signed Sparkle update feed.
 ]]></description>
-            <enclosure url="https://github.com/aosama/astronomical/releases/download/v0.2.17/Astronomical-0.2.17-macOS-arm64.dmg" length="15465565" type="application/octet-stream" sparkle:edSignature="feSGKexyoes6D+nW9z4+br2i1Xbza1oNG88mMu5fkSSGiI4DGPdySPNvGDBhhAAKiNCEHh5sHvi6q2SvSq19Dw=="></enclosure>
+            <enclosure url="https://github.com/aosama/astronomical/releases/download/v0.2.18/Astronomical-0.2.18-macOS-arm64.dmg" length="15482537" type="application/octet-stream" sparkle:edSignature="dFaH3L8kqPSdcANHi0DAEy75Jay89a3RHGmOGVLgiavU6rzJ389WCNB5Yoa3vaz8rcOIU/dp4leUZLAgQiBsDQ=="></enclosure>
         </item>
     </channel>
 </rss><!-- sparkle-signatures:
-edSignature: wV9fnnn3Lnp7krXrVTZL+r7Jf4fmJEpvO8msWCcWsnAz+ZJRMyfJmKBZR3pjrZf+1mYxaDpCZsRl1YvmuaP0Cg==
-length: 2690
+edSignature: YBX+YvZtBqRdlVM31xyZ6/2sMByB/Jq9scigrKUBM/6X0NyEZw65fv8FmPTmBhCEFJ9TOWKfD8RU0J1HlkoEAA==
+length: 2053
 -->


### PR DESCRIPTION
## Summary

Activates the signed Sparkle update feed for Astronomical 0.2.18.

- `site/appcast.xml` is the signed artifact produced by `scripts/release/prepare-and-publish.sh` for the v0.2.18 release. It is byte-identical to `target/releases/v0.2.18/appcast.xml`.
- The enclosure points to the public GitHub release asset `Astronomical-0.2.18-macOS-arm64.dmg` and carries the Ed25519 signature plus the signed-feed envelope.
- No formatting or manual edits were applied to the XML.

The public GitHub release v0.2.18 is already published with the reviewed DMG. This pull request makes the update feed serve the new signed bytes so users receive 0.2.18 through the normal Sparkle update journey.

## Linked issue

Fixes #282