### PR TITLE
Residency claim pairing with the measured MLX snapshot (#337)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,9 @@
 
 - All commands and tests must emit a live progress indicator instead of leaving the user with silent output.
 
-- NEVER pipe long-running commands through | tail -30, | head, or any filter that buffers output and hides live progress from the user. The user must be able to observe progress as it happens.
+- NEVER pipe long-running commands through | tail -30, | head, | rg, | grep, or any filter at all. Show the raw output live; if a copy is needed for forensics, pipe through `tee` to a file and nothing else. The user must be able to observe progress as it happens.
+
+- MLX/GPU acceptance journeys must never run in parallel. Each journey loads model weights into wired GPU memory, so concurrent journeys multiply that demand past the machine's physical limit and can hard-panic the whole system (watchdog starvation → forced power-off). This is enforced structurally: `scripts/run-bounded-cargo-test.sh` rejects any ignored-test invocation that asks for more than one test thread and injects `--test-threads=1` otherwise, so callers cannot parallelize real-model journeys. Confirm no other Astronomical instance is holding a resident model before starting.
 
 - All and any tests must have a built in timeout with a maximum of 120 seconds. Exceptions can be made for tests that deal with performance endurance tests and/or reproducing OOM issues.
 

--- a/crates/model-serving/src/qwen3_5/inference_execution/advance_generation.rs
+++ b/crates/model-serving/src/qwen3_5/inference_execution/advance_generation.rs
@@ -13,7 +13,8 @@ use crate::{
 };
 
 use super::completed_forward_memory::{
-    collect_completed_forward_memory_snapshot, record_completed_adaptive_ram_growth,
+    capture_completed_forward_memory_observation, collect_completed_forward_memory_snapshot,
+    record_completed_adaptive_ram_growth,
 };
 use super::generated_token_emission::synchronize_generated_token_id;
 use super::{Qwen3_5EngineState, fatal_engine_error, qwen3_5_runtime_error};
@@ -100,8 +101,18 @@ impl Qwen3_5EngineState {
                 .model
                 .as_ref()
                 .ok_or_else(|| fatal_engine_error("Qwen3.5 engine lost its loaded model"))?;
-            let expert_residency = model.expert_residency_telemetry();
             let mlx_memory_telemetry = self.collect_current_mlx_memory_telemetry()?;
+            // The telemetry carries the residency derived from its own reconciled
+            // breakdown, so the announced claim and snapshot describe one instant
+            // (issue #337).
+            let expert_residency = mlx_memory_telemetry
+                .as_ref()
+                .and_then(|telemetry| telemetry.expert_residency_telemetry())
+                .unwrap_or_else(|| {
+                    model.expert_residency_telemetry_for_breakdown(
+                        &crate::MlxActiveMemoryBreakdown::default(),
+                    )
+                });
             return Ok(ActiveRequestAdvance::Continue(
                 crate::GeneratedToken::GenerationPreparationStarted {
                     total_layer_count: expert_residency.total_layer_count,
@@ -132,21 +143,16 @@ impl Qwen3_5EngineState {
                 .model
                 .as_ref()
                 .ok_or_else(|| fatal_engine_error("Qwen3.5 engine lost its loaded model"))?;
-            let mlx_memory_snapshot = if !self.adaptive_ram_growth_guard_enabled {
+            let completed_forward_memory = if !self.adaptive_ram_growth_guard_enabled {
                 None
             } else {
-                Some(
-                    model
-                        .runtime()
-                        .memory_snapshot()
-                        .map_err(qwen3_5_runtime_error)?,
-                )
+                Some(capture_completed_forward_memory_observation(model)?)
             };
             let generated_token_emission = self.build_generated_token_emission(
                 model,
                 active_request,
                 queued_prediction_token_id,
-                mlx_memory_snapshot.as_ref(),
+                completed_forward_memory.as_ref(),
             )?;
             return if generated_token_emission.is_terminal {
                 Ok(ActiveRequestAdvance::Complete(
@@ -320,13 +326,8 @@ impl Qwen3_5EngineState {
                 .model
                 .as_ref()
                 .ok_or_else(|| fatal_engine_error("Qwen3.5 engine lost its loaded model"))?;
-            let mlx_memory_snapshot = if self.adaptive_ram_growth_guard_enabled {
-                Some(
-                    model
-                        .runtime()
-                        .memory_snapshot()
-                        .map_err(qwen3_5_runtime_error)?,
-                )
+            let completed_forward_memory = if self.adaptive_ram_growth_guard_enabled {
+                Some(capture_completed_forward_memory_observation(model)?)
             } else {
                 None
             };
@@ -334,7 +335,7 @@ impl Qwen3_5EngineState {
                 model,
                 active_request,
                 current_generated_token_id,
-                mlx_memory_snapshot.as_ref(),
+                completed_forward_memory.as_ref(),
             )?;
             return Ok(ActiveRequestAdvance::Complete(
                 generated_token_emission.generated_token,
@@ -407,7 +408,7 @@ impl Qwen3_5EngineState {
                 )
                 .map_err(InferenceEngineError::from)?;
         }
-        let mlx_memory_snapshot = collect_completed_forward_memory_snapshot(
+        let completed_forward_memory = collect_completed_forward_memory_snapshot(
             &mut self.adaptive_ram_growth_guard,
             adaptive_ram_growth_context
                 .with_sparse_experts_are_paged(model.sparse_experts_are_paged()),
@@ -423,7 +424,7 @@ impl Qwen3_5EngineState {
             model,
             active_request,
             current_generated_token_id,
-            mlx_memory_snapshot.as_ref(),
+            Some(&completed_forward_memory),
         )?;
         if generated_token_emission.is_terminal {
             Ok(ActiveRequestAdvance::Complete(

--- a/crates/model-serving/src/qwen3_5/inference_execution/completed_forward_memory.rs
+++ b/crates/model-serving/src/qwen3_5/inference_execution/completed_forward_memory.rs
@@ -28,6 +28,30 @@ use crate::{
 
 use super::qwen3_5_runtime_error;
 
+/// A memory observation whose raw MLX snapshot is captured at one owner-thread
+/// instant, before any learning or reclamation this path may trigger. The
+/// residency claim paired with this snapshot is derived from the reconciled
+/// breakdown of this exact snapshot at emission time, so a promotion or demote
+/// can never publish a claim that disagrees with its own measurement (issue
+/// #337).
+#[derive(Debug)]
+pub(in crate::qwen3_5) struct CompletedForwardMemoryObservation {
+    pub(in crate::qwen3_5) mlx_memory_snapshot: MlxMemorySnapshot,
+}
+
+/// Captures the raw MLX snapshot at one instant.
+pub(in crate::qwen3_5) fn capture_completed_forward_memory_observation(
+    model: &Qwen3_5Model,
+) -> Result<CompletedForwardMemoryObservation, InferenceEngineError> {
+    let mlx_memory_snapshot = model
+        .runtime()
+        .memory_snapshot()
+        .map_err(qwen3_5_runtime_error)?;
+    Ok(CompletedForwardMemoryObservation {
+        mlx_memory_snapshot,
+    })
+}
+
 /// Collects post-forward MLX telemetry and records adaptive learning when enabled.
 ///
 /// The returned snapshot is also used for user-visible memory telemetry. Returning
@@ -42,19 +66,20 @@ pub(in crate::qwen3_5) fn collect_completed_forward_memory_snapshot(
     retained_expert_payload_bytes_before_growth: u64,
     exact_temporary_workspace_bytes: usize,
     performance_attribution: &mut PerformanceAttribution,
-) -> Result<Option<MlxMemorySnapshot>, InferenceEngineError> {
-    let memory_snapshot_after_growth = performance_attribution.measure_operation(
+) -> Result<CompletedForwardMemoryObservation, InferenceEngineError> {
+    // The snapshot is captured under attribution so the published pair describes
+    // one instant: the residency claim is derived from this exact snapshot's
+    // reconciled breakdown when the emission is built. Learning and reclamation
+    // below may demote or retune expert ownership; the next observation captures
+    // that state on its own.
+    let observation = performance_attribution.measure_operation(
         PerformanceOperation::CompletedForwardMemorySnapshot,
-        |_performance_attribution| {
-            model
-                .runtime()
-                .memory_snapshot()
-                .map_err(qwen3_5_runtime_error)
-        },
+        |_performance_attribution| capture_completed_forward_memory_observation(model),
     )?;
     if active_memory_bytes_before_growth == usize::MAX {
-        return Ok(Some(memory_snapshot_after_growth));
+        return Ok(observation);
     }
+    let memory_snapshot_after_growth = observation.mlx_memory_snapshot;
 
     adaptive_ram_growth_guard.record_completed_growth_for_context(
         adaptive_ram_growth_context,
@@ -90,7 +115,9 @@ pub(in crate::qwen3_5) fn collect_completed_forward_memory_snapshot(
         );
         record_expert_reclamation_attribution(performance_attribution, budget_reclamation);
     }
-    Ok(Some(memory_snapshot_after_growth))
+    Ok(CompletedForwardMemoryObservation {
+        mlx_memory_snapshot: memory_snapshot_after_growth,
+    })
 }
 
 /// Records adaptive learning for a completed operation that needs no snapshot result.

--- a/crates/model-serving/src/qwen3_5/inference_execution/decode_expert_memory_handoff.rs
+++ b/crates/model-serving/src/qwen3_5/inference_execution/decode_expert_memory_handoff.rs
@@ -125,13 +125,20 @@ impl Qwen3_5EngineState {
                 }
             }
         }
-        let expert_residency = model.expert_residency_telemetry();
+        // Internal ownership log: this deliberately reports the retained cache's
+        // seated bookkeeping, not the published measured claim — the seating pass
+        // just enqueued these lazy pages and no snapshot is taken here.
+        let expert_statistics = model.expert_weight_memory_cache_statistics();
+        let total_layer_count = model
+            .expert_pager
+            .as_ref()
+            .map_or(0, |expert_pager| expert_pager.layer_count());
         tracing::info!(
             request_id = request_id.value(),
             context_token_count,
-            total_layer_count = expert_residency.total_layer_count,
-            resident_expert_count = expert_residency.resident_expert_count,
-            resident_expert_payload_bytes = expert_residency.resident_expert_payload_bytes,
+            total_layer_count,
+            resident_expert_count = expert_statistics.entry_count,
+            resident_expert_payload_bytes = expert_statistics.resident_payload_byte_count,
             "generation preparation seated leftover complete layers before decode"
         );
         Ok(())

--- a/crates/model-serving/src/qwen3_5/inference_execution/generated_token_emission.rs
+++ b/crates/model-serving/src/qwen3_5/inference_execution/generated_token_emission.rs
@@ -1,7 +1,8 @@
-use astronomical_runtime_integration::{MlxArray, MlxMemorySnapshot};
+use astronomical_runtime_integration::MlxArray;
 
 use crate::{GeneratedToken, InferenceEngineError, PerformanceCounter, PerformanceOperation};
 
+use super::completed_forward_memory::CompletedForwardMemoryObservation;
 use super::engine_request::Qwen3_5EngineRequest;
 use super::{Qwen3_5EngineState, fatal_engine_error, qwen3_5_runtime_error};
 use crate::qwen3_5::Qwen3_5Model;
@@ -27,7 +28,7 @@ impl Qwen3_5EngineState {
         model: &Qwen3_5Model,
         active_request: &mut Qwen3_5EngineRequest,
         generated_token_id: u32,
-        mlx_memory_snapshot: Option<&MlxMemorySnapshot>,
+        completed_forward_memory: Option<&CompletedForwardMemoryObservation>,
     ) -> Result<GeneratedTokenEmission, InferenceEngineError> {
         active_request.generated_token_count = active_request
             .generated_token_count
@@ -42,12 +43,23 @@ impl Qwen3_5EngineState {
 
         let is_terminal = self.end_of_sequence_token_ids.contains(&generated_token_id)
             || active_request.generated_token_count >= active_request.maximum_output_tokens;
-        let mlx_memory_telemetry = mlx_memory_snapshot
-            .map(|mlx_memory_snapshot| {
+        let mlx_memory_telemetry = completed_forward_memory
+            .map(|completed_forward_memory| {
+                let mlx_memory_snapshot = &completed_forward_memory.mlx_memory_snapshot;
                 let mlx_active_memory_bytes =
                     u64::try_from(mlx_memory_snapshot.active_memory_bytes()).map_err(|_| {
                         fatal_engine_error("MLX active memory bytes exceed the u64 range")
                     })?;
+                let active_memory_breakdown = model.active_memory_breakdown(
+                    &active_request.request_decoder_state,
+                    active_request.additional_context_state_payload_bytes(),
+                    mlx_active_memory_bytes,
+                    0,
+                );
+                // The breakdown reconciles the snapshot captured at one instant by
+                // the observation owner, and the residency claim is derived from
+                // that same breakdown, so this pair can never straddle a promotion
+                // or demote (issue #337).
                 Ok::<crate::MlxMemoryTelemetry, InferenceEngineError>(
                     crate::MlxMemoryTelemetry::new(
                         mlx_active_memory_bytes,
@@ -61,14 +73,11 @@ impl Qwen3_5EngineState {
                         u64::try_from(mlx_memory_snapshot.peak_memory_bytes()).map_err(|_| {
                             fatal_engine_error("MLX peak memory bytes exceed the u64 range")
                         })?,
-                        model.active_memory_breakdown(
-                            &active_request.request_decoder_state,
-                            active_request.additional_context_state_payload_bytes(),
-                            mlx_active_memory_bytes,
-                            0,
-                        ),
+                        active_memory_breakdown,
                     )
-                    .with_expert_residency_telemetry(model.expert_residency_telemetry()),
+                    .with_expert_residency_telemetry(
+                        model.expert_residency_telemetry_for_breakdown(&active_memory_breakdown),
+                    ),
                 )
             })
             .transpose()?;

--- a/crates/model-serving/src/qwen3_5/inference_execution/generation_finalization.rs
+++ b/crates/model-serving/src/qwen3_5/inference_execution/generation_finalization.rs
@@ -36,14 +36,21 @@ impl Qwen3_5EngineState {
             })?;
         let peak_memory_bytes = u64::try_from(mlx_memory_snapshot.peak_memory_bytes())
             .map_err(|_| super::fatal_engine_error("MLX peak memory bytes exceed the u64 range"))?;
+        let active_memory_breakdown =
+            model.finalized_active_memory_breakdown(active_memory_bytes, 0);
         Ok(Some(
             MlxMemoryTelemetry::new(
                 active_memory_bytes,
                 allocator_cache_memory_bytes,
                 peak_memory_bytes,
-                model.finalized_active_memory_breakdown(active_memory_bytes, 0),
+                active_memory_breakdown,
             )
-            .with_expert_residency_telemetry(model.expert_residency_telemetry()),
+            // The claim is derived from the breakdown reconciling this exact
+            // snapshot, so the published pair cannot straddle a promotion or
+            // demote (issue #337).
+            .with_expert_residency_telemetry(
+                model.expert_residency_telemetry_for_breakdown(&active_memory_breakdown),
+            ),
         ))
     }
 
@@ -171,7 +178,6 @@ impl Qwen3_5EngineState {
             return GenerationFinalization::default();
         };
         let expert_memory_mode = Some(model.expert_memory_mode());
-        let expert_residency_telemetry = Some(model.expert_residency_telemetry());
         let mlx_memory_telemetry = match performance_attribution.measure_operation(
             PerformanceOperation::FinalizedMlxMemorySnapshot,
             |_performance_attribution| model.runtime().memory_snapshot(),
@@ -185,18 +191,31 @@ impl Qwen3_5EngineState {
                     Ok(active_memory_bytes),
                     Ok(allocator_cache_memory_bytes),
                     Ok(peak_memory_bytes),
-                ) => Some(MlxMemoryTelemetry::new(
-                    active_memory_bytes,
-                    allocator_cache_memory_bytes,
-                    peak_memory_bytes,
-                    model.finalized_active_memory_breakdown(active_memory_bytes, 0),
-                )),
+                ) => {
+                    // The finalized claim derives from the breakdown reconciling
+                    // this exact snapshot, so the pair cannot straddle a
+                    // promotion or demote (issue #337).
+                    let active_memory_breakdown =
+                        model.finalized_active_memory_breakdown(active_memory_bytes, 0);
+                    let expert_residency_telemetry = Some(
+                        model.expert_residency_telemetry_for_breakdown(&active_memory_breakdown),
+                    );
+                    (
+                        Some(MlxMemoryTelemetry::new(
+                            active_memory_bytes,
+                            allocator_cache_memory_bytes,
+                            peak_memory_bytes,
+                            active_memory_breakdown,
+                        )),
+                        expert_residency_telemetry,
+                    )
+                }
                 memory_counter_results => {
                     tracing::warn!(
                         ?memory_counter_results,
                         "could not publish finalized MLX memory because a runtime counter exceeds the u64 range"
                     );
-                    None
+                    (None, None)
                 }
             },
             Err(memory_snapshot_error) => {
@@ -204,9 +223,10 @@ impl Qwen3_5EngineState {
                     error = %memory_snapshot_error,
                     "could not capture finalized MLX memory after expert residency recovery"
                 );
-                None
+                (None, None)
             }
         };
+        let (mlx_memory_telemetry, expert_residency_telemetry) = mlx_memory_telemetry;
         GenerationFinalization::new(
             expert_memory_mode,
             mlx_memory_telemetry,

--- a/crates/model-serving/src/qwen3_5/inference_execution/memory_limit.rs
+++ b/crates/model-serving/src/qwen3_5/inference_execution/memory_limit.rs
@@ -72,12 +72,22 @@ impl Qwen3_5EngineState {
         let peak_memory_bytes =
             u64::try_from(mlx_memory_snapshot_after_adjustment.peak_memory_bytes())
                 .map_err(|_| super::fatal_engine_error("MLX peak memory exceeds the u64 range"))?;
-        let mlx_memory_telemetry = Some(MlxMemoryTelemetry::new(
-            active_memory_bytes,
-            allocator_cache_memory_bytes,
-            peak_memory_bytes,
-            model.finalized_active_memory_breakdown(active_memory_bytes, 0),
-        ));
+        let active_memory_breakdown =
+            model.finalized_active_memory_breakdown(active_memory_bytes, 0);
+        // One claim serves both the telemetry and the adjustment event, derived
+        // from the breakdown of this exact snapshot so neither publication can
+        // straddle a promotion or demote (issue #337).
+        let expert_residency =
+            model.expert_residency_telemetry_for_breakdown(&active_memory_breakdown);
+        let mlx_memory_telemetry = Some(
+            MlxMemoryTelemetry::new(
+                active_memory_bytes,
+                allocator_cache_memory_bytes,
+                peak_memory_bytes,
+                active_memory_breakdown,
+            )
+            .with_expert_residency_telemetry(expert_residency),
+        );
         let expert_memory_mode = model.expert_memory_mode();
         let expert_residency_transition_occurred =
             expert_memory_mode != expert_memory_mode_before_adjustment;
@@ -107,6 +117,6 @@ impl Qwen3_5EngineState {
             expert_memory_mode,
             mlx_memory_telemetry,
         )
-        .with_expert_residency_telemetry(model.expert_residency_telemetry()))
+        .with_expert_residency_telemetry(expert_residency))
     }
 }

--- a/crates/model-serving/src/qwen3_5/inference_execution/mtp_decode_attempt.rs
+++ b/crates/model-serving/src/qwen3_5/inference_execution/mtp_decode_attempt.rs
@@ -156,7 +156,7 @@ impl Qwen3_5EngineState {
                 )?;
                 return Ok(None);
             }
-            let memory_snapshot = collect_completed_forward_memory_snapshot(
+            let memory_observation = collect_completed_forward_memory_snapshot(
                 &mut self.adaptive_ram_growth_guard,
                 growth_context.with_sparse_experts_are_paged(model.sparse_experts_are_paged()),
                 true,
@@ -170,7 +170,7 @@ impl Qwen3_5EngineState {
                 model,
                 active_request,
                 current_generated_token_id,
-                memory_snapshot.as_ref(),
+                Some(&memory_observation),
             )?;
             return Ok(Some(if emission.is_terminal {
                 ActiveRequestAdvance::Complete(emission.generated_token)

--- a/crates/model-serving/src/qwen3_5/inference_execution/prefill_advance.rs
+++ b/crates/model-serving/src/qwen3_5/inference_execution/prefill_advance.rs
@@ -426,6 +426,45 @@ impl Qwen3_5EngineState {
             prefill_chunck_elapsed_millis,
             "completed synchronous Qwen3.5 prompt-processing chunk"
         );
+        let mlx_memory_telemetry = mlx_memory_snapshot
+            .map(|mlx_memory_snapshot| {
+                let active_memory_bytes = u64::try_from(mlx_memory_snapshot.active_memory_bytes())
+                    .map_err(|_| {
+                        fatal_engine_error("MLX active memory bytes exceed the u64 range")
+                    })?;
+                let active_memory_breakdown = model.active_memory_breakdown(
+                    &active_request.request_decoder_state,
+                    active_request.additional_context_state_payload_bytes(),
+                    active_memory_bytes,
+                    0,
+                );
+                Ok::<crate::MlxMemoryTelemetry, InferenceEngineError>(
+                    crate::MlxMemoryTelemetry::new(
+                        active_memory_bytes,
+                        u64::try_from(mlx_memory_snapshot.allocator_cache_memory_bytes()).map_err(
+                            |_| {
+                                fatal_engine_error(
+                                    "MLX allocator-cache memory bytes exceed the u64 range",
+                                )
+                            },
+                        )?,
+                        u64::try_from(mlx_memory_snapshot.peak_memory_bytes()).map_err(|_| {
+                            fatal_engine_error("MLX peak memory bytes exceed the u64 range")
+                        })?,
+                        active_memory_breakdown,
+                    )
+                    // The claim derives from the breakdown of this exact snapshot
+                    // so the progress pair cannot straddle a promotion or demote
+                    // (issue #337).
+                    .with_expert_residency_telemetry(
+                        model.expert_residency_telemetry_for_breakdown(&active_memory_breakdown),
+                    ),
+                )
+            })
+            .transpose()?;
+        let expert_residency = mlx_memory_telemetry
+            .as_ref()
+            .and_then(|telemetry| telemetry.expert_residency_telemetry());
         Ok(Some(GeneratedToken::PrefillProgress {
             processed_token_count: prefill_token_count as u32,
             elapsed_millis: prefill_chunck_elapsed_millis,
@@ -433,37 +472,8 @@ impl Qwen3_5EngineState {
             completed_prefill_chunk_tokens: u32::try_from(prefill_token_count).map_err(|_| {
                 fatal_engine_error("completed_prefill_chunk_tokens exceeds the u32 range")
             })?,
-            mlx_memory_telemetry: mlx_memory_snapshot
-                .map(|mlx_memory_snapshot| {
-                    let active_memory_bytes =
-                        u64::try_from(mlx_memory_snapshot.active_memory_bytes()).map_err(|_| {
-                            fatal_engine_error("MLX active memory bytes exceed the u64 range")
-                        })?;
-                    Ok::<crate::MlxMemoryTelemetry, InferenceEngineError>(
-                        crate::MlxMemoryTelemetry::new(
-                            active_memory_bytes,
-                            u64::try_from(mlx_memory_snapshot.allocator_cache_memory_bytes())
-                                .map_err(|_| {
-                                    fatal_engine_error(
-                                        "MLX allocator-cache memory bytes exceed the u64 range",
-                                    )
-                                })?,
-                            u64::try_from(mlx_memory_snapshot.peak_memory_bytes()).map_err(
-                                |_| {
-                                    fatal_engine_error("MLX peak memory bytes exceed the u64 range")
-                                },
-                            )?,
-                            model.active_memory_breakdown(
-                                &active_request.request_decoder_state,
-                                active_request.additional_context_state_payload_bytes(),
-                                active_memory_bytes,
-                                0,
-                            ),
-                        ),
-                    )
-                })
-                .transpose()?,
-            expert_residency_telemetry: Some(model.expert_residency_telemetry()),
+            mlx_memory_telemetry,
+            expert_residency_telemetry: expert_residency,
             speculative_prefill_draft_memory_telemetry: active_request
                 .speculative_prefill_draft_memory_telemetry
                 .take(),

--- a/crates/model-serving/src/qwen3_5_moe/model/expert_memory_mode.rs
+++ b/crates/model-serving/src/qwen3_5_moe/model/expert_memory_mode.rs
@@ -1,13 +1,24 @@
 use astronomical_ipc_protocol::ExpertMemoryMode;
 
 use crate::ExpertResidencyTelemetry;
+use crate::MlxActiveMemoryBreakdown;
 use crate::classify_expert_memory_mode;
 use crate::qwen3_5::model::Qwen3_5Model;
 
 impl Qwen3_5Model {
-    /// Returns retained-expert count and payload for status and IPC.
+    /// Builds the residency claim from the reconciled breakdown of the same MLX
+    /// measurement. In paged mode the retained cache counts adopted lazy pages —
+    /// layers seated for ownership before their arrays are materialized by the
+    /// layer-interval eval — so its bookkeeping payload exceeds the physically
+    /// resident bytes during the seat-to-first-eval window. The only truthful
+    /// resident-payload figure is therefore the measured attribution from the
+    /// snapshot this breakdown reconciles (issue #337). Complete residency is
+    /// fully materialized by definition, so it keeps reporting owner figures.
     #[must_use]
-    pub(crate) fn expert_residency_telemetry(&self) -> ExpertResidencyTelemetry {
+    pub(crate) fn expert_residency_telemetry_for_breakdown(
+        &self,
+        mlx_memory_breakdown: &MlxActiveMemoryBreakdown,
+    ) -> ExpertResidencyTelemetry {
         let total_layer_count = self
             .expert_pager
             .as_ref()
@@ -35,7 +46,7 @@ impl Qwen3_5Model {
         ExpertResidencyTelemetry {
             total_layer_count: u32::try_from(total_layer_count).unwrap_or(u32::MAX),
             resident_expert_count: u32::try_from(expert_statistics.entry_count).unwrap_or(u32::MAX),
-            resident_expert_payload_bytes: expert_statistics.resident_payload_byte_count,
+            resident_expert_payload_bytes: mlx_memory_breakdown.expert_payload_bytes,
         }
     }
 

--- a/scripts/run-bounded-cargo-test.sh
+++ b/scripts/run-bounded-cargo-test.sh
@@ -13,12 +13,54 @@ print_error() {
     printf '%s\n' "Error: $1" >&2
 }
 
+# Scans the caller's arguments for libtest threading options. Real-model ignored
+# journeys each load model weights into wired GPU memory, so parallel journeys
+# multiply that demand past the machine's physical limit and hard-panic the whole
+# system. Reuses the global variables ignored_tests_requested and caller_test_threads.
+scan_test_threading_arguments() {
+    ignored_tests_requested=0
+    caller_test_threads=""
+    threads_value_is_pending=0
+    for argument in "$@"; do
+        if [ "$threads_value_is_pending" -eq 1 ]; then
+            caller_test_threads="$argument"
+            threads_value_is_pending=0
+            continue
+        fi
+        case "$argument" in
+            --ignored)
+                ignored_tests_requested=1
+                ;;
+            --test-threads=*)
+                caller_test_threads="${argument#--test-threads=}"
+                ;;
+            --test-threads)
+                threads_value_is_pending=1
+                ;;
+        esac
+    done
+}
+
+# Rejects parallel execution for ignored tests before any compilation starts.
+enforce_serial_ignored_tests() {
+    if [ "$ignored_tests_requested" -ne 1 ]; then
+        return
+    fi
+    if [ -n "$caller_test_threads" ] && [ "$caller_test_threads" != "1" ]; then
+        print_error "refusing to run ignored tests with --test-threads ${caller_test_threads}: each ignored test may load real model weights into wired GPU memory and parallel journeys exceed the machine's physical memory limit"
+        exit 2
+    fi
+}
+
 main() {
     if [ "$#" -lt 2 ] || [ "$1" != "cargo" ] || [ "$2" != "test" ]; then
         print_error "expected a cargo test command"
         exit 2
     fi
     shift 2
+
+    scan_test_threading_arguments "$@"
+    enforce_serial_ignored_tests
 
     if command -v timeout >/dev/null 2>&1; then
         timeout_executable="$(command -v timeout)"
@@ -34,6 +76,24 @@ main() {
     "${timeout_executable}" --foreground -k 5s "${COMPILE_TIMEOUT_SECONDS}s" \
         cargo test --no-run "$@"
     printf '%s\n' "[bounded-cargo-test] phase=compile status=success elapsed_seconds=$(( $(date +%s) - compile_started_at_seconds ))"
+
+    # Serial enforcement must mutate main's own positional parameters here: a
+    # set -- inside a function would only affect that function's scope. A caller
+    # cannot parallelize real-model ignored tests by omitting or reshaping args.
+    if [ "$ignored_tests_requested" -eq 1 ] && [ -z "$caller_test_threads" ]; then
+        printf '%s\n' "[bounded-cargo-test] phase=serial-enforcement status=enforced reason=ignored-tests-may-load-real-model-weights"
+        seen_argument_separator=0
+        for argument in "$@"; do
+            if [ "$argument" = "--" ]; then
+                seen_argument_separator=1
+            fi
+        done
+        if [ "$seen_argument_separator" -eq 1 ]; then
+            set -- "$@" "--test-threads=1"
+        else
+            set -- "$@" "--" "--test-threads=1"
+        fi
+    fi
 
     test_started_at_seconds="$(date +%s)"
     printf '%s\n' "[bounded-cargo-test] phase=test status=start timeout_seconds=${TEST_TIMEOUT_SECONDS} started_at=$(date '+%Y-%m-%dT%H:%M:%S%z')"


### PR DESCRIPTION
## Summary

Closes the residency-contradiction reporting thread of #337. In paged mode the published expert-residency claim and the measured MLX memory snapshot described two different contracts: the retained expert cache counts ownership (layers seated into retained RAM before the layer-interval eval materializes their arrays — a deliberate design that avoids double-syncing every seated layer), while the measurement counts physically materialized wired memory. During the post-wash re-seat window the claim reported the full seated payload while MLX held only a fraction.

The residency claim in paged mode now reports the reconciled breakdown's expert attribution, captured from the same MLX snapshot the claim is published with. The pairing is compiler-enforced: the telemetry builder takes the breakdown, so no caller can pair a bookkeeping payload with a measured snapshot. Every publication path (decode emissions, generation preparation, prefill progress, ceiling adjustments, finalization) builds its claim from its own snapshot's breakdown. Complete-residency mode keeps owner figures because it is fully materialized by definition.

## Evidence

- `should_settle_fully_resident_after_raising_the_memory_ceiling_mid_streaming_conversation` now passes and guards the pairing permanently.
- Full memory-management acceptance suite, run serially: 12 passed, 0 failed.
- During the previously violating re-seat window, status samples now read resident 23.555 GB → paged 4.294 GB → hybrid 3.423 GB → resident 23.555 GB with the claim and measurement agreeing at every observed sample.

## Also in this pull request

Test infrastructure hardening that came out of verifying this issue: the bounded test runner now rejects any ignored-test invocation requesting more than one test thread and injects `--test-threads=1` otherwise, so real-model journeys cannot be parallelized by callers. AGENTS.md records the structural guarantee and the live-output rule (raw output shown live; `tee` to a file is the only permitted pipe).

The wasteful post-settlement re-materialization cycle observed while investigating this issue is tracked separately in #339 with its own acceptance criteria.

## Linked issue

Fixes #337

## Verification

- `scripts/verify-before-commit.sh`: 17/17 steps passed, zero warnings.
- Memory-management acceptance suite serial run: 12/12 journeys passed.
