### PR TITLE
fix: stabilize CI cache keys for cross-run reuse

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,7 +163,9 @@ jobs:
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
         with:
           path: ${{ env.NATIVE_BUILD_ENTRY_DIRECTORY }}
-          key: astronomical-v2-native-build-${{ runner.os }}-${{ runner.arch }}-${{ env.NATIVE_BUILD_IDENTITY }}-${{ github.run_id }}
+          # Key on native build identity alone so the same identity restores
+          # across runs and PR refs instead of missing on every new run_id.
+          key: astronomical-v2-native-build-${{ runner.os }}-${{ runner.arch }}-${{ env.NATIVE_BUILD_IDENTITY }}
           restore-keys: |
             astronomical-v2-native-build-${{ runner.os }}-${{ runner.arch }}-${{ env.NATIVE_BUILD_IDENTITY }}-
       - name: Report native-build-cache restoration
@@ -173,7 +175,7 @@ jobs:
           CACHE_STEP_OUTCOME: ${{ steps.native-build-cache.outcome }}
           CACHE_HIT: ${{ steps.native-build-cache.outputs.cache-hit }}
           CACHE_MATCHED_KEY: ${{ steps.native-build-cache.outputs.cache-matched-key }}
-          CACHE_PRIMARY_KEY: astronomical-v2-native-build-${{ runner.os }}-${{ runner.arch }}-${{ env.NATIVE_BUILD_IDENTITY }}-${{ github.run_id }}
+          CACHE_PRIMARY_KEY: astronomical-v2-native-build-${{ runner.os }}-${{ runner.arch }}-${{ env.NATIVE_BUILD_IDENTITY }}
           CACHE_STARTED_AT_EPOCH_SECONDS: ${{ steps.native-build-cache-start.outputs.started_at }}
         run: CACHE_FINISHED_AT_EPOCH_SECONDS="$(date +%s)" scripts/report-build-cache-restoration.sh
 
@@ -186,7 +188,9 @@ jobs:
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
         with:
           path: ~/Library/Caches/Astronomical/sccache
-          key: astronomical-v2-sccache-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('rust-toolchain.toml') }}-${{ env.NATIVE_BUILD_IDENTITY }}-${{ hashFiles('Cargo.lock') }}-${{ github.sha }}
+          # Key on Cargo.lock (not github.sha) so the same dependency graph
+          # restores across commits instead of missing on every new SHA.
+          key: astronomical-v2-sccache-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('rust-toolchain.toml') }}-${{ env.NATIVE_BUILD_IDENTITY }}-${{ hashFiles('Cargo.lock') }}
           restore-keys: |
             astronomical-v2-sccache-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('rust-toolchain.toml') }}-${{ env.NATIVE_BUILD_IDENTITY }}-${{ hashFiles('Cargo.lock') }}-
             astronomical-v2-sccache-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('rust-toolchain.toml') }}-${{ env.NATIVE_BUILD_IDENTITY }}-
@@ -197,7 +201,7 @@ jobs:
           CACHE_STEP_OUTCOME: ${{ steps.sccache-cache.outcome }}
           CACHE_HIT: ${{ steps.sccache-cache.outputs.cache-hit }}
           CACHE_MATCHED_KEY: ${{ steps.sccache-cache.outputs.cache-matched-key }}
-          CACHE_PRIMARY_KEY: astronomical-v2-sccache-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('rust-toolchain.toml') }}-${{ env.NATIVE_BUILD_IDENTITY }}-${{ hashFiles('Cargo.lock') }}-${{ github.sha }}
+          CACHE_PRIMARY_KEY: astronomical-v2-sccache-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('rust-toolchain.toml') }}-${{ env.NATIVE_BUILD_IDENTITY }}-${{ hashFiles('Cargo.lock') }}
           CACHE_STARTED_AT_EPOCH_SECONDS: ${{ steps.sccache-cache-start.outputs.started_at }}
         run: CACHE_FINISHED_AT_EPOCH_SECONDS="$(date +%s)" scripts/report-build-cache-restoration.sh
 
@@ -369,14 +373,14 @@ jobs:
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
         with:
           path: ${{ env.NATIVE_BUILD_ENTRY_DIRECTORY }}
-          key: astronomical-v2-native-build-${{ runner.os }}-${{ runner.arch }}-${{ env.NATIVE_BUILD_IDENTITY }}-${{ github.run_id }}
+          key: astronomical-v2-native-build-${{ runner.os }}-${{ runner.arch }}-${{ env.NATIVE_BUILD_IDENTITY }}
       - name: Report native-build-cache save
         if: always() && steps.native-build-cache-save-start.outcome == 'success'
         env:
           CACHE_OWNER: native-build
           CACHE_OPERATION: save
           CACHE_STEP_OUTCOME: ${{ steps.native-build-cache-save.outcome }}
-          CACHE_PRIMARY_KEY: astronomical-v2-native-build-${{ runner.os }}-${{ runner.arch }}-${{ env.NATIVE_BUILD_IDENTITY }}-${{ github.run_id }}
+          CACHE_PRIMARY_KEY: astronomical-v2-native-build-${{ runner.os }}-${{ runner.arch }}-${{ env.NATIVE_BUILD_IDENTITY }}
           CACHE_STARTED_AT_EPOCH_SECONDS: ${{ steps.native-build-cache-save-start.outputs.started_at }}
         run: CACHE_FINISHED_AT_EPOCH_SECONDS="$(date +%s)" scripts/report-build-cache-restoration.sh
 
