### PR TITLE
feat: record emitted tool calls in a bounded completion log

### DIFF
--- a/apps/supervisor/src/completion_attribution_log.rs
+++ b/apps/supervisor/src/completion_attribution_log.rs
@@ -1,0 +1,256 @@
+//! Switchable completion attribution log.
+//!
+//! The completion attribution log captures *what* a chat generation emitted —
+//! each tool call's function name and arguments JSON plus the completion
+//! reason — so tool-call argument pollution, foreign-dialect regressions, and
+//! fail-closed retry loops are diagnosable instead of invisible. It is the
+//! symmetric sibling of the generation performance log: performance attribution
+//! answers "how well did it run?" (timing); completion attribution answers
+//! "what did it emit?" (the tool calls and arguments).
+//!
+//! The log is off by default. An operator enables it through the
+//! `diagnostics.completion_attribution_enabled` configuration flag, mirroring
+//! `diagnostics.performance_attribution_enabled`. When disabled, the sink is
+//! `None` and `record` is a no-op with no allocation on the generation path.
+
+use std::fs::OpenOptions;
+use std::io::{BufWriter, Write};
+use std::path::Path;
+
+use serde::Serialize;
+
+use crate::generation_performance_log::unix_epoch_millis;
+
+/// Maximum number of bytes of arguments JSON recorded verbatim. Arguments at or
+/// under this cap are written in full so polluted keys (`content`, `hash`,
+/// duplicates) are visible. Larger arguments are truncated and hashed so the
+/// log never grows without bound while still correlating identical payloads.
+const COMPLETION_ARGUMENTS_FULL_LIMIT_BYTES: usize = 8_192;
+
+/// One row in the completion attribution log, written when a chat generation
+/// completes.
+///
+/// Fields are chosen to answer "what did the model emit?" at a glance:
+/// - Identity: `request_id`, `model_id`
+/// - Outcome: `completion_reason`
+/// - Content: `tool_calls` (names + bounded arguments)
+#[derive(Clone, Debug, Serialize)]
+pub struct CompletionAttributionRecord {
+    /// Unix epoch milliseconds when the record was written (request completion time).
+    pub timestamp_millis: u64,
+    /// Supervisor-local monotonic request identifier.
+    pub request_id: u64,
+    /// The model that produced this generation.
+    pub model_id: String,
+    /// Why the generation stopped: `end_of_sequence`, `tool_calls`,
+    /// `maximum_output_tokens`, or `cancelled`.
+    pub completion_reason: String,
+    /// The tool calls the model emitted, in emission order. Empty for
+    /// non-tool-call completions.
+    pub tool_calls: Vec<CompletionToolCallRecord>,
+}
+
+/// One emitted tool call, with arguments bounded for safe logging.
+#[derive(Clone, Debug, Serialize)]
+pub struct CompletionToolCallRecord {
+    /// Emission order of this tool call within the generation.
+    pub tool_call_index: u16,
+    /// The function name the model emitted.
+    pub function_name: String,
+    /// The arguments JSON, bounded so the log never grows without bound.
+    pub arguments: CompletionArgumentsRecord,
+}
+
+/// Bounded arguments payload for one tool call.
+///
+/// `size_bytes` and `sha256` are always present so identical payloads correlate
+/// regardless of truncation. `json` is the full arguments string when at or
+/// under the cap, or a truncated preview when over the cap; `truncated`
+/// distinguishes the two.
+#[derive(Clone, Debug, Serialize)]
+pub struct CompletionArgumentsRecord {
+    /// Original argument length in bytes, before any truncation.
+    pub size_bytes: usize,
+    /// SHA-256 of the full original arguments, never of the truncation.
+    pub sha256: String,
+    /// The arguments JSON: full when `truncated` is false, a bounded preview
+    /// when `truncated` is true.
+    pub json: String,
+    /// Whether `json` is a truncation rather than the full arguments.
+    pub truncated: bool,
+}
+
+impl CompletionToolCallRecord {
+    /// Builds one bounded tool-call record from the raw arguments JSON.
+    ///
+    /// Arguments at or under the cap are recorded verbatim. Larger arguments
+    /// are truncated to the cap and the full original is hashed so identical
+    /// payloads correlate regardless of truncation.
+    #[must_use]
+    pub fn from_arguments(tool_call_index: u16, function_name: &str, arguments_json: &str) -> Self {
+        let size_bytes = arguments_json.len();
+        let sha256 = sha256_hex(arguments_json.as_bytes());
+        let (json, truncated) = if size_bytes <= COMPLETION_ARGUMENTS_FULL_LIMIT_BYTES {
+            (arguments_json.to_owned(), false)
+        } else {
+            let truncated_at =
+                arguments_json.floor_char_boundary(COMPLETION_ARGUMENTS_FULL_LIMIT_BYTES);
+            (arguments_json[..truncated_at].to_owned(), true)
+        };
+        Self {
+            tool_call_index,
+            function_name: function_name.to_owned(),
+            arguments: CompletionArgumentsRecord {
+                size_bytes,
+                sha256,
+                json,
+                truncated,
+            },
+        }
+    }
+}
+
+/// Append-only JSONL writer for completion attribution records, gated by
+/// configuration.
+///
+/// Opens `completion.jsonl` in the configured log directory when enabled.
+/// When disabled, the sink is `None` and `record` is a no-op so the
+/// generation path pays no attribution cost. Uses a synchronous `BufWriter`
+/// because the volume is low (one line per completed request).
+pub struct CompletionAttributionLog {
+    sink: Option<BufWriter<Box<dyn Write + Send>>>,
+}
+
+impl CompletionAttributionLog {
+    /// Creates a no-overhead log for the disabled configuration.
+    #[must_use]
+    pub const fn disabled() -> Self {
+        Self { sink: None }
+    }
+
+    /// Opens (or creates) the completion log when enabled.
+    ///
+    /// Returns a disabled log (no file, no writes) when the flag is false so
+    /// normal inference never touches the attribution path.
+    pub fn open(
+        log_directory: &Path,
+        completion_attribution_enabled: bool,
+    ) -> std::io::Result<Self> {
+        if !completion_attribution_enabled {
+            return Ok(Self::disabled());
+        }
+        let file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(log_directory.join("completion.jsonl"))?;
+        Ok(Self {
+            sink: Some(BufWriter::new(Box::new(file))),
+        })
+    }
+
+    /// Appends one completion record as a JSON line when enabled.
+    ///
+    /// No-op when disabled. Flushes after each write so records are durable
+    /// immediately, matching the generation performance log contract.
+    pub fn record(&mut self, record: &CompletionAttributionRecord) {
+        let Some(writer) = self.sink.as_mut() else {
+            return;
+        };
+        let json_line = match serde_json::to_string(record) {
+            Ok(json) => json,
+            Err(serialization_error) => {
+                tracing::warn!(
+                    error = %serialization_error,
+                    "failed to serialize completion attribution record"
+                );
+                return;
+            }
+        };
+        if let Err(write_error) = writeln!(writer, "{json_line}") {
+            tracing::warn!(
+                error = %write_error,
+                "failed to write completion attribution record"
+            );
+            return;
+        }
+        if let Err(flush_error) = writer.flush() {
+            tracing::warn!(
+                error = %flush_error,
+                "failed to flush completion attribution log"
+            );
+        }
+    }
+
+    /// Records one completion from the raw emitted tool calls.
+    ///
+    /// Binds the accumulated raw tool calls into bounded records and writes the
+    /// row when enabled. The caller supplies the timestamp so the completion
+    /// event owns request-correlation time, mirroring the performance log.
+    pub fn record_completion(
+        &mut self,
+        timestamp_millis: u64,
+        request_id: u64,
+        model_id: &str,
+        completion_reason: &str,
+        completed_tool_calls: &[CompletedToolCall],
+    ) {
+        let tool_calls = completed_tool_calls
+            .iter()
+            .map(|completed| {
+                CompletionToolCallRecord::from_arguments(
+                    completed.tool_call_index,
+                    &completed.function_name,
+                    &completed.arguments_json,
+                )
+            })
+            .collect();
+        self.record(&CompletionAttributionRecord {
+            timestamp_millis,
+            request_id,
+            model_id: model_id.to_owned(),
+            completion_reason: completion_reason.to_owned(),
+            tool_calls,
+        });
+    }
+}
+
+/// Raw accumulated tool call, captured at emission time and bounded at write
+/// time. Stored on the active request so the completion event can attribute the
+/// emitted content without re-reading the stream.
+#[derive(Clone, Debug)]
+pub struct CompletedToolCall {
+    /// Emission order of this tool call within the generation.
+    pub tool_call_index: u16,
+    /// The function name the model emitted.
+    pub function_name: String,
+    /// The raw arguments JSON exactly as the model emitted it.
+    pub arguments_json: String,
+}
+
+/// Convenience for the completion event to record at the request's wall-clock
+/// time without each caller repeating the clock call.
+pub(crate) fn record_completion_at_now(
+    log: &mut CompletionAttributionLog,
+    request_id: u64,
+    model_id: &str,
+    completion_reason: &str,
+    completed_tool_calls: &[CompletedToolCall],
+) {
+    log.record_completion(
+        unix_epoch_millis(),
+        request_id,
+        model_id,
+        completion_reason,
+        completed_tool_calls,
+    );
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    use sha2::{Digest, Sha256};
+    let digest = Sha256::digest(bytes);
+    let mut hex_string = String::with_capacity(digest.len() * 2);
+    for digest_byte in digest {
+        hex_string.push_str(&format!("{digest_byte:02x}"));
+    }
+    hex_string
+}

