### PR TITLE
fix: fail-open Qwen3.5 tool attempts in foreign dialects and thinking

### DIFF
--- a/crates/model-serving/src/laguna/text/output_parser.rs
+++ b/crates/model-serving/src/laguna/text/output_parser.rs
@@ -96,16 +96,22 @@ impl LagunaOutputParser {
                 // name still reaches the harness instead of aborting generation.
                 return Ok(self.salvage_unclosed_tool_call());
             }
-            return Err(LagunaOutputParserError::FragmentTooLarge {
-                maximum_bytes: MAXIMUM_FRAGMENT_BYTES,
-            });
+            let mut output_events = self.flush_pending_as_visible_delta();
+            if let Some(fragment_event) =
+                self.visible_delta_for_current_state(decoded_fragment.to_owned())
+            {
+                output_events.push(fragment_event);
+            }
+            return Ok(output_events);
         }
         self.pending_output.push_str(decoded_fragment);
-        if let Err(parser_error) = self.validate_pending_bound() {
+        if self.validate_pending_bound().is_err() {
             if self.state == LagunaOutputParserState::ToolCall {
                 return Ok(self.salvage_unclosed_tool_call());
             }
-            return Err(parser_error);
+            let mut output_events = self.flush_pending_as_visible_delta();
+            while self.advance(&mut output_events)? {}
+            return Ok(output_events);
         }
         let mut output_events = Vec::new();
         while self.advance(&mut output_events)? {}
@@ -116,19 +122,7 @@ impl LagunaOutputParser {
     pub fn finish(&mut self) -> Result<Vec<LagunaOutputEvent>, LagunaOutputParserError> {
         match self.state {
             LagunaOutputParserState::ToolCall => Ok(self.salvage_unclosed_tool_call()),
-            LagunaOutputParserState::Text => {
-                if is_prefix_of_any_marker(
-                    &self.pending_output,
-                    &[THINK_START_MARKER, TOOL_CALL_START_MARKER],
-                ) {
-                    return Err(LagunaOutputParserError::IncompleteControlMarker);
-                }
-                let remaining_text = std::mem::take(&mut self.pending_output);
-                Ok((!remaining_text.is_empty())
-                    .then_some(LagunaOutputEvent::TextDelta(remaining_text))
-                    .into_iter()
-                    .collect())
-            }
+            LagunaOutputParserState::Text => Ok(self.flush_pending_as_visible_delta()),
             LagunaOutputParserState::Reasoning => {
                 let remaining_reasoning = std::mem::take(&mut self.pending_output);
                 Ok((!remaining_reasoning.is_empty())
@@ -323,6 +317,25 @@ impl LagunaOutputParser {
         self.pending_output.drain(..byte_count).collect()
     }
 
+    fn flush_pending_as_visible_delta(&mut self) -> Vec<LagunaOutputEvent> {
+        if self.pending_output.is_empty() {
+            return Vec::new();
+        }
+        let pending_output = std::mem::take(&mut self.pending_output);
+        self.visible_delta_for_current_state(pending_output)
+            .into_iter()
+            .collect()
+    }
+
+    fn visible_delta_for_current_state(&self, text: String) -> Option<LagunaOutputEvent> {
+        match self.state {
+            LagunaOutputParserState::Text | LagunaOutputParserState::ToolCall => {
+                Some(LagunaOutputEvent::TextDelta(text))
+            }
+            LagunaOutputParserState::Reasoning => Some(LagunaOutputEvent::ReasoningDelta(text)),
+        }
+    }
+
     pub(crate) const fn state_for_diagnostics(&self) -> &'static str {
         match self.state {
             LagunaOutputParserState::Text => "text",
@@ -464,8 +477,4 @@ fn longest_suffix_matching_marker_prefix(text: &str, markers: &[&str]) -> usize 
         }
     }
     0
-}
-
-fn is_prefix_of_any_marker(text: &str, markers: &[&str]) -> bool {
-    !text.is_empty() && markers.iter().any(|marker| marker.starts_with(text))
 }

--- a/crates/model-serving/src/qwen3_5/text/output_parser.rs
+++ b/crates/model-serving/src/qwen3_5/text/output_parser.rs
@@ -1,8 +1,8 @@
 //! Incremental Qwen3.5 output parser for reasoning, text, and tool calls.
 //!
 //! Dense and mixture-of-experts share this parser. Tool-call defects fail open so a
-//! coding client can reject or retry. Incomplete text control markers remain fatal
-//! because they are not yet a tool call.
+//! coding client can reject or retry. Incomplete control-marker prefixes flush as
+//! visible text at generation end instead of aborting the stream.
 
 use std::collections::BTreeMap;
 
@@ -12,19 +12,41 @@ use serde_json::Value;
 use super::output_parser_error::Qwen3_5OutputParserError;
 use super::tool_schema::{DeclaredTool, parse_tool_parameters};
 
+mod foreign_syntax;
 mod salvage;
 
 const MAX_OUTPUT_FRAGMENT_BYTES: usize = 16 * 1024;
 const MAX_MARKER_SCAN_PENDING_OUTPUT_BYTES: usize = 128 * 1024;
-const THINK_END_MARKER: &str = "</think>";
-const THINK_START_MARKER: &str = "<think>";
-const TOOL_CALL_END_MARKER: &str = "</tool_call>";
-const TOOL_CALL_START_MARKER: &str = "<tool_call>";
+const THINK_END_MARKER: &str = concat!("<", "/think", ">");
+const THINK_START_MARKER: &str = concat!("<", "think", ">");
+pub(super) const TOOL_CALL_END_MARKER: &str = concat!("<", "/tool_call", ">");
+const TOOL_CALL_START_MARKER: &str = concat!("<", "tool_call", ">");
+pub(super) const BARE_FUNCTION_START_MARKER: &str = concat!("<", "function=");
+pub(super) const FUNCTION_END_MARKER: &str = concat!("<", "/function", ">");
+pub(super) const INVOKE_START_MARKER: &str = concat!("<", "invoke");
+pub(super) const INVOKE_END_MARKER: &str = concat!("<", "/invoke", ">");
+
+const TEXT_STATE_START_MARKERS: &[&str] = &[
+    THINK_START_MARKER,
+    TOOL_CALL_START_MARKER,
+    BARE_FUNCTION_START_MARKER,
+    INVOKE_START_MARKER,
+];
+
+// mlx-lm transitions from reasoning to tool on a tool-call start. Ornith often
+// writes the call inside the still-open think channel; scanning only for the
+// think end marker would dump that call as reasoning text and end the turn.
+const REASONING_SCAN_MARKERS: &[&str] = &[
+    THINK_END_MARKER,
+    TOOL_CALL_START_MARKER,
+    BARE_FUNCTION_START_MARKER,
+    INVOKE_START_MARKER,
+];
 
 /// A model-output event translated from Qwen3.5 syntax into neutral structured output.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Qwen3_5OutputEvent {
-    /// Reasoning content with `<think>` markers removed.
+    /// Reasoning content with think markers removed.
     ReasoningDelta(String),
     /// Normal assistant response content with control markers removed.
     TextDelta(String),
@@ -61,7 +83,7 @@ impl Qwen3_5OutputParser {
         Self::new_with_state(declared_tools, Qwen3_5OutputParserState::Text)
     }
 
-    /// Creates a parser for generation that continues after the prompt's `<think>` prefix.
+    /// Creates a parser for generation that continues after the prompt's think prefix.
     pub fn new_after_thinking_prefix(
         declared_tools: &[ChatToolDefinition],
     ) -> Result<Self, Qwen3_5OutputParserError> {
@@ -99,39 +121,40 @@ impl Qwen3_5OutputParser {
         decoded_fragment: &str,
     ) -> Result<Vec<Qwen3_5OutputEvent>, Qwen3_5OutputParserError> {
         if decoded_fragment.len() > MAX_OUTPUT_FRAGMENT_BYTES {
-            if self.state == Qwen3_5OutputParserState::ToolCall {
+            if matches!(self.state, Qwen3_5OutputParserState::ToolCall(_)) {
                 // The fragment cannot be buffered. Salvage the pending call so a usable
                 // name still reaches the harness instead of aborting generation.
                 return Ok(self.salvage_unclosed_tool_call());
             }
-            return Err(Qwen3_5OutputParserError::FragmentTooLarge {
-                actual_fragment_bytes: decoded_fragment.len(),
-                maximum_fragment_bytes: MAX_OUTPUT_FRAGMENT_BYTES,
-            });
+            let mut output_events = self.flush_pending_as_visible_delta();
+            if let Some(fragment_event) =
+                self.visible_delta_for_current_state(decoded_fragment.to_owned())
+            {
+                output_events.push(fragment_event);
+            }
+            return Ok(output_events);
         }
-        let pending_output_bytes = match self
+        let pending_output_bytes = self
             .pending_output
             .len()
-            .checked_add(decoded_fragment.len())
+            .saturating_add(decoded_fragment.len());
+        if matches!(self.state, Qwen3_5OutputParserState::ToolCall(_))
+            && self
+                .pending_output
+                .len()
+                .checked_add(decoded_fragment.len())
+                .is_none()
         {
-            Some(pending_output_bytes) => pending_output_bytes,
-            None => {
-                if self.state == Qwen3_5OutputParserState::ToolCall {
-                    return Ok(self.salvage_unclosed_tool_call());
-                }
-                return Err(Qwen3_5OutputParserError::PendingOutputTooLarge {
-                    actual_pending_bytes: usize::MAX,
-                    maximum_pending_bytes: MAX_MARKER_SCAN_PENDING_OUTPUT_BYTES,
-                });
-            }
-        };
+            return Ok(self.salvage_unclosed_tool_call());
+        }
         if self.state.requires_marker_scan_pending_output_cap()
             && pending_output_bytes > MAX_MARKER_SCAN_PENDING_OUTPUT_BYTES
         {
-            return Err(Qwen3_5OutputParserError::PendingOutputTooLarge {
-                actual_pending_bytes: pending_output_bytes,
-                maximum_pending_bytes: MAX_MARKER_SCAN_PENDING_OUTPUT_BYTES,
-            });
+            // Drain retained text so memory stays bounded. Generation continues.
+            let mut output_events = self.flush_pending_as_visible_delta();
+            self.pending_output.push_str(decoded_fragment);
+            while self.advance(&mut output_events)? {}
+            return Ok(output_events);
         }
         self.pending_output.push_str(decoded_fragment);
 
@@ -140,28 +163,12 @@ impl Qwen3_5OutputParser {
         Ok(output_events)
     }
 
-    /// Completes the stream. Unclosed tool calls salvage because aborting drops a usable name.
+    /// Completes the stream. Unclosed tool calls salvage; leftover marker prefixes flush as text.
     pub fn finish(&mut self) -> Result<Vec<Qwen3_5OutputEvent>, Qwen3_5OutputParserError> {
         match self.state {
-            Qwen3_5OutputParserState::Text => {
-                if is_marker_prefix(&self.pending_output) {
-                    return Err(Qwen3_5OutputParserError::IncompleteControlMarker);
-                }
-                if self.pending_output.is_empty() {
-                    return Ok(Vec::new());
-                }
-                let final_text = std::mem::take(&mut self.pending_output);
-                self.has_streamed_visible_text = true;
-                Ok(vec![Qwen3_5OutputEvent::TextDelta(final_text)])
-            }
-            Qwen3_5OutputParserState::Reasoning => {
-                if self.pending_output.is_empty() {
-                    return Ok(Vec::new());
-                }
-                let final_reasoning = std::mem::take(&mut self.pending_output);
-                Ok(vec![Qwen3_5OutputEvent::ReasoningDelta(final_reasoning)])
-            }
-            Qwen3_5OutputParserState::ToolCall => Ok(self.salvage_unclosed_tool_call()),
+            Qwen3_5OutputParserState::Text => Ok(self.flush_pending_as_visible_delta()),
+            Qwen3_5OutputParserState::Reasoning => Ok(self.flush_pending_as_visible_delta()),
+            Qwen3_5OutputParserState::ToolCall(_) => Ok(self.salvage_unclosed_tool_call()),
             Qwen3_5OutputParserState::SuppressedLateReasoning => {
                 self.pending_output.clear();
                 Ok(Vec::new())
@@ -176,7 +183,9 @@ impl Qwen3_5OutputParser {
         match self.state {
             Qwen3_5OutputParserState::Text => self.advance_text(output_events),
             Qwen3_5OutputParserState::Reasoning => self.advance_reasoning(output_events),
-            Qwen3_5OutputParserState::ToolCall => self.advance_tool_call(output_events),
+            Qwen3_5OutputParserState::ToolCall(entry) => {
+                self.advance_tool_call(output_events, entry)
+            }
             Qwen3_5OutputParserState::SuppressedLateReasoning => {
                 self.advance_suppressed_late_reasoning()
             }
@@ -187,10 +196,7 @@ impl Qwen3_5OutputParser {
         &mut self,
         output_events: &mut Vec<Qwen3_5OutputEvent>,
     ) -> Result<bool, Qwen3_5OutputParserError> {
-        let next_marker = earliest_marker(
-            &self.pending_output,
-            &[THINK_START_MARKER, TOOL_CALL_START_MARKER],
-        );
+        let next_marker = earliest_marker(&self.pending_output, TEXT_STATE_START_MARKERS);
         if let Some((marker_index, marker)) = next_marker {
             if marker_index > 0 {
                 self.has_streamed_visible_text = true;
@@ -200,22 +206,17 @@ impl Qwen3_5OutputParser {
                 return Ok(true);
             }
             self.take_pending_prefix(marker.len());
-            self.state = if marker == THINK_START_MARKER {
-                if self.has_streamed_visible_text {
-                    Qwen3_5OutputParserState::SuppressedLateReasoning
-                } else {
-                    Qwen3_5OutputParserState::Reasoning
-                }
-            } else {
-                Qwen3_5OutputParserState::ToolCall
-            };
+            self.enter_state_after_start_marker(marker);
             return Ok(true);
         }
 
-        let stable_text_bytes = self
-            .pending_output
-            .len()
-            .saturating_sub(longest_marker_prefix_suffix(&self.pending_output));
+        let stable_text_bytes =
+            self.pending_output
+                .len()
+                .saturating_sub(longest_suffix_prefix_for_markers(
+                    &self.pending_output,
+                    TEXT_STATE_START_MARKERS,
+                ));
         if stable_text_bytes == 0 {
             return Ok(false);
         }
@@ -230,15 +231,20 @@ impl Qwen3_5OutputParser {
         &mut self,
         output_events: &mut Vec<Qwen3_5OutputEvent>,
     ) -> Result<bool, Qwen3_5OutputParserError> {
-        if let Some(marker_index) = self.pending_output.find(THINK_END_MARKER) {
+        let next_marker = earliest_marker(&self.pending_output, REASONING_SCAN_MARKERS);
+        if let Some((marker_index, marker)) = next_marker {
             if marker_index > 0 {
                 output_events.push(Qwen3_5OutputEvent::ReasoningDelta(
                     self.take_pending_prefix(marker_index),
                 ));
                 return Ok(true);
             }
-            self.take_pending_prefix(THINK_END_MARKER.len());
-            self.state = Qwen3_5OutputParserState::Text;
+            self.take_pending_prefix(marker.len());
+            if marker == THINK_END_MARKER {
+                self.state = Qwen3_5OutputParserState::Text;
+            } else {
+                self.enter_state_after_start_marker(marker);
+            }
             return Ok(true);
         }
 
@@ -247,7 +253,7 @@ impl Qwen3_5OutputParser {
                 .len()
                 .saturating_sub(longest_suffix_prefix_for_markers(
                     &self.pending_output,
-                    &[THINK_END_MARKER],
+                    REASONING_SCAN_MARKERS,
                 ));
         if stable_reasoning_bytes == 0 {
             return Ok(false);
@@ -283,30 +289,38 @@ impl Qwen3_5OutputParser {
     fn advance_tool_call(
         &mut self,
         output_events: &mut Vec<Qwen3_5OutputEvent>,
+        entry: ToolCallEntryKind,
     ) -> Result<bool, Qwen3_5OutputParserError> {
-        let Some(marker_index) = self.pending_output.find(TOOL_CALL_END_MARKER) else {
+        let Some((marker_index, end_marker)) =
+            earliest_marker(&self.pending_output, salvage::tool_call_end_markers(entry))
+        else {
             return Ok(false);
         };
-        let tool_call_body = self.take_pending_prefix(marker_index);
-        self.take_pending_prefix(TOOL_CALL_END_MARKER.len());
+        let remaining_body = self.take_pending_prefix(marker_index);
+        self.take_pending_prefix(end_marker.len());
+        if end_marker != TOOL_CALL_END_MARKER {
+            self.consume_trailing_envelope_close_if_present();
+        }
+        let reconstructed_body = salvage::reconstruct_tool_call_body(entry, &remaining_body);
         // Closed envelopes fail open: the harness owns retries.
-        match self.parse_tool_call(&tool_call_body) {
+        match self.parse_tool_call(&reconstructed_body) {
             Ok(tool_call) => {
                 output_events.push(self.emit_tool_call_or_visible_text(
                     Qwen3_5OutputEvent::ToolCall(tool_call),
-                    tool_call_body,
+                    reconstructed_body,
                 ));
             }
             Err(parser_error) => {
-                let fail_open_event = self.fail_open_closed_tool_call(&tool_call_body);
+                let fail_open_event = self.fail_open_closed_tool_call(&reconstructed_body);
                 salvage::log_fail_open_closed_tool_call(
                     &parser_error,
-                    &tool_call_body,
+                    &reconstructed_body,
                     fail_open_event.as_ref(),
                 );
                 if let Some(fail_open_event) = fail_open_event {
-                    output_events
-                        .push(self.emit_tool_call_or_visible_text(fail_open_event, tool_call_body));
+                    output_events.push(
+                        self.emit_tool_call_or_visible_text(fail_open_event, reconstructed_body),
+                    );
                 }
             }
         }
@@ -318,8 +332,9 @@ impl Qwen3_5OutputParser {
         &self,
         tool_call_body: &str,
     ) -> Result<Qwen3_5ToolCall, Qwen3_5OutputParserError> {
+        let normalized_body = foreign_syntax::normalize_foreign_tool_call_syntax(tool_call_body);
         let (function_name, parameter_content) =
-            split_qwen_function_envelope(tool_call_body.trim())?;
+            split_qwen_function_envelope(normalized_body.trim())?;
         // Unknown names and sloppy-but-closed XML are forwarded so the harness
         // can return "no such tool" and the model can retry.
         let parsed_arguments = parse_tool_parameters(
@@ -336,8 +351,9 @@ impl Qwen3_5OutputParser {
     }
 
     fn fail_open_closed_tool_call(&self, tool_call_body: &str) -> Option<Qwen3_5OutputEvent> {
+        let normalized_body = foreign_syntax::normalize_foreign_tool_call_syntax(tool_call_body);
         let Ok((function_name, parameter_content)) =
-            split_qwen_function_envelope(tool_call_body.trim())
+            split_qwen_function_envelope(normalized_body.trim())
         else {
             if tool_call_body.is_empty() {
                 return None;
@@ -356,8 +372,58 @@ impl Qwen3_5OutputParser {
         }))
     }
 
+    fn enter_state_after_start_marker(&mut self, marker: &str) {
+        self.state = match marker {
+            THINK_START_MARKER => {
+                if self.has_streamed_visible_text {
+                    Qwen3_5OutputParserState::SuppressedLateReasoning
+                } else {
+                    Qwen3_5OutputParserState::Reasoning
+                }
+            }
+            TOOL_CALL_START_MARKER => {
+                Qwen3_5OutputParserState::ToolCall(ToolCallEntryKind::Envelope)
+            }
+            BARE_FUNCTION_START_MARKER => {
+                Qwen3_5OutputParserState::ToolCall(ToolCallEntryKind::BareFunction)
+            }
+            INVOKE_START_MARKER => Qwen3_5OutputParserState::ToolCall(ToolCallEntryKind::InvokeTag),
+            _ => Qwen3_5OutputParserState::Text,
+        };
+    }
+
     fn take_pending_prefix(&mut self, byte_count: usize) -> String {
         self.pending_output.drain(..byte_count).collect()
+    }
+
+    fn consume_trailing_envelope_close_if_present(&mut self) {
+        let trimmed = self.pending_output.trim_start();
+        let Some(after_marker) = trimmed.strip_prefix(TOOL_CALL_END_MARKER) else {
+            return;
+        };
+        let consumed_bytes = self.pending_output.len() - after_marker.len();
+        self.take_pending_prefix(consumed_bytes);
+    }
+
+    fn flush_pending_as_visible_delta(&mut self) -> Vec<Qwen3_5OutputEvent> {
+        if self.pending_output.is_empty() {
+            return Vec::new();
+        }
+        let pending_output = std::mem::take(&mut self.pending_output);
+        self.visible_delta_for_current_state(pending_output)
+            .into_iter()
+            .collect()
+    }
+
+    fn visible_delta_for_current_state(&mut self, text: String) -> Option<Qwen3_5OutputEvent> {
+        match self.state {
+            Qwen3_5OutputParserState::Text | Qwen3_5OutputParserState::ToolCall(_) => {
+                self.has_streamed_visible_text = true;
+                Some(Qwen3_5OutputEvent::TextDelta(text))
+            }
+            Qwen3_5OutputParserState::Reasoning => Some(Qwen3_5OutputEvent::ReasoningDelta(text)),
+            Qwen3_5OutputParserState::SuppressedLateReasoning => None,
+        }
     }
 
     pub(crate) fn state_for_diagnostics(&self) -> &'static str {
@@ -383,8 +449,15 @@ impl Qwen3_5OutputParser {
 enum Qwen3_5OutputParserState {
     Text,
     Reasoning,
-    ToolCall,
+    ToolCall(ToolCallEntryKind),
     SuppressedLateReasoning,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum ToolCallEntryKind {
+    Envelope,
+    BareFunction,
+    InvokeTag,
 }
 
 impl Qwen3_5OutputParserState {
@@ -392,7 +465,7 @@ impl Qwen3_5OutputParserState {
         match self {
             Self::Text => "text",
             Self::Reasoning => "reasoning",
-            Self::ToolCall => "tool_call",
+            Self::ToolCall(_) => "tool_call",
             Self::SuppressedLateReasoning => "suppressed_late_reasoning",
         }
     }
@@ -408,7 +481,7 @@ impl Qwen3_5OutputParserState {
 fn split_qwen_function_envelope(
     tool_call_body: &str,
 ) -> Result<(String, String), Qwen3_5OutputParserError> {
-    // Closed envelopes still reach the harness when the model drops `<` or `</function>`.
+    // Closed envelopes still reach the harness when the model drops `<` or the function close tag.
     let after_function_open = strip_qwen_function_open(tool_call_body)
         .ok_or(Qwen3_5OutputParserError::ToolCallMissingFunction)?;
     let function_name_end = after_function_open
@@ -422,7 +495,7 @@ fn split_qwen_function_envelope(
         .trim_start_matches('>')
         .trim();
     let parameter_content = after_function_name
-        .strip_suffix("</function>")
+        .strip_suffix(FUNCTION_END_MARKER)
         .unwrap_or(after_function_name)
         .trim()
         .to_owned();
@@ -431,7 +504,7 @@ fn split_qwen_function_envelope(
 
 fn strip_qwen_function_open(tool_call_body: &str) -> Option<&str> {
     tool_call_body
-        .strip_prefix("<function=")
+        .strip_prefix(BARE_FUNCTION_START_MARKER)
         .or_else(|| tool_call_body.strip_prefix("function="))
 }
 
@@ -443,10 +516,6 @@ fn earliest_marker<'a>(text: &str, markers: &'a [&'a str]) -> Option<(usize, &'a
                 .map(|marker_index| (marker_index, *marker))
         })
         .min_by_key(|(marker_index, _)| *marker_index)
-}
-
-fn longest_marker_prefix_suffix(text: &str) -> usize {
-    longest_suffix_prefix_for_markers(text, &[THINK_START_MARKER, TOOL_CALL_START_MARKER])
 }
 
 fn longest_suffix_prefix_for_markers(text: &str, markers: &[&str]) -> usize {
@@ -467,11 +536,4 @@ fn longest_suffix_prefix_for_markers(text: &str, markers: &[&str]) -> usize {
         }
     }
     0
-}
-
-fn is_marker_prefix(text: &str) -> bool {
-    !text.is_empty()
-        && [THINK_START_MARKER, TOOL_CALL_START_MARKER]
-            .iter()
-            .any(|marker| marker.starts_with(text))
 }

--- a/crates/model-serving/src/qwen3_5/text/output_parser/foreign_syntax.rs
+++ b/crates/model-serving/src/qwen3_5/text/output_parser/foreign_syntax.rs
@@ -1,0 +1,142 @@
+//! Normalize non-canonical tool-call dialects into the Qwen3.5 function grammar.
+//!
+//! Quantized models mix Claude-style attribute tags into Qwen output. Rewriting
+//! those tags here lets the existing function/parameter parser stay fail-open
+//! instead of inventing a second grammar.
+
+pub(super) fn normalize_foreign_tool_call_syntax(tool_call_body: &str) -> String {
+    let with_canonical_function_open = normalize_invoke_function_open(tool_call_body);
+    rewrite_attribute_parameter_opens(&with_canonical_function_open)
+}
+
+fn normalize_invoke_function_open(tool_call_body: &str) -> String {
+    let leading_whitespace_bytes = tool_call_body.len() - tool_call_body.trim_start().len();
+    let trimmed = &tool_call_body[leading_whitespace_bytes..];
+    let Some(after_invoke_open) = strip_invoke_open(trimmed) else {
+        return tool_call_body.to_owned();
+    };
+    let Some((function_name, after_opening_tag)) = extract_named_attribute(after_invoke_open)
+    else {
+        return tool_call_body.to_owned();
+    };
+    if function_name.is_empty() {
+        return tool_call_body.to_owned();
+    }
+    let mut normalized = String::with_capacity(tool_call_body.len());
+    normalized.push_str(&tool_call_body[..leading_whitespace_bytes]);
+    normalized.push_str(concat!("<", "function="));
+    normalized.push_str(function_name);
+    normalized.push('>');
+    normalized.push_str(after_opening_tag);
+    normalized
+}
+
+fn strip_invoke_open(trimmed_body: &str) -> Option<&str> {
+    trimmed_body
+        .strip_prefix(concat!("<", "invoke"))
+        .or_else(|| trimmed_body.strip_prefix("invoke"))
+}
+
+fn extract_named_attribute(after_tag_name: &str) -> Option<(&str, &str)> {
+    let name_keyword_offset = after_tag_name.find("name=")?;
+    let after_name_keyword = &after_tag_name[name_keyword_offset + "name=".len()..];
+    let quote = after_name_keyword
+        .chars()
+        .next()
+        .filter(|character| matches!(character, '"' | '\''))?;
+    let name_end = after_name_keyword[1..].find(quote)?;
+    let attribute_name = &after_name_keyword[1..1 + name_end];
+    let after_quoted_name = &after_name_keyword[1 + name_end + 1..];
+    let after_opening_tag = after_quoted_name
+        .strip_prefix('>')
+        .unwrap_or(after_quoted_name);
+    Some((attribute_name, after_opening_tag))
+}
+
+fn rewrite_attribute_parameter_opens(tool_call_body: &str) -> String {
+    let mut normalized = String::with_capacity(tool_call_body.len());
+    let mut remaining = tool_call_body;
+    while let Some(parameter_open_offset) = next_attribute_parameter_open_offset(remaining) {
+        normalized.push_str(&remaining[..parameter_open_offset]);
+        let after_open = &remaining[parameter_open_offset..];
+        let (parameter_name, after_opening_tag) = match consume_attribute_parameter_open(after_open)
+        {
+            Some(rewritten) => rewritten,
+            None => {
+                normalized.push(remaining.as_bytes()[parameter_open_offset] as char);
+                remaining = &remaining[parameter_open_offset + 1..];
+                continue;
+            }
+        };
+        normalized.push_str(concat!("<", "parameter="));
+        normalized.push_str(parameter_name);
+        normalized.push('>');
+        remaining = after_opening_tag;
+    }
+    normalized.push_str(remaining);
+    normalized
+}
+
+fn next_attribute_parameter_open_offset(remaining: &str) -> Option<usize> {
+    let mut search_from = 0usize;
+    while search_from < remaining.len() {
+        let haystack = &remaining[search_from..];
+        let relative = haystack.find("parameter")?;
+        let absolute = search_from + relative;
+        let has_opening_bracket = absolute > 0 && remaining.as_bytes()[absolute - 1] == b'<';
+        let marker_start = if has_opening_bracket {
+            absolute - 1
+        } else {
+            absolute
+        };
+        let after_marker = &remaining[absolute + "parameter".len()..];
+        let after_whitespace = after_marker.trim_start();
+        if after_whitespace.starts_with("name=") {
+            return Some(marker_start);
+        }
+        search_from = absolute + 1;
+    }
+    None
+}
+
+fn consume_attribute_parameter_open(after_open: &str) -> Option<(&str, &str)> {
+    let after_optional_bracket = after_open.strip_prefix('<').unwrap_or(after_open);
+    let after_parameter = after_optional_bracket.strip_prefix("parameter")?;
+    let after_whitespace = after_parameter.trim_start();
+    let after_name_keyword = after_whitespace.strip_prefix("name=")?;
+    extract_named_attribute_value(after_name_keyword)
+}
+
+fn extract_named_attribute_value(after_name_keyword: &str) -> Option<(&str, &str)> {
+    let quote = after_name_keyword
+        .chars()
+        .next()
+        .filter(|character| matches!(character, '"' | '\''))?;
+    let name_end = after_name_keyword[1..].find(quote)?;
+    let parameter_name = &after_name_keyword[1..1 + name_end];
+    let after_quoted_name = &after_name_keyword[1 + name_end + 1..];
+    let after_opening_tag = after_quoted_name
+        .strip_prefix('>')
+        .unwrap_or(after_quoted_name);
+    Some((parameter_name, after_opening_tag))
+}
+
+#[cfg(test)]
+mod foreign_syntax_unit_tests {
+    use super::normalize_foreign_tool_call_syntax;
+
+    #[test]
+    fn should_rewrite_invoke_and_named_parameter_tags() {
+        let foreign = concat!(
+            "<",
+            "invoke name=\"find_character\">",
+            "<",
+            "parameter name=\"name\">Romeo",
+            "<",
+            "/parameter>",
+        );
+        let normalized = normalize_foreign_tool_call_syntax(foreign);
+        assert!(normalized.starts_with(concat!("<", "function=find_character>")));
+        assert!(normalized.contains(concat!("<", "parameter=name>Romeo")));
+    }
+}

--- a/crates/model-serving/src/qwen3_5/text/output_parser/salvage.rs
+++ b/crates/model-serving/src/qwen3_5/text/output_parser/salvage.rs
@@ -4,12 +4,21 @@
 //! output drops a usable function name the coding client could reject or retry.
 
 use super::super::output_parser_error::Qwen3_5OutputParserError;
-use super::{Qwen3_5OutputEvent, Qwen3_5OutputParser, Qwen3_5OutputParserState};
+use super::{
+    BARE_FUNCTION_START_MARKER, FUNCTION_END_MARKER, INVOKE_END_MARKER, INVOKE_START_MARKER,
+    Qwen3_5OutputEvent, Qwen3_5OutputParser, Qwen3_5OutputParserState, TOOL_CALL_END_MARKER,
+    ToolCallEntryKind,
+};
 
 impl Qwen3_5OutputParser {
     pub(super) fn salvage_unclosed_tool_call(&mut self) -> Vec<Qwen3_5OutputEvent> {
-        let tool_call_body = std::mem::take(&mut self.pending_output);
+        let entry = match self.state {
+            Qwen3_5OutputParserState::ToolCall(entry) => entry,
+            _ => ToolCallEntryKind::Envelope,
+        };
+        let remaining_body = std::mem::take(&mut self.pending_output);
         self.state = Qwen3_5OutputParserState::Text;
+        let tool_call_body = reconstruct_tool_call_body(entry, &remaining_body);
         match self.fail_open_closed_tool_call(&tool_call_body) {
             Some(salvaged_event) => {
                 vec![self.emit_tool_call_or_visible_text(salvaged_event, tool_call_body)]
@@ -72,4 +81,33 @@ fn bounded_fail_open_log_body(tool_call_body: &str) -> &str {
     let maximum_log_bytes = 256.min(tool_call_body.len());
     let bound = tool_call_body.floor_char_boundary(maximum_log_bytes);
     &tool_call_body[..bound]
+}
+
+pub(super) fn reconstruct_tool_call_body(entry: ToolCallEntryKind, remaining_body: &str) -> String {
+    match entry {
+        ToolCallEntryKind::Envelope => remaining_body.to_owned(),
+        ToolCallEntryKind::BareFunction => {
+            let mut reconstructed =
+                String::with_capacity(BARE_FUNCTION_START_MARKER.len() + remaining_body.len());
+            reconstructed.push_str(BARE_FUNCTION_START_MARKER);
+            reconstructed.push_str(remaining_body);
+            reconstructed
+        }
+        ToolCallEntryKind::InvokeTag => {
+            let mut reconstructed =
+                String::with_capacity(INVOKE_START_MARKER.len() + remaining_body.len());
+            reconstructed.push_str(INVOKE_START_MARKER);
+            reconstructed.push_str(remaining_body);
+            reconstructed
+        }
+    }
+}
+
+pub(super) fn tool_call_end_markers(entry: ToolCallEntryKind) -> &'static [&'static str] {
+    match entry {
+        ToolCallEntryKind::Envelope => &[TOOL_CALL_END_MARKER],
+        ToolCallEntryKind::BareFunction | ToolCallEntryKind::InvokeTag => {
+            &[TOOL_CALL_END_MARKER, FUNCTION_END_MARKER, INVOKE_END_MARKER]
+        }
+    }
 }

--- a/crates/model-serving/tests/qwen3_5_hermetic/output_parser/foreign_dialect.rs
+++ b/crates/model-serving/tests/qwen3_5_hermetic/output_parser/foreign_dialect.rs
@@ -1,0 +1,279 @@
+//! Fail-open coverage for non-canonical tool-call dialects and stream-end flushes.
+//!
+//! Quantized models sometimes emit Claude-style invoke/parameter attribute tags,
+//! bare Qwen function tags without the envelope, or end the stream while a
+//! control marker prefix is still buffered. Every one of those must reach the
+//! harness as a tool call or visible text; generation must never abort.
+
+use astronomical_model_serving::{Qwen3_5OutputEvent, Qwen3_5OutputParser, Qwen3_5ToolCall};
+
+use super::support::{
+    BALCONY_ARGUMENTS_JSON, DECLARED_CHARACTER_FUNCTION, DECLARED_SCENE_FUNCTION,
+    ROMEO_ARGUMENTS_JSON, UNDECLARED_FUNCTION_NAME, literary_declared_tools,
+    literary_output_parser,
+};
+use super::{TC_CLOSE, TC_OPEN};
+
+// Marker literals are assembled so this suite never spells a live invoke block.
+const INVOKE_OPEN: &str = concat!("<", "invoke name=\"");
+const PARAM_ATTR_OPEN: &str = concat!("<", "parameter name=\"");
+const PARAM_CLOSE: &str = concat!("<", "/parameter", ">");
+const FUNC_OPEN: &str = concat!("<", "function=");
+const FUNC_CLOSE: &str = concat!("<", "/function", ">");
+const INVOKE_CLOSE: &str = concat!("<", "/invoke", ">");
+
+fn invoke_style_envelope(
+    function_name: &str,
+    parameter_name: &str,
+    parameter_value: &str,
+) -> String {
+    format!(
+        "{INVOKE_OPEN}{function_name}\">\n{PARAM_ATTR_OPEN}{parameter_name}\">\n{parameter_value}\n{PARAM_CLOSE}\n{FUNC_CLOSE}\n{TC_CLOSE}"
+    )
+}
+
+fn bare_qwen_function(
+    function_name: &str,
+    parameter_name: &str,
+    parameter_value: &str,
+    trailing_text: &str,
+) -> String {
+    format!(
+        "{FUNC_OPEN}{function_name}>\n{PARAM_ATTR_OPEN}{parameter_name}\">\n{parameter_value}\n{PARAM_CLOSE}\n{FUNC_CLOSE}\n{trailing_text}"
+    )
+}
+
+#[test]
+fn should_parse_a_claude_style_invoke_envelope_as_a_tool_call() {
+    let mut output_parser = literary_output_parser();
+    let output_events = output_parser
+        .push_fragment(&invoke_style_envelope(
+            DECLARED_CHARACTER_FUNCTION,
+            "name",
+            "Romeo",
+        ))
+        .expect("a closed invoke-dialect envelope must not abort generation");
+    assert_eq!(
+        output_events,
+        vec![Qwen3_5OutputEvent::ToolCall(Qwen3_5ToolCall {
+            index: 0,
+            function_name: DECLARED_CHARACTER_FUNCTION.to_owned(),
+            arguments_json: ROMEO_ARGUMENTS_JSON.to_owned(),
+        })]
+    );
+    assert!(
+        output_parser
+            .finish()
+            .expect("finish after a parsed invoke envelope must stay fail-open")
+            .is_empty()
+    );
+}
+
+#[test]
+fn should_parse_a_bare_qwen_function_and_resume_visible_text() {
+    let mut output_parser = literary_output_parser();
+    let output_events = output_parser
+        .push_fragment(&bare_qwen_function(
+            DECLARED_SCENE_FUNCTION,
+            "scene",
+            "balcony",
+            "Juliet waits below.",
+        ))
+        .expect("a bare function without the envelope must not abort generation");
+    assert_eq!(
+        output_events,
+        vec![
+            Qwen3_5OutputEvent::ToolCall(Qwen3_5ToolCall {
+                index: 0,
+                function_name: DECLARED_SCENE_FUNCTION.to_owned(),
+                arguments_json: BALCONY_ARGUMENTS_JSON.to_owned(),
+            }),
+            Qwen3_5OutputEvent::TextDelta("\nJuliet waits below.".to_owned()),
+        ]
+    );
+}
+
+#[test]
+fn should_salvage_an_unclosed_invoke_envelope_when_generation_finishes() {
+    let mut output_parser = literary_output_parser();
+    let unclosed_invoke = format!(
+        "{INVOKE_OPEN}{UNDECLARED_FUNCTION_NAME}\">\n{PARAM_ATTR_OPEN}name\">\nRomeo\n{PARAM_CLOSE}"
+    );
+    assert!(
+        output_parser
+            .push_fragment(&unclosed_invoke)
+            .expect("an unclosed invoke envelope must stay pending")
+            .is_empty()
+    );
+    let finish_events = output_parser
+        .finish()
+        .expect("an unclosed invoke envelope must salvage instead of aborting");
+    assert_eq!(
+        finish_events,
+        vec![Qwen3_5OutputEvent::ToolCall(Qwen3_5ToolCall {
+            index: 0,
+            function_name: UNDECLARED_FUNCTION_NAME.to_owned(),
+            arguments_json: ROMEO_ARGUMENTS_JSON.to_owned(),
+        })]
+    );
+}
+
+#[test]
+fn should_flush_partial_marker_prefixes_as_text_when_generation_ends() {
+    for partial_marker in ["<", "<t", "<inv", "<tool", "<func"] {
+        let mut output_parser = literary_output_parser();
+        let fragment = format!("Romeo seeks the friar. {partial_marker}");
+        let push_events = output_parser
+            .push_fragment(&fragment)
+            .expect("a partial marker prefix must hold back instead of aborting");
+        let finish_events = output_parser.finish().unwrap_or_else(|parser_error| {
+            panic!("partial marker {partial_marker} must flush as text, not abort: {parser_error}")
+        });
+        let streamed_text = push_events
+            .into_iter()
+            .chain(finish_events)
+            .map(|output_event| match output_event {
+                Qwen3_5OutputEvent::TextDelta(text) => text,
+                other_event => panic!(
+                    "partial marker {partial_marker} emitted a non-text event: {other_event:?}"
+                ),
+            })
+            .collect::<String>();
+        assert_eq!(
+            streamed_text, fragment,
+            "partial marker {partial_marker} must flush verbatim instead of aborting"
+        );
+    }
+}
+
+#[test]
+fn should_flush_an_oversized_text_frame_instead_of_aborting_generation() {
+    let mut output_parser = literary_output_parser();
+    let oversized_verse = format!("{}<", "Romeo ".repeat(4 * 1024));
+    assert!(oversized_verse.len() > 16 * 1024);
+    let output_events = output_parser
+        .push_fragment(&oversized_verse)
+        .expect("an oversized text frame must flush instead of aborting");
+    assert_eq!(
+        output_events,
+        vec![Qwen3_5OutputEvent::TextDelta(oversized_verse)]
+    );
+    assert!(
+        output_parser
+            .finish()
+            .expect("finish after an oversized flush must stay open")
+            .is_empty()
+    );
+}
+
+#[test]
+fn should_keep_streaming_text_after_the_pending_cap_is_crossed() {
+    let mut output_parser = literary_output_parser();
+    let verse_block = "Juliet ".repeat(8 * 1024);
+    let mut streamed_bytes = 0usize;
+    for _ in 0..20 {
+        let output_events = output_parser
+            .push_fragment(&verse_block)
+            .expect("crossing the pending cap must flush instead of aborting");
+        streamed_bytes += output_events
+            .iter()
+            .map(|output_event| match output_event {
+                Qwen3_5OutputEvent::TextDelta(text) => text.len(),
+                other_event => panic!("unexpected event while flushing: {other_event:?}"),
+            })
+            .sum::<usize>();
+    }
+    let finish_events = output_parser
+        .finish()
+        .expect("finish after crossing the pending cap must stay open");
+    streamed_bytes += finish_events
+        .iter()
+        .map(|output_event| match output_event {
+            Qwen3_5OutputEvent::TextDelta(text) => text.len(),
+            other_event => panic!("unexpected finish event: {other_event:?}"),
+        })
+        .sum::<usize>();
+    assert_eq!(
+        streamed_bytes,
+        verse_block.len() * 20,
+        "no generated text may be dropped while flushing"
+    );
+}
+
+#[test]
+fn should_forward_a_nameless_invoke_body_as_visible_text_not_an_abort() {
+    let mut output_parser = literary_output_parser();
+    let nameless_invoke = format!(
+        "{TC_OPEN}{INVOKE_OPEN}\">\n{PARAM_ATTR_OPEN}name\">\nRomeo\n{PARAM_CLOSE}\n{FUNC_CLOSE}\n{TC_CLOSE}"
+    );
+    let output_events = output_parser
+        .push_fragment(&nameless_invoke)
+        .expect("a nameless invoke body must not abort generation");
+    assert!(
+        !output_events
+            .iter()
+            .any(|output_event| matches!(output_event, Qwen3_5OutputEvent::ToolCall(_))),
+        "a nameless invoke body must not invent a tool call: {output_events:?}"
+    );
+    assert!(
+        output_parser
+            .finish()
+            .expect("finish after a nameless invoke must stay open")
+            .is_empty()
+    );
+}
+
+fn invoke_closed_with_invoke_end(
+    function_name: &str,
+    parameter_name: &str,
+    parameter_value: &str,
+) -> String {
+    format!(
+        "{INVOKE_OPEN}{function_name}\">\n{PARAM_ATTR_OPEN}{parameter_name}\">\n{parameter_value}\n{PARAM_CLOSE}\n{INVOKE_CLOSE}"
+    )
+}
+
+#[test]
+fn should_parse_an_invoke_block_that_closes_with_the_invoke_end_tag() {
+    let mut output_parser = literary_output_parser();
+    let output_events = output_parser
+        .push_fragment(&invoke_closed_with_invoke_end(
+            DECLARED_CHARACTER_FUNCTION,
+            "name",
+            "Romeo",
+        ))
+        .expect("an invoke-end-closed call must not abort generation");
+    assert_eq!(
+        output_events,
+        vec![Qwen3_5OutputEvent::ToolCall(Qwen3_5ToolCall {
+            index: 0,
+            function_name: DECLARED_CHARACTER_FUNCTION.to_owned(),
+            arguments_json: ROMEO_ARGUMENTS_JSON.to_owned(),
+        })]
+    );
+}
+
+#[test]
+fn should_promote_an_invoke_inside_prompt_opened_reasoning_to_a_tool_call() {
+    let mut output_parser =
+        Qwen3_5OutputParser::new_after_thinking_prefix(&literary_declared_tools())
+            .expect("literary tools should construct a prompt-opened reasoning parser");
+    let fragment = format!(
+        "Romeo waits on the balcony.\n{}",
+        invoke_closed_with_invoke_end(DECLARED_CHARACTER_FUNCTION, "name", "Romeo")
+    );
+    let output_events = output_parser
+        .push_fragment(&fragment)
+        .expect("a tool attempt inside the open think channel must reach the harness");
+    assert_eq!(
+        output_events,
+        vec![
+            Qwen3_5OutputEvent::ReasoningDelta("Romeo waits on the balcony.\n".to_owned()),
+            Qwen3_5OutputEvent::ToolCall(Qwen3_5ToolCall {
+                index: 0,
+                function_name: DECLARED_CHARACTER_FUNCTION.to_owned(),
+                arguments_json: ROMEO_ARGUMENTS_JSON.to_owned(),
+            }),
+        ]
+    );
+}

--- a/crates/model-serving/tests/qwen3_5_hermetic/output_parser/marker_permutations.rs
+++ b/crates/model-serving/tests/qwen3_5_hermetic/output_parser/marker_permutations.rs
@@ -91,37 +91,42 @@ fn should_forward_unclosed_qwen_envelopes_when_generation_finishes() {
 }
 
 #[test]
-fn should_treat_missing_qwen_tool_call_open_as_visible_text_not_a_tool_call() {
-    for visible_text_case in missing_tool_call_open_cases() {
-        let mut output_parser = literary_output_parser();
-        let output_events = output_parser
-            .push_fragment(&visible_text_case.qwen_fragment)
-            .unwrap_or_else(|parser_error| {
-                panic!(
-                    "missing-open defect {} should stream as text: {parser_error}; fragment={}",
-                    visible_text_case.marker_defect, visible_text_case.qwen_fragment
-                )
-            });
-        assert!(
-            !output_events
-                .iter()
-                .any(|output_event| matches!(output_event, Qwen3_5OutputEvent::ToolCall(_))),
-            "missing-open defect {} emitted a tool call: {output_events:?}",
-            visible_text_case.marker_defect
-        );
-        assert!(
-            output_events.iter().any(|output_event| matches!(
-                output_event,
-                Qwen3_5OutputEvent::TextDelta(text)
-                    if text.contains(DECLARED_CHARACTER_FUNCTION)
-                        || text.contains(UNDECLARED_FUNCTION_NAME)
-                        || text.contains("parameter")
-                        || text.contains("function=")
-            )),
-            "missing-open defect {} did not stream the model text: {output_events:?}",
-            visible_text_case.marker_defect
-        );
-    }
+fn should_recover_tool_calls_that_omit_the_envelope_open() {
+    // The model sometimes writes Qwen function tags without the surrounding
+    // envelope. The call must still reach the harness, and any slop before the
+    // function open streams as visible text.
+    let mut declared_open = literary_output_parser();
+    let declared_events = declared_open
+        .push_fragment(&format!(
+            "<function={DECLARED_CHARACTER_FUNCTION}><parameter=name>Romeo</parameter></function>{TOOL_CALL_END}"
+        ))
+        .expect("a bare declared function must not abort generation");
+    assert_eq!(
+        declared_events,
+        vec![Qwen3_5OutputEvent::ToolCall(Qwen3_5ToolCall {
+            index: 0,
+            function_name: DECLARED_CHARACTER_FUNCTION.to_owned(),
+            arguments_json: ROMEO_ARGUMENTS_JSON.to_owned(),
+        })]
+    );
+
+    let mut undeclared_open = literary_output_parser();
+    let undeclared_events = undeclared_open
+        .push_fragment(&format!(
+            "tool_call><function={UNDECLARED_FUNCTION_NAME}><parameter=name>Romeo</parameter></function>{TOOL_CALL_END}"
+        ))
+        .expect("slop before a bare function must stream as text");
+    assert_eq!(
+        undeclared_events,
+        vec![
+            Qwen3_5OutputEvent::TextDelta("tool_call>".to_owned()),
+            Qwen3_5OutputEvent::ToolCall(Qwen3_5ToolCall {
+                index: 0,
+                function_name: UNDECLARED_FUNCTION_NAME.to_owned(),
+                arguments_json: ROMEO_ARGUMENTS_JSON.to_owned(),
+            }),
+        ]
+    );
 }
 
 fn closed_envelope_cases() -> Vec<MarkerDefectCase> {
@@ -220,25 +225,6 @@ fn unclosed_envelope_cases() -> Vec<UnclosedEnvelopeCase> {
         UnclosedEnvelopeCase {
             marker_defect: "nameless unclosed arguments",
             qwen_fragment: format!("{TOOL_CALL_START}<parameter=name>Romeo</parameter>"),
-            expectation: ClosedEnvelopeExpectation::VisibleText,
-        },
-    ]
-}
-
-fn missing_tool_call_open_cases() -> Vec<UnclosedEnvelopeCase> {
-    vec![
-        UnclosedEnvelopeCase {
-            marker_defect: "missing tool_call open entirely",
-            qwen_fragment: format!(
-                "<function=find_character><parameter=name>Romeo</parameter></function>{TOOL_CALL_END}"
-            ),
-            expectation: ClosedEnvelopeExpectation::VisibleText,
-        },
-        UnclosedEnvelopeCase {
-            marker_defect: "missing < on tool_call open",
-            qwen_fragment: format!(
-                "tool_call><function=inspect_verse><parameter=name>Romeo</parameter></function>{TOOL_CALL_END}"
-            ),
             expectation: ClosedEnvelopeExpectation::VisibleText,
         },
     ]

--- a/crates/model-serving/tests/qwen3_5_hermetic/output_parser/mod.rs
+++ b/crates/model-serving/tests/qwen3_5_hermetic/output_parser/mod.rs
@@ -1,5 +1,7 @@
 //! Qwen3.5 dense and MoE share this output parser. Happy-path, marker-defect,
-//! schema, and streaming tests cover that shared tool-call contract.
+//! foreign-dialect, schema, and streaming tests cover that shared tool-call
+//! contract. The parser is fail-open by design: malformed or foreign tool-call
+//! syntax reaches the harness as a tool call or visible text, never an abort.
 
 use astronomical_ipc_protocol::ChatToolDefinition;
 use astronomical_model_serving::{Qwen3_5OutputEvent, Qwen3_5OutputParser, Qwen3_5ToolCall};
@@ -10,6 +12,11 @@ const THINK_END: &str = concat!("<", "/think", ">");
 const TOOL_CALL_START: &str = concat!("<", "tool_call", ">");
 const TOOL_CALL_END: &str = concat!("<", "/tool_call", ">");
 
+// Re-exported under short names for the foreign-dialect suite.
+const TC_OPEN: &str = TOOL_CALL_START;
+const TC_CLOSE: &str = TOOL_CALL_END;
+
+mod foreign_dialect;
 mod happy_path_permutations;
 mod marker_permutations;
 mod permissive_arguments;


### PR DESCRIPTION
## Linked issue

Fixes #317

## Summary

Quantized Qwen3.5 generations missed the coding harness when a tool attempt used attribute-style function tags, appeared inside the open thinking block, or left a partial control marker at stream end. The client never received structured tool calls, so it could not reject or retry.

## Changes

- Normalize attribute-style invoke and parameter tags into the Qwen function grammar and emit a structured tool call when a name is present.
- Treat tool-call start markers inside prompt-opened thinking as a tool attempt, matching mlx-lm's reasoning-to-tool transition.
- Flush leftover control-marker prefixes and oversized text frames as visible content instead of aborting.
- Laguna: the same never-abort rule for leftover prefixes and oversized frames. No dialect rewrite.
- Hermetic parser coverage with Romeo and Juliet literary fixtures.

## Verification

- `scripts/verify-before-commit.sh` — all 17 steps pass
- Focused hermetic output-parser suite — 65 tests pass