@@ -391,14 +395,14 @@ jobs:
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
         with:
           path: ~/Library/Caches/Astronomical/sccache
-          key: astronomical-v2-sccache-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('rust-toolchain.toml') }}-${{ env.NATIVE_BUILD_IDENTITY }}-${{ hashFiles('Cargo.lock') }}-${{ github.sha }}
+          key: astronomical-v2-sccache-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('rust-toolchain.toml') }}-${{ env.NATIVE_BUILD_IDENTITY }}-${{ hashFiles('Cargo.lock') }}
       - name: Report sccache-cache save
         if: always() && steps.sccache-cache-save-start.outcome == 'success'
         env:
           CACHE_OWNER: sccache
           CACHE_OPERATION: save
           CACHE_STEP_OUTCOME: ${{ steps.sccache-cache-save.outcome }}
-          CACHE_PRIMARY_KEY: astronomical-v2-sccache-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('rust-toolchain.toml') }}-${{ env.NATIVE_BUILD_IDENTITY }}-${{ hashFiles('Cargo.lock') }}-${{ github.sha }}
+          CACHE_PRIMARY_KEY: astronomical-v2-sccache-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('rust-toolchain.toml') }}-${{ env.NATIVE_BUILD_IDENTITY }}-${{ hashFiles('Cargo.lock') }}
           CACHE_STARTED_AT_EPOCH_SECONDS: ${{ steps.sccache-cache-save-start.outputs.started_at }}
         run: CACHE_FINISHED_AT_EPOCH_SECONDS="$(date +%s)" scripts/report-build-cache-restoration.sh
 

--- a/scripts/classify-ci-change-scope.sh
+++ b/scripts/classify-ci-change-scope.sh
@@ -133,8 +133,11 @@ classify_native_input_changes() {
 
 resolve_macos_verification_authority() {
     case "$EVENT_NAME" in
+        # PRs and push events (PR merges) both gate on code_changed so that
+        # default-branch pushes save native-build and sccache caches for future
+        # PRs to restore.  Static-only changes (docs, site) still skip.
         pull_request) macos_verification_required="$code_changed" ;;
-        push) macos_verification_required="$native_inputs_changed" ;;
+        push) macos_verification_required="$code_changed" ;;
         *)
             print_error "unsupported CI event: ${EVENT_NAME}"
             exit 2

--- a/scripts/test-ci-native-cache-coordination.sh
+++ b/scripts/test-ci-native-cache-coordination.sh
@@ -307,7 +307,7 @@ assert_workflow_contract() {
         raise "native key omits full identity" unless native_configuration.fetch("key").include?("NATIVE_BUILD_IDENTITY")
 
         sccache_restore = steps.find { |step| step["id"] == "sccache-cache" }
-        raise "sccache key is not rolling by source" unless sccache_restore.fetch("with").fetch("key").include?("github.sha")
+        raise "sccache key is not stable by dependency graph" unless sccache_restore.fetch("with").fetch("key").include?("Cargo.lock")
         swift_restore = steps.find { |step| step["id"] == "swiftpm-cache" }
         raise "Swift state is coupled to Rust" if swift_restore.fetch("with").fetch("key").include?("Cargo")
         raise "Swift cache omits toolchain compatibility" unless swift_restore.fetch("with").fetch("key").include?("SWIFT_TOOLCHAIN_IDENTITY")
@@ -386,11 +386,11 @@ main() {
     assert_change_scope "$change_scope_fixture_root" pull_request \
         "$static_scope_sha" "$rust_scope_sha" true false true
     assert_change_scope "$change_scope_fixture_root" push \
-        "$static_scope_sha" "$rust_scope_sha" true false false
+        "$static_scope_sha" "$rust_scope_sha" true false true
     assert_change_scope "$change_scope_fixture_root" pull_request \
         "$rust_scope_sha" "$renamed_code_scope_sha" true false true
     assert_change_scope "$change_scope_fixture_root" push \
-        "$rust_scope_sha" "$renamed_code_scope_sha" true false false
+        "$rust_scope_sha" "$renamed_code_scope_sha" true false true
     assert_change_scope "$change_scope_fixture_root" push \
         "$renamed_code_scope_sha" "$native_scope_sha" true true true
     assert_change_scope "$change_scope_fixture_root" push \


### PR DESCRIPTION
## Linked issue

Fixes #314

## Summary

Three cache key design issues caused new PRs to start with cold caches every time, producing 5× compile time variance (1:15 warm cache with 99.7% sccache hit rate vs 6:53 cold cache with 14.2% hit rate).

## Changes

1. **Remove `github.run_id` from native-build-cache key** — the primary key now keys on native build identity alone, so the same identity restores across runs and PR refs instead of missing on every new run_id.

2. **Remove `github.sha` from sccache primary key** — the primary key now keys on `Cargo.lock` hash (not `github.sha`), so the same dependency graph restores across commits instead of missing on every new SHA.

3. **Change push verification policy from `native_inputs_changed` to `code_changed`** — PR merges (push events) with code changes now trigger macOS verification, which saves native-build and sccache caches on the main branch for future PRs to restore. Static-only changes (docs, site) still skip verification.

## Verification

- `scripts/test-ci-native-cache-coordination.sh` — all cases pass with updated assertions
- `scripts/verify-before-commit.sh` — all 16 steps pass
- `cargo fmt --all -- --check` — clean