--- a/apps/supervisor/src/lib.rs
+++ b/apps/supervisor/src/lib.rs
@@ -5,6 +5,7 @@ mod application_build_identity;
 mod cache_clear_endpoint;
 mod chat_diagnostics;
 mod chat_generation_executor;
+mod completion_attribution_log;
 mod config_reload;
 mod config_reload_endpoint;
 mod config_reload_response;
@@ -87,6 +88,10 @@ pub use chat_diagnostics::{
 pub use chat_generation_executor::{
     ChatGenerationExecutor, ChatGenerationStreamErrorCode, ChatGenerationStreamEvent,
     GenerationStartError,
+};
+pub use completion_attribution_log::{
+    CompletedToolCall, CompletionArgumentsRecord, CompletionAttributionLog,
+    CompletionAttributionRecord, CompletionToolCallRecord,
 };
 pub use config_reload::{
     ConfigReloadDecision, ConfigReloadDiff, ResolvedRuntimeConfig, ResolvedRuntimeConfigError,

--- a/apps/supervisor/src/main.rs
+++ b/apps/supervisor/src/main.rs
@@ -7,12 +7,13 @@ use std::{
 
 use astronomical_config::{AstronomicalConfig, AstronomicalConfigError, AstronomicalInstancePaths};
 use astronomical_supervisor::{
-    ApplicationBuildIdentity, AstronomicalInstanceLock, DownloadCatalog, DownloadCatalogError,
-    GenerationPerformanceLog, ImageGenerationTimeouts, LibraryDownloadCoordinatorError,
-    LibraryModelDiscoveryRefresh, ReqwestHubTransportBuildError, ResolvedRuntimeConfigError,
-    ResolvedRuntimeConfigResolver, ShutdownController, SupervisorPerformanceAttributionLog,
-    SupervisorPerformanceMeasurement, SupervisorPerformanceOperation, WorkerControlError,
-    WorkerHandle, build_application_with_full_control_and_library_download,
+    ApplicationBuildIdentity, AstronomicalInstanceLock, CompletionAttributionLog, DownloadCatalog,
+    DownloadCatalogError, GenerationPerformanceLog, ImageGenerationTimeouts,
+    LibraryDownloadCoordinatorError, LibraryModelDiscoveryRefresh, ReqwestHubTransportBuildError,
+    ResolvedRuntimeConfigError, ResolvedRuntimeConfigResolver, ShutdownController,
+    SupervisorPerformanceAttributionLog, SupervisorPerformanceMeasurement,
+    SupervisorPerformanceOperation, WorkerControlError, WorkerHandle,
+    build_application_with_full_control_and_library_download,
 };
 use thiserror::Error;
 use tokio::{net::TcpListener, signal};
@@ -173,12 +174,18 @@ async fn run_daemon(
     );
     let performance_log = GenerationPerformanceLog::open(logging_config.directory())
         .map_err(DaemonError::CreatePerformanceLog)?;
+    let completion_log = CompletionAttributionLog::open(
+        logging_config.directory(),
+        user_config.completion_attribution_enabled(),
+    )
+    .map_err(DaemonError::CreateCompletionAttributionLog)?;
     let worker_handle =
         match WorkerHandle::launch_with_startup_configuration_and_image_generation_timeouts(
             &resolved_runtime_config.worker_executable_path,
             WORKER_MODEL_LOAD_TIMEOUT,
             ImageGenerationTimeouts::DEFAULT,
             performance_log,
+            completion_log,
             Arc::clone(&resolved_runtime_config.model_policy_catalog),
             resolved_runtime_config.worker_startup_configuration(),
         )
@@ -320,6 +327,8 @@ enum DaemonError {
     CreateLogAppender(#[source] tracing_appender::rolling::InitError),
     #[error("failed to create the performance log: {0}")]
     CreatePerformanceLog(#[source] io::Error),
+    #[error("failed to create the completion attribution log: {0}")]
+    CreateCompletionAttributionLog(#[source] io::Error),
     #[error("failed to create the supervisor performance-attribution log: {0}")]
     CreateSupervisorPerformanceAttributionLog(#[source] io::Error),
     #[error("failed to record supervisor performance attribution: {0}")]

--- a/apps/supervisor/src/worker.rs
+++ b/apps/supervisor/src/worker.rs
@@ -22,10 +22,10 @@ use crate::worker_memory_limit::{
     MlxMemoryLimitUpdateOutcome, apply_mlx_memory_limit, contain_mlx_memory_limit_failure,
 };
 use crate::{
-    ChatGenerationStreamErrorCode, GenerationPerformanceLog, GenerationStartError,
-    ImageGenerationExecutionError, ImageGenerationTimeouts, RuntimeModelPolicy, WorkerActivity,
-    WorkerControlError, WorkerHealthSnapshot, WorkerHealthStatus, WorkerProcess,
-    WorkerTerminationOutcome,
+    ChatGenerationStreamErrorCode, CompletionAttributionLog, GenerationPerformanceLog,
+    GenerationStartError, ImageGenerationExecutionError, ImageGenerationTimeouts,
+    RuntimeModelPolicy, WorkerActivity, WorkerControlError, WorkerHealthSnapshot,
+    WorkerHealthStatus, WorkerProcess, WorkerTerminationOutcome,
     chat_generation_executor::{wait_for_deadline, wait_for_stream_disconnect},
     worker_containment::{
         cancel_active_generation, close_worker_if_running, contain_worker_failure,
@@ -55,6 +55,7 @@ pub(crate) async fn run_worker(
     cancellation_acknowledgement_timeout: Duration,
     image_generation_timeouts: ImageGenerationTimeouts,
     mut performance_log: GenerationPerformanceLog,
+    mut completion_log: CompletionAttributionLog,
     mut model_policy_catalog: Arc<HashMap<String, RuntimeModelPolicy>>,
     active_generation_permits: Arc<Semaphore>,
     generation_queue_permits: Arc<Semaphore>,
@@ -85,6 +86,7 @@ pub(crate) async fn run_worker(
                 &mut model_load_deadline,
                 &mut active_generation,
                 &mut performance_log,
+                &mut completion_log,
             )
             .await
             {
@@ -106,6 +108,7 @@ pub(crate) async fn run_worker(
             &mut is_ready,
             &mut model_load_deadline,
             &mut performance_log,
+            &mut completion_log,
             &active_generation_permits,
             &generation_queue_permits,
         )
@@ -157,6 +160,7 @@ pub(crate) async fn run_worker(
                             &mut model_load_deadline,
                             &mut active_generation,
                             &mut performance_log,
+                            &mut completion_log,
                             &model_policy_catalog,
                             model_load_timeout,
                             cancellation_acknowledgement_timeout,
@@ -198,6 +202,7 @@ pub(crate) async fn run_worker(
                             &mut model_load_deadline,
                             &mut active_generation,
                             &mut performance_log,
+                            &mut completion_log,
                             &model_policy_catalog,
                             model_load_timeout,
                             cancellation_acknowledgement_timeout,
@@ -267,6 +272,7 @@ pub(crate) async fn run_worker(
                             &mut model_load_deadline,
                             &mut active_generation,
                             &mut performance_log,
+                            &mut completion_log,
                         )
                         .await;
                         let _send_outcome = restart_sender.send(replacement_result);
@@ -299,6 +305,7 @@ pub(crate) async fn run_worker(
                             &mut model_load_deadline,
                             &mut active_generation,
                             &mut performance_log,
+                            &mut completion_log,
                         )
                         .await;
                         let _send_outcome = update_sender.send(update_outcome);
@@ -324,6 +331,7 @@ pub(crate) async fn run_worker(
                             &mut is_ready,
                             &mut model_load_deadline,
                             &mut performance_log,
+                            &mut completion_log,
                             &active_generation_permits,
                             &generation_queue_permits,
                         )
@@ -341,6 +349,7 @@ pub(crate) async fn run_worker(
                             &mut model_load_deadline,
                             &mut active_generation,
                             &mut performance_log,
+                            &mut completion_log,
                         ) {
                             if matches!(
                                 &event_handling_error,

--- a/apps/supervisor/src/worker_cache_clear.rs
+++ b/apps/supervisor/src/worker_cache_clear.rs
@@ -9,8 +9,8 @@ use crate::worker_containment::contain_worker_failure;
 use crate::worker_event_handler::handle_worker_event;
 use crate::worker_loop_types::ActiveWorkerRequest;
 use crate::{
-    GenerationPerformanceLog, GenerationQueueDepth, PendingPromptCacheClear, WorkerControlError,
-    WorkerHealthSnapshot, WorkerProcess,
+    CompletionAttributionLog, GenerationPerformanceLog, GenerationQueueDepth,
+    PendingPromptCacheClear, WorkerControlError, WorkerHealthSnapshot, WorkerProcess,
 };
 
 /// Result returned to the HTTP request that submitted one cache clear.
@@ -36,6 +36,7 @@ pub(super) async fn apply_prompt_cache_clear(
     model_load_deadline: &mut Option<Instant>,
     active_generation: &mut Option<ActiveWorkerRequest>,
     performance_log: &mut GenerationPerformanceLog,
+    completion_log: &mut CompletionAttributionLog,
 ) -> Result<PromptCacheClearOutcome, WorkerControlError> {
     let requested_model_id = model_id.clone();
     let clear_result = timeout(cache_clear_timeout, async {
@@ -69,6 +70,7 @@ pub(super) async fn apply_prompt_cache_clear(
                 model_load_deadline,
                 active_generation,
                 performance_log,
+                completion_log,
             )?;
         }
     })
@@ -117,6 +119,7 @@ pub(super) async fn apply_pending_prompt_cache_clear_if_idle(
     is_ready: &mut bool,
     model_load_deadline: &mut Option<Instant>,
     performance_log: &mut GenerationPerformanceLog,
+    completion_log: &mut CompletionAttributionLog,
     active_generation_permits: &Semaphore,
     generation_queue_permits: &Semaphore,
 ) {
@@ -140,6 +143,7 @@ pub(super) async fn apply_pending_prompt_cache_clear_if_idle(
         model_load_deadline,
         active_generation,
         performance_log,
+        completion_log,
     )
     .await;
 }
@@ -156,6 +160,7 @@ pub(super) async fn handle_prompt_cache_clear_command(
     is_ready: &mut bool,
     model_load_deadline: &mut Option<Instant>,
     performance_log: &mut GenerationPerformanceLog,
+    completion_log: &mut CompletionAttributionLog,
     active_generation_permits: &Semaphore,
     generation_queue_permits: &Semaphore,
 ) {
@@ -181,6 +186,7 @@ pub(super) async fn handle_prompt_cache_clear_command(
         model_load_deadline,
         active_generation,
         performance_log,
+        completion_log,
     )
     .await;
     let _send_outcome = clear_sender.send(clear_outcome);

--- a/apps/supervisor/src/worker_completion_event.rs
+++ b/apps/supervisor/src/worker_completion_event.rs
@@ -1,8 +1,9 @@
 //! Completion-event validation, local performance logging, and stream delivery.
 //!
-//! Worker completion has three audiences with different contracts: protocol
+//! Worker completion has four audiences with different contracts: protocol
 //! validation protects supervisor state, the local performance log receives
-//! cache diagnostics, and the public stream receives only OpenAI-compatible
+//! cache diagnostics, the completion attribution log receives emitted tool
+//! calls when enabled, and the public stream receives only OpenAI-compatible
 //! completion fields. Keeping the fan-out here makes that separation explicit.
 
 use std::sync::{Arc, RwLock};
@@ -12,9 +13,10 @@ use astronomical_ipc_protocol::{
 };
 
 use crate::{
-    ChatGenerationStreamEvent, GenerationPerformanceLog, GenerationPerformanceRecord,
-    WorkerActivity, WorkerControlError, WorkerHealthSnapshot,
+    ChatGenerationStreamEvent, CompletionAttributionLog, GenerationPerformanceLog,
+    GenerationPerformanceRecord, WorkerActivity, WorkerControlError, WorkerHealthSnapshot,
     chat_generation_executor::try_send_stream_event,
+    completion_attribution_log::record_completion_at_now,
     generation_performance_log::unix_epoch_millis,
     worker_event_handler::protocol_violation,
     worker_health::{clear_active_request_progress, publish_activity, record_serving_session},
@@ -33,6 +35,7 @@ pub(super) fn handle_worker_completion_event(
     health_snapshot: &Arc<RwLock<WorkerHealthSnapshot>>,
     active_worker_request: &mut Option<ActiveWorkerRequest>,
     performance_log: &mut GenerationPerformanceLog,
+    completion_log: &mut CompletionAttributionLog,
 ) -> Result<(), WorkerControlError> {
     // Cache diagnostics are request-scoped completion evidence. They go only to
     // the local performance row; the public generation stream keeps its stable
@@ -94,6 +97,12 @@ pub(super) fn handle_worker_completion_event(
         .ok()
         .flatten()
         .unwrap_or_default();
+    let completion_reason = match reason {
+        ChatGenerationCompletionReason::EndOfSequence => "end_of_sequence",
+        ChatGenerationCompletionReason::MaximumOutputTokens => "maximum_output_tokens",
+        ChatGenerationCompletionReason::ToolCalls => "tool_calls",
+        ChatGenerationCompletionReason::Cancelled => "cancelled",
+    };
     tracing::info!(
         request_id = request_id.value(),
         prompt_token_count,
@@ -113,17 +122,11 @@ pub(super) fn handle_worker_completion_event(
     performance_log.record(&GenerationPerformanceRecord {
         timestamp_millis: unix_epoch_millis(),
         request_id: request_id.value(),
-        model_id,
+        model_id: model_id.clone(),
         prompt_token_count,
         cached_token_count,
         generated_token_count,
-        completion_reason: match reason {
-            ChatGenerationCompletionReason::EndOfSequence => "end_of_sequence",
-            ChatGenerationCompletionReason::MaximumOutputTokens => "maximum_output_tokens",
-            ChatGenerationCompletionReason::ToolCalls => "tool_calls",
-            ChatGenerationCompletionReason::Cancelled => "cancelled",
-        }
-        .to_owned(),
+        completion_reason: completion_reason.to_owned(),
         prefill_elapsed_millis,
         generation_elapsed_millis,
         total_elapsed_millis,
@@ -140,6 +143,16 @@ pub(super) fn handle_worker_completion_event(
         mlx_active_memory_bytes: completed_request.last_mlx_active_memory_bytes,
         persistent_prompt_cache_diagnostics,
     });
+    // Attribute what the model emitted — function names and the arguments JSON —
+    // so argument pollution and foreign-dialect regressions are diagnosable
+    // instead of invisible. No-op unless the operator enabled the toggle.
+    record_completion_at_now(
+        completion_log,
+        request_id.value(),
+        &model_id,
+        completion_reason,
+        &completed_request.completed_tool_calls,
+    );
     record_serving_session(
         health_snapshot,
         prompt_token_count,

--- a/apps/supervisor/src/worker_event_handler.rs
+++ b/apps/supervisor/src/worker_event_handler.rs
@@ -10,8 +10,8 @@ use std::sync::{Arc, RwLock};
 use tokio::time::Instant;
 
 use crate::{
-    ChatGenerationStreamEvent, ExpertResidencySnapshot, GenerationPerformanceLog, WorkerActivity,
-    WorkerControlError, WorkerHealthSnapshot,
+    ChatGenerationStreamEvent, CompletionAttributionLog, ExpertResidencySnapshot,
+    GenerationPerformanceLog, WorkerActivity, WorkerControlError, WorkerHealthSnapshot,
     chat_generation_executor::try_send_stream_event,
     worker_completion_event::handle_worker_completion_event,
     worker_generation_output::{
@@ -42,6 +42,7 @@ pub(super) fn handle_worker_event(
     model_load_deadline: &mut Option<Instant>,
     active_request: &mut Option<ActiveWorkerRequest>,
     performance_log: &mut GenerationPerformanceLog,
+    completion_log: &mut CompletionAttributionLog,
 ) -> Result<(), WorkerControlError> {
     match worker_event {
         WorkerEvent::RuntimeFeatureConfigurationApplied {
@@ -284,6 +285,7 @@ pub(super) fn handle_worker_event(
                 health_snapshot,
                 active_request,
                 performance_log,
+                completion_log,
             )?;
         }
         WorkerEvent::Failed { request_id, reason } => {

--- a/apps/supervisor/src/worker_generate.rs
+++ b/apps/supervisor/src/worker_generate.rs
@@ -11,8 +11,8 @@ use astronomical_ipc_protocol::ProtocolError;
 use tokio::time::{Instant, timeout};
 
 use crate::{
-    GenerationPerformanceLog, GenerationStartError, RuntimeModelPolicy, WorkerActivity,
-    WorkerControlError, WorkerHealthSnapshot, WorkerProcess,
+    CompletionAttributionLog, GenerationPerformanceLog, GenerationStartError, RuntimeModelPolicy,
+    WorkerActivity, WorkerControlError, WorkerHealthSnapshot, WorkerProcess,
     worker_containment::{cancel_active_generation, contain_worker_failure},
     worker_health::{clear_active_request_progress, publish_activity},
     worker_loop_types::{ActiveGeneration, ActiveWorkerRequest},
@@ -30,6 +30,7 @@ pub(super) async fn handle_generate_command(
     model_load_deadline: &mut Option<Instant>,
     active_request: &mut Option<ActiveWorkerRequest>,
     performance_log: &mut GenerationPerformanceLog,
+    completion_log: &mut CompletionAttributionLog,
     model_policy_catalog: &Arc<HashMap<String, RuntimeModelPolicy>>,
     model_load_timeout: Duration,
     cancellation_acknowledgement_timeout: Duration,
@@ -101,6 +102,7 @@ pub(super) async fn handle_generate_command(
                     model_load_deadline,
                     active_request,
                     performance_log,
+                    completion_log,
                     expected_configuration_generation.as_deref(),
                     &expected_model_runtime_configuration,
                 ),
@@ -189,6 +191,7 @@ pub(super) async fn handle_generate_command(
         max_output_tokens: request_max_output_tokens,
         next_sequence_number: 0,
         next_tool_call_index: 0,
+        completed_tool_calls: Vec::new(),
         request_started_at: Instant::now(),
         prefill_elapsed_millis: 0,
         maximum_mlx_peak_memory_bytes: None,

--- a/apps/supervisor/src/worker_generation_output.rs
+++ b/apps/supervisor/src/worker_generation_output.rs
@@ -8,8 +8,8 @@ use std::sync::{Arc, RwLock};
 use tokio::time::Instant;
 
 use crate::{
-    ActiveRequestProgress, ChatGenerationStreamEvent, WorkerActivity, WorkerControlError,
-    WorkerHealthSnapshot,
+    ActiveRequestProgress, ChatGenerationStreamEvent, CompletedToolCall, WorkerActivity,
+    WorkerControlError, WorkerHealthSnapshot,
     chat_generation_executor::try_send_stream_event,
     worker_event_handler::protocol_violation,
     worker_health::{
@@ -60,12 +60,22 @@ pub(super) fn handle_worker_output(
     let mut next_tool_call_index = active_request.next_tool_call_index;
     for output in &outputs {
         if let astronomical_ipc_protocol::ChatGenerationOutput::ToolCall {
-            tool_call_index, ..
+            tool_call_index,
+            function_name,
+            arguments_json,
         } = output
         {
             if *tool_call_index != next_tool_call_index {
                 return Err(protocol_violation("tool-call index mismatch"));
             }
+            // Accumulate the emitted tool call for completion attribution so the
+            // completion event can log function names and arguments without
+            // re-reading the public stream. The arguments are bounded at write time.
+            active_request.completed_tool_calls.push(CompletedToolCall {
+                tool_call_index: *tool_call_index,
+                function_name: function_name.clone(),
+                arguments_json: arguments_json.clone(),
+            });
             next_tool_call_index = next_tool_call_index
                 .checked_add(1)
                 .ok_or_else(|| protocol_violation("tool-call index overflow"))?;

--- a/apps/supervisor/src/worker_handle.rs
+++ b/apps/supervisor/src/worker_handle.rs
@@ -6,9 +6,9 @@ use std::{
 };
 
 use crate::{
-    GenerationPerformanceLog, ImageGenerationTimeouts, PromptCacheClearOutcome, RuntimeModelPolicy,
-    WorkerControlError, WorkerHealthSnapshot, WorkerHealthStatus, WorkerProcess,
-    WorkerTerminationOutcome,
+    CompletionAttributionLog, GenerationPerformanceLog, ImageGenerationTimeouts,
+    PromptCacheClearOutcome, RuntimeModelPolicy, WorkerControlError, WorkerHealthSnapshot,
+    WorkerHealthStatus, WorkerProcess, WorkerTerminationOutcome,
 };
 use astronomical_ipc_protocol::{WorkerRuntimeFeatureConfiguration, WorkerStartupConfiguration};
 use tokio::sync::{Semaphore, mpsc, oneshot};
@@ -84,6 +84,7 @@ impl WorkerHandle {
             DEFAULT_WORKER_CANCELLATION_ACKNOWLEDGEMENT_TIMEOUT,
             ImageGenerationTimeouts::DEFAULT,
             performance_log,
+            CompletionAttributionLog::disabled(),
             model_policy_catalog,
             None,
         )
@@ -104,6 +105,7 @@ impl WorkerHandle {
             DEFAULT_WORKER_CANCELLATION_ACKNOWLEDGEMENT_TIMEOUT,
             ImageGenerationTimeouts::DEFAULT,
             performance_log,
+            CompletionAttributionLog::disabled(),
             model_policy_catalog,
             Some(worker_startup_configuration),
         )
@@ -116,6 +118,7 @@ impl WorkerHandle {
         worker_model_load_timeout: Duration,
         image_generation_timeouts: ImageGenerationTimeouts,
         performance_log: GenerationPerformanceLog,
+        completion_log: CompletionAttributionLog,
         model_policy_catalog: Arc<HashMap<String, RuntimeModelPolicy>>,
         worker_startup_configuration: WorkerStartupConfiguration,
     ) -> Result<Self, WorkerControlError> {
@@ -125,6 +128,7 @@ impl WorkerHandle {
             DEFAULT_WORKER_CANCELLATION_ACKNOWLEDGEMENT_TIMEOUT,
             image_generation_timeouts,
             performance_log,
+            completion_log,
             model_policy_catalog,
             Some(worker_startup_configuration),
         )
@@ -145,6 +149,7 @@ impl WorkerHandle {
             worker_cancellation_acknowledgement_timeout,
             ImageGenerationTimeouts::DEFAULT,
             performance_log,
+            CompletionAttributionLog::disabled(),
             model_policy_catalog,
             None,
         )
@@ -166,6 +171,7 @@ impl WorkerHandle {
             worker_cancellation_acknowledgement_timeout,
             image_generation_timeouts,
             performance_log,
+            CompletionAttributionLog::disabled(),
             model_policy_catalog,
             None,
         )
@@ -178,6 +184,7 @@ impl WorkerHandle {
         worker_cancellation_acknowledgement_timeout: Duration,
         image_generation_timeouts: ImageGenerationTimeouts,
         performance_log: GenerationPerformanceLog,
+        completion_log: CompletionAttributionLog,
         model_policy_catalog: Arc<HashMap<String, RuntimeModelPolicy>>,
         worker_startup_configuration: Option<WorkerStartupConfiguration>,
     ) -> Result<Self, WorkerControlError> {
@@ -206,6 +213,7 @@ impl WorkerHandle {
             worker_cancellation_acknowledgement_timeout,
             image_generation_timeouts,
             performance_log,
+            completion_log,
             model_policy_catalog,
             Arc::clone(&active_generation_permits),
             Arc::clone(&generation_queue_permits),

--- a/apps/supervisor/src/worker_image_request.rs
+++ b/apps/supervisor/src/worker_image_request.rs
@@ -10,9 +10,9 @@ use astronomical_ipc_protocol::{ImageGenerationCommand, ProtocolError};
 use tokio::time::{Instant, timeout};
 
 use crate::{
-    GenerationPerformanceLog, GenerationStartError, ImageGenerationExecutionError,
-    ImageGenerationOutput, ImageGenerationTimeouts, RuntimeModelPolicy, WorkerActivity,
-    WorkerControlError, WorkerHealthSnapshot, WorkerProcess,
+    CompletionAttributionLog, GenerationPerformanceLog, GenerationStartError,
+    ImageGenerationExecutionError, ImageGenerationOutput, ImageGenerationTimeouts,
+    RuntimeModelPolicy, WorkerActivity, WorkerControlError, WorkerHealthSnapshot, WorkerProcess,
     worker_containment::{cancel_active_generation, contain_worker_failure},
     worker_health::{clear_active_request_progress, publish_activity},
     worker_loop_types::{ActiveImageGeneration, ActiveWorkerRequest},
@@ -35,6 +35,7 @@ pub(super) async fn handle_generate_image_command(
     model_load_deadline: &mut Option<Instant>,
     active_request: &mut Option<ActiveWorkerRequest>,
     performance_log: &mut GenerationPerformanceLog,
+    completion_log: &mut CompletionAttributionLog,
     model_policy_catalog: &Arc<HashMap<String, RuntimeModelPolicy>>,
     model_load_timeout: Duration,
     cancellation_acknowledgement_timeout: Duration,
@@ -88,6 +89,7 @@ pub(super) async fn handle_generate_image_command(
                 model_load_deadline,
                 active_request,
                 performance_log,
+                completion_log,
                 expected_configuration_generation.as_deref(),
                 &expected_model_runtime_configuration,
             ),

--- a/apps/supervisor/src/worker_loop_types.rs
+++ b/apps/supervisor/src/worker_loop_types.rs
@@ -9,9 +9,9 @@ use tokio::sync::{OwnedSemaphorePermit, mpsc, oneshot};
 use tokio::time::Instant;
 
 use crate::{
-    ChatGenerationStreamEvent, GenerationStartError, ImageGenerationExecutionError,
-    ImageGenerationOutput, MlxMemoryLimitUpdateOutcome, PromptCacheClearOutcome,
-    RuntimeModelPolicy, WorkerControlError, WorkerTerminationOutcome,
+    ChatGenerationStreamEvent, CompletedToolCall, GenerationStartError,
+    ImageGenerationExecutionError, ImageGenerationOutput, MlxMemoryLimitUpdateOutcome,
+    PromptCacheClearOutcome, RuntimeModelPolicy, WorkerControlError, WorkerTerminationOutcome,
 };
 
 pub(crate) enum WorkerLoopCommand {
@@ -128,6 +128,9 @@ pub(crate) struct ActiveGeneration {
     pub(crate) max_output_tokens: u16,
     pub(crate) next_sequence_number: u16,
     pub(crate) next_tool_call_index: u16,
+    /// Tool calls emitted so far, accumulated for completion attribution.
+    /// Bounded at write time so the completion log never grows without bound.
+    pub(crate) completed_tool_calls: Vec<CompletedToolCall>,
     pub(crate) request_started_at: Instant,
     pub(crate) prefill_elapsed_millis: u64,
     pub(crate) maximum_mlx_peak_memory_bytes: Option<u64>,

--- a/apps/supervisor/src/worker_memory_limit.rs
+++ b/apps/supervisor/src/worker_memory_limit.rs
@@ -9,7 +9,10 @@ use tokio::time::{Instant, timeout};
 use crate::worker_containment::contain_worker_failure;
 use crate::worker_event_handler::handle_worker_event;
 use crate::worker_loop_types::ActiveWorkerRequest;
-use crate::{GenerationPerformanceLog, WorkerControlError, WorkerHealthSnapshot, WorkerProcess};
+use crate::{
+    CompletionAttributionLog, GenerationPerformanceLog, WorkerControlError, WorkerHealthSnapshot,
+    WorkerProcess,
+};
 
 /// Completion state returned by a live MLX memory-limit request.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -30,6 +33,7 @@ pub(super) async fn apply_mlx_memory_limit(
     model_load_deadline: &mut Option<Instant>,
     active_request: &mut Option<ActiveWorkerRequest>,
     performance_log: &mut GenerationPerformanceLog,
+    completion_log: &mut CompletionAttributionLog,
 ) -> Result<MlxMemoryLimitUpdateOutcome, WorkerControlError> {
     let update_outcome = timeout(memory_limit_update_timeout, async {
         worker_process
@@ -56,6 +60,7 @@ pub(super) async fn apply_mlx_memory_limit(
                 model_load_deadline,
                 active_request,
                 performance_log,
+                completion_log,
             )?;
             if let Some(memory_limit_update_outcome) = memory_limit_update_outcome {
                 return Ok(memory_limit_update_outcome);

--- a/apps/supervisor/src/worker_model_swap.rs
+++ b/apps/supervisor/src/worker_model_swap.rs
@@ -8,7 +8,10 @@ use tokio::time::Instant;
 use crate::worker_event_handler::handle_worker_event;
 use crate::worker_health::publish_health;
 use crate::worker_loop_types::ActiveWorkerRequest;
-use crate::{GenerationPerformanceLog, WorkerControlError, WorkerHealthSnapshot, WorkerProcess};
+use crate::{
+    CompletionAttributionLog, GenerationPerformanceLog, WorkerControlError, WorkerHealthSnapshot,
+    WorkerProcess,
+};
 
 /// Result of waiting for a worker model-swap acknowledgement.
 pub(super) enum ModelSwapWaitOutcome {
@@ -28,6 +31,7 @@ pub(super) async fn wait_for_model_swap(
     model_load_deadline: &mut Option<Instant>,
     active_request: &mut Option<ActiveWorkerRequest>,
     performance_log: &mut GenerationPerformanceLog,
+    completion_log: &mut CompletionAttributionLog,
     expected_configuration_generation: Option<&str>,
     expected_model_runtime_configuration: &WorkerLoadedModelRuntimeConfiguration,
 ) -> Result<ModelSwapWaitOutcome, WorkerControlError> {
@@ -126,6 +130,7 @@ pub(super) async fn wait_for_model_swap(
                             model_load_deadline,
                             active_request,
                             performance_log,
+                            completion_log,
                         )?;
                         tracing::debug!(
                             worker_event = interleaved_worker_event_summary,

--- a/apps/supervisor/src/worker_replacement.rs
+++ b/apps/supervisor/src/worker_replacement.rs
@@ -8,9 +8,10 @@ use astronomical_ipc_protocol::{
 use tokio::time::{Instant, timeout};
 
 use crate::{
-    GenerationPerformanceLog, RuntimeModelPolicy, WorkerControlError, WorkerHealthSnapshot,
-    WorkerHealthStatus, WorkerProcess, worker_event_handler::handle_worker_event,
-    worker_health::publish_health, worker_loop_types::ActiveWorkerRequest,
+    CompletionAttributionLog, GenerationPerformanceLog, RuntimeModelPolicy, WorkerControlError,
+    WorkerHealthSnapshot, WorkerHealthStatus, WorkerProcess,
+    worker_event_handler::handle_worker_event, worker_health::publish_health,
+    worker_loop_types::ActiveWorkerRequest,
 };
 
 const MAXIMUM_DEFERRED_CANDIDATE_PROCESS_EVENTS: usize = 64;
@@ -51,6 +52,7 @@ impl WorkerReplacement {
         model_load_deadline: &mut Option<Instant>,
         active_generation: &mut Option<ActiveWorkerRequest>,
         performance_log: &mut GenerationPerformanceLog,
+        completion_log: &mut CompletionAttributionLog,
     ) -> Result<WorkerRuntimeFeatureConfiguration, WorkerControlError> {
         let replacement_started_at = Instant::now();
         tracing::info!(
@@ -170,6 +172,7 @@ impl WorkerReplacement {
             model_load_deadline,
             active_generation,
             performance_log,
+            completion_log,
         );
         if let Err(publish_error) = publish_result {
             let cleanup_error = trusted_worker_process.force_terminate().await.err();
@@ -322,6 +325,7 @@ fn publish_candidate_acknowledgement(
     model_load_deadline: &mut Option<Instant>,
     active_generation: &mut Option<ActiveWorkerRequest>,
     performance_log: &mut GenerationPerformanceLog,
+    completion_log: &mut CompletionAttributionLog,
 ) -> Result<(), WorkerControlError> {
     handle_worker_event(
         candidate_acknowledgement.readiness_event,
@@ -330,6 +334,7 @@ fn publish_candidate_acknowledgement(
         model_load_deadline,
         active_generation,
         performance_log,
+        completion_log,
     )?;
     handle_worker_event(
         WorkerEvent::RuntimeFeatureConfigurationApplied {
@@ -341,6 +346,7 @@ fn publish_candidate_acknowledgement(
         model_load_deadline,
         active_generation,
         performance_log,
+        completion_log,
     )?;
     for deferred_process_event in candidate_acknowledgement.deferred_process_events {
         handle_worker_event(
@@ -350,6 +356,7 @@ fn publish_candidate_acknowledgement(
             model_load_deadline,
             active_generation,
             performance_log,
+            completion_log,
         )?;
     }
     Ok(())

--- a/apps/supervisor/tests/hermetic/completion_attribution_log.rs
+++ b/apps/supervisor/tests/hermetic/completion_attribution_log.rs
@@ -1,0 +1,215 @@
+//! Hermetic coverage for the completion attribution log.
+//!
+//! The completion attribution log captures what a chat generation emitted —
+//! function names and the arguments JSON — so tool-call argument pollution and
+//! foreign-dialect regressions are diagnosable instead of invisible. These
+//! tests cover the bounding logic, the enabled/disabled gating, and the JSONL
+//! serialization contract, mirroring the generation performance log tests.
+
+use std::fs;
+
+use astronomical_supervisor::{
+    CompletedToolCall, CompletionArgumentsRecord, CompletionAttributionLog,
+    CompletionToolCallRecord,
+};
+
+/// A literary payload used as oversized tool-call arguments so the bounding
+/// path is exercised with source text rather than random tokens.
+fn romeo_arguments_payload(repeats: usize) -> String {
+    let passage =
+        "Juliet: O Romeo, Romeo! wherefore art thou Romeo? Deny thy father and refuse thy name.";
+    passage.repeat(repeats)
+}
+
+#[test]
+fn should_record_full_arguments_when_under_the_size_cap() {
+    let record = CompletionToolCallRecord::from_arguments(
+        /* tool_call_index */ 0,
+        /* function_name */ "read",
+        /* arguments_json */ r#"{"path":"romeo-and-juliet.md"}"#,
+    );
+    let CompletionArgumentsRecord {
+        size_bytes,
+        sha256,
+        json,
+        truncated,
+    } = record.arguments;
+    assert!(!truncated, "small arguments must not be truncated");
+    assert_eq!(
+        json, r#"{"path":"romeo-and-juliet.md"}"#,
+        "under-cap arguments must be recorded verbatim"
+    );
+    assert!(!sha256.is_empty(), "a sha256 must always be recorded");
+    assert_eq!(
+        size_bytes,
+        r#"{"path":"romeo-and-juliet.md"}"#.len(),
+        "size must be the original argument length"
+    );
+}
+
+#[test]
+fn should_truncate_and_hash_arguments_when_over_the_size_cap() {
+    let oversized_arguments = romeo_arguments_payload(/* repeats */ 1_000);
+    let record = CompletionToolCallRecord::from_arguments(
+        /* tool_call_index */ 1,
+        /* function_name */ "find_character",
+        /* arguments_json */ &oversized_arguments,
+    );
+    let CompletionArgumentsRecord {
+        size_bytes,
+        sha256,
+        json,
+        truncated,
+    } = record.arguments;
+    assert!(truncated, "over-cap arguments must be marked truncated");
+    assert_eq!(
+        size_bytes,
+        oversized_arguments.len(),
+        "size must reflect the original argument length, not the truncation"
+    );
+    assert!(
+        json.len() < oversized_arguments.len(),
+        "the recorded json must be shorter than the original"
+    );
+    assert!(!sha256.is_empty(), "a sha256 must always be recorded");
+    // The sha256 must be of the full original arguments, not the truncation,
+    // so two identical over-cap calls correlate regardless of truncation.
+    let expected_sha = sha256_hex(oversized_arguments.as_bytes());
+    assert_eq!(sha256, expected_sha);
+}
+
+#[test]
+fn should_write_one_completion_row_with_tool_calls_when_enabled() {
+    let temp_dir = tempfile::tempdir().expect("test directory should be created");
+    let mut log = CompletionAttributionLog::open(temp_dir.path(), true)
+        .expect("enabled completion log should open");
+
+    log.record_completion(
+        /* timestamp_millis */ 1_700_000_000_000,
+        /* request_id */ 42,
+        /* model_id */ "ornith-1.5-35b",
+        /* completion_reason */ "tool_calls",
+        &[
+            CompletedToolCall {
+                tool_call_index: 0,
+                function_name: "read".to_owned(),
+                arguments_json: r#"{"path":"romeo-and-juliet.md"}"#.to_owned(),
+            },
+            CompletedToolCall {
+                tool_call_index: 1,
+                function_name: "find_character".to_owned(),
+                arguments_json: r#"{"name":"Romeo"}"#.to_owned(),
+            },
+        ],
+    );
+
+    let completion_path = temp_dir.path().join("completion.jsonl");
+    let contents =
+        fs::read_to_string(&completion_path).expect("completion log file should be readable");
+    let lines: Vec<&str> = contents.trim().lines().collect();
+    assert_eq!(lines.len(), 1, "should write exactly one JSON line");
+
+    let parsed: serde_json::Value =
+        serde_json::from_str(lines[0]).expect("completion log line should be valid JSON");
+    assert_eq!(parsed["request_id"], 42);
+    assert_eq!(parsed["model_id"], "ornith-1.5-35b");
+    assert_eq!(parsed["completion_reason"], "tool_calls");
+    assert_eq!(parsed["tool_calls"][0]["tool_call_index"], 0);
+    assert_eq!(parsed["tool_calls"][0]["function_name"], "read");
+    assert_eq!(parsed["tool_calls"][0]["arguments"]["truncated"], false);
+    assert_eq!(
+        parsed["tool_calls"][0]["arguments"]["json"],
+        r#"{"path":"romeo-and-juliet.md"}"#
+    );
+    assert_eq!(parsed["tool_calls"][1]["function_name"], "find_character");
+}
+
+#[test]
+fn should_write_an_empty_tool_call_list_for_end_of_sequence() {
+    let temp_dir = tempfile::tempdir().expect("test directory should be created");
+    let mut log = CompletionAttributionLog::open(temp_dir.path(), true)
+        .expect("enabled completion log should open");
+
+    log.record_completion(
+        /* timestamp_millis */ 1_700_000_000_000,
+        /* request_id */ 7,
+        /* model_id */ "ornith-1.5-35b",
+        /* completion_reason */ "end_of_sequence",
+        &[],
+    );
+
+    let completion_path = temp_dir.path().join("completion.jsonl");
+    let contents =
+        fs::read_to_string(&completion_path).expect("completion log file should be readable");
+    let parsed: serde_json::Value =
+        serde_json::from_str(contents.trim()).expect("completion log line should be valid JSON");
+    assert_eq!(parsed["completion_reason"], "end_of_sequence");
+    assert!(
+        parsed["tool_calls"].is_array(),
+        "tool_calls must always serialize as an array"
+    );
+    assert_eq!(parsed["tool_calls"].as_array().map(Vec::len), Some(0));
+}
+
+#[test]
+fn should_write_nothing_when_attribution_is_disabled() {
+    let temp_dir = tempfile::tempdir().expect("test directory should be created");
+    let mut disabled = CompletionAttributionLog::open(temp_dir.path(), false)
+        .expect("disabled completion log should open");
+    disabled.record_completion(
+        /* timestamp_millis */ 1_700_000_000_000,
+        /* request_id */ 99,
+        /* model_id */ "ornith-1.5-35b",
+        /* completion_reason */ "tool_calls",
+        &[CompletedToolCall {
+            tool_call_index: 0,
+            function_name: "read".to_owned(),
+            arguments_json: r#"{"path":"romeo-and-juliet.md"}"#.to_owned(),
+        }],
+    );
+    assert!(
+        !temp_dir.path().join("completion.jsonl").exists(),
+        "a disabled log must not create the completion file"
+    );
+}
+
+#[test]
+fn should_never_leak_local_paths_into_completion_rows() {
+    let temp_dir = tempfile::tempdir().expect("test directory should be created");
+    let mut log = CompletionAttributionLog::open(temp_dir.path(), true)
+        .expect("enabled completion log should open");
+
+    log.record_completion(
+        /* timestamp_millis */ 1_700_000_000_000,
+        /* request_id */ 5,
+        /* model_id */ "ornith-1.5-35b",
+        /* completion_reason */ "tool_calls",
+        &[CompletedToolCall {
+            tool_call_index: 0,
+            function_name: "read".to_owned(),
+            arguments_json: r#"{"path":"romeo-and-juliet.md"}"#.to_owned(),
+        }],
+    );
+
+    let completion_path = temp_dir.path().join("completion.jsonl");
+    let serialized =
+        fs::read_to_string(&completion_path).expect("completion log file should be readable");
+    assert!(
+        !serialized.contains("/fictional/"),
+        "completion rows must not carry synthetic local paths"
+    );
+    assert!(
+        !serialized.contains("Users"),
+        "completion rows must not carry home-directory paths"
+    );
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    use sha2::{Digest, Sha256};
+    let digest = Sha256::digest(bytes);
+    let mut hex = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        hex.push_str(&format!("{byte:02x}"));
+    }
+    hex
+}

--- a/apps/supervisor/tests/hermetic/mod.rs
+++ b/apps/supervisor/tests/hermetic/mod.rs
@@ -1,4 +1,5 @@
 mod chat_generation_executor;
+mod completion_attribution_log;
 mod config_reload;
 mod config_reload_resolver;
 mod download_catalog;

--- a/crates/config/src/config_document.rs
+++ b/crates/config/src/config_document.rs
@@ -101,6 +101,8 @@ pub(crate) struct DiagnosticsConfigFile {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) performance_attribution_enabled: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) completion_attribution_enabled: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) log_level: Option<LogLevel>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) retained_log_files: Option<usize>,

--- a/crates/config/src/legacy_config_migration.rs
+++ b/crates/config/src/legacy_config_migration.rs
@@ -230,6 +230,7 @@ fn build_migrated_config(
         models,
         diagnostics: Some(DiagnosticsConfigFile {
             performance_attribution_enabled: legacy_config.performance_attribution_enabled,
+            completion_attribution_enabled: None,
             log_level: legacy_config.logging.as_ref().map(|logging| logging.level),
             retained_log_files: legacy_config
                 .logging

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -287,6 +287,22 @@ impl AstronomicalConfig {
             .unwrap_or(false)
     }
 
+    /// Returns whether completion attribution is enabled.
+    ///
+    /// Completion attribution captures the emitted tool calls and arguments of
+    /// each chat completion to a bounded log so tool-call argument pollution
+    /// and foreign-dialect regressions are diagnosable. It defaults to disabled
+    /// so normal inference never pays the attribution cost unless the operator
+    /// explicitly requests it.
+    #[must_use]
+    pub fn completion_attribution_enabled(&self) -> bool {
+        self.user_config_file
+            .diagnostics
+            .as_ref()
+            .and_then(|diagnostics| diagnostics.completion_attribution_enabled)
+            .unwrap_or(false)
+    }
+
     /// Returns whether the optional Qwen thinking-channel seed may be read.
     ///
     /// The experiment is opt-in so an existing `thinking.md` file cannot alter

--- a/crates/config/tests/hermetic/completion_attribution.rs
+++ b/crates/config/tests/hermetic/completion_attribution.rs
@@ -1,0 +1,40 @@
+use astronomical_config::AstronomicalConfig;
+
+use super::write_config;
+
+#[test]
+fn should_disable_completion_attribution_by_default() {
+    let temporary_home_directory = tempfile::tempdir().expect("temp home should be created");
+    write_config(
+        temporary_home_directory.path(),
+        r#"{
+          "$schema":"./astronomical-config.schema.json",
+          "schema_version":1,
+          "runtime":{"model_directories":[]}
+        }"#,
+    );
+    let astronomical_config =
+        AstronomicalConfig::load_from_home_directory(temporary_home_directory.path())
+            .expect("config should load");
+
+    assert!(!astronomical_config.completion_attribution_enabled());
+}
+
+#[test]
+fn should_enable_completion_attribution_when_explicitly_configured() {
+    let temporary_home_directory = tempfile::tempdir().expect("temp home should be created");
+    write_config(
+        temporary_home_directory.path(),
+        r#"{
+          "$schema":"./astronomical-config.schema.json",
+          "schema_version":1,
+          "runtime":{"model_directories":[]},
+          "diagnostics":{"completion_attribution_enabled":true}
+        }"#,
+    );
+    let astronomical_config =
+        AstronomicalConfig::load_from_home_directory(temporary_home_directory.path())
+            .expect("config should load");
+
+    assert!(astronomical_config.completion_attribution_enabled());
+}

--- a/crates/config/tests/hermetic/config/runtime.rs
+++ b/crates/config/tests/hermetic/config/runtime.rs
@@ -84,6 +84,11 @@ fn should_create_minimal_v1_config_and_byte_identical_local_schema_on_first_run(
         "application-restart"
     );
     assert_eq!(
+        checked_in_schema_json["$defs"]["diagnostics"]["properties"]["completion_attribution_enabled"]
+            ["x-astronomical-apply-mode"],
+        "application-restart"
+    );
+    assert_eq!(
         checked_in_schema_json["$defs"]["mtp"]["properties"]["enabled"]["default"],
         false
     );
@@ -111,6 +116,7 @@ fn should_create_minimal_v1_config_and_byte_identical_local_schema_on_first_run(
     );
     assert!(astronomical_config.persistent_prompt_cache_enabled());
     assert!(!astronomical_config.performance_attribution_enabled());
+    assert!(!astronomical_config.completion_attribution_enabled());
     assert!(!astronomical_config.experimental_qwen_thinking_channel_seed_enabled());
 }
 

--- a/crates/config/tests/hermetic/mod.rs
+++ b/crates/config/tests/hermetic/mod.rs
@@ -1,3 +1,4 @@
+mod completion_attribution;
 mod config;
 mod model_discovery;
 mod performance_attribution;

--- a/site/schemas/config/v1/astronomical-config.schema.json
+++ b/site/schemas/config/v1/astronomical-config.schema.json
@@ -304,6 +304,12 @@
           "description": "Whether critical-path operations emit detailed performance attribution.",
           "x-astronomical-apply-mode": "application-restart"
         },
+        "completion_attribution_enabled": {
+          "type": "boolean",
+          "default": false,
+          "description": "Whether completed chat generations record emitted tool-call names and bounded arguments.",
+          "x-astronomical-apply-mode": "application-restart"
+        },
         "log_level": {
           "type": "string",
           "enum": ["error", "warn", "info", "debug", "trace"],


### PR DESCRIPTION
## Linked issue

Fixes #332

## Problem

Chat completions that finish as tool calls leave no server-side record of the emitted function names and arguments. When a model pollutes those arguments, operators can only diagnose from a screenshot. Request diagnostics and `performance.jsonl` do not capture that content.

## Change

Add opt-in completion attribution, symmetric to performance attribution:

- `diagnostics.completion_attribution_enabled` (off by default; application restart)
- bounded `logs/completion.jsonl` rows with `request_id`, `model_id`, `completion_reason`, and per tool call the function name plus arguments (full under 8,192 bytes, otherwise sha256 + size + truncation)
- accumulate tool calls on the active generation and write the row at the worker completion event

Disabled path is a no-op. Public OpenAI completion shape is unchanged.

## Verification

- `scripts/verify-before-commit.sh` — all 17 steps pass
- supervisor hermetic: completion attribution log (6 tests)
- config hermetic: default-off and explicit-on toggle tests
- supervisor hermetic: worker launch (8 tests)

## Safety

- [x] No credentials, personal paths, prompts, model inventories, proprietary artifacts, or machine logs are included.
- [x] Model precision and output semantics are preserved or explicitly justified.
- [x] Performance and memory effects are measured when the critical path changes.
- [x] Source reuse and third-party licensing are accurately attributed.
