### PR TITLE
Resync tool-call parsing when quoted prose markers hijack the parser

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@
 
 - When overseeing GitHub Actions builds (CI runs, PR checks, post-merge verification), poll at intervals of at most 10 seconds so the result is noticed the moment it lands instead of waiting on a long sleep between checks. Use a bounded number of polls so a stuck run still reports back.
 
-- MLX/GPU acceptance journeys must never run in parallel. Each journey loads model weights into wired GPU memory, so concurrent journeys multiply that demand past the machine's physical limit and can hard-panic the whole system (watchdog starvation → forced power-off). This is enforced structurally: `scripts/run-bounded-cargo-test.sh` rejects any ignored-test invocation that asks for more than one test thread and injects `--test-threads=1` otherwise, so callers cannot parallelize real-model journeys. Confirm no other Astronomical instance is holding a resident model before starting.
+- MLX/GPU acceptance journeys must never run in parallel. Each journey loads model weights into wired GPU memory, so concurrent journeys multiply that demand past the machine's physical limit and can hard-panic the whole system (watchdog starvation → forced power-off). This is enforced structurally: `scripts/run-bounded-cargo-test.sh` rejects any ignored-test invocation that asks for more than one test thread and injects `--test-threads=1` otherwise, so callers cannot parallelize real-model journeys. Confirm no other Astronomical instance is holding a resident model before starting. Test threads = 1 is not applicable for hermetic tests, those can be parallelized safely since they use CPU only.
 
 - All and any tests must have a built in timeout with a maximum of 120 seconds. Exceptions can be made for tests that deal with performance endurance tests and/or reproducing OOM issues.
 

--- a/crates/model-serving/src/qwen3_5/text/output_parser.rs
+++ b/crates/model-serving/src/qwen3_5/text/output_parser.rs
@@ -2,7 +2,10 @@
 //!
 //! Dense and mixture-of-experts share this parser. Tool-call defects fail open so a
 //! coding client can reject or retry. Incomplete control-marker prefixes flush as
-//! visible text at generation end instead of aborting the stream.
+//! visible text at generation end instead of aborting the stream. Tool-call markers
+//! quoted inside model prose (a coding model discussing tool syntax) must not hijack
+//! the state machine: a think close inside a tool-call body proves the opener was
+//! prose, so the parser restores the buffered text to its origin channel and resumes.
 
 use std::collections::BTreeMap;
 
@@ -206,7 +209,7 @@ impl Qwen3_5OutputParser {
                 return Ok(true);
             }
             self.take_pending_prefix(marker.len());
-            self.enter_state_after_start_marker(marker);
+            self.enter_state_after_start_marker(marker, false);
             return Ok(true);
         }
 
@@ -243,7 +246,7 @@ impl Qwen3_5OutputParser {
             if marker == THINK_END_MARKER {
                 self.state = Qwen3_5OutputParserState::Text;
             } else {
-                self.enter_state_after_start_marker(marker);
+                self.enter_state_after_start_marker(marker, true);
             }
             return Ok(true);
         }
@@ -289,11 +292,25 @@ impl Qwen3_5OutputParser {
     fn advance_tool_call(
         &mut self,
         output_events: &mut Vec<Qwen3_5OutputEvent>,
-        entry: ToolCallEntryKind,
+        entry: ToolCallEntry,
     ) -> Result<bool, Qwen3_5OutputParserError> {
-        let Some((marker_index, end_marker)) =
-            earliest_marker(&self.pending_output, salvage::tool_call_end_markers(entry))
-        else {
+        let end_marker_match = earliest_marker(
+            &self.pending_output,
+            salvage::tool_call_end_markers(entry.kind),
+        );
+        let spurious_think_close_index = self.pending_output.find(THINK_END_MARKER);
+        let opener_was_quoted_prose = match (end_marker_match, spurious_think_close_index) {
+            (Some((end_marker_index, _)), Some(think_close_index)) => {
+                think_close_index < end_marker_index
+            }
+            (None, Some(_)) => true,
+            _ => false,
+        };
+        if opener_was_quoted_prose {
+            self.resync_spurious_tool_call(output_events, entry);
+            return Ok(true);
+        }
+        let Some((marker_index, end_marker)) = end_marker_match else {
             return Ok(false);
         };
         let remaining_body = self.take_pending_prefix(marker_index);
@@ -301,7 +318,7 @@ impl Qwen3_5OutputParser {
         if end_marker != TOOL_CALL_END_MARKER {
             self.consume_trailing_envelope_close_if_present();
         }
-        let reconstructed_body = salvage::reconstruct_tool_call_body(entry, &remaining_body);
+        let reconstructed_body = salvage::reconstruct_tool_call_body(entry.kind, &remaining_body);
         // Closed envelopes fail open: the harness owns retries.
         match self.parse_tool_call(&reconstructed_body) {
             Ok(tool_call) => {
@@ -326,6 +343,31 @@ impl Qwen3_5OutputParser {
         }
         self.state = Qwen3_5OutputParserState::Text;
         Ok(true)
+    }
+
+    /// A think close inside a tool-call body proves the opener was quoted prose:
+    /// a real tool-call body cannot contain a think close. Restore the opener and
+    /// the buffered text to the origin channel, consume the marker, and resume
+    /// channel scanning so a real tool call later in the generation still arrives.
+    fn resync_spurious_tool_call(
+        &mut self,
+        output_events: &mut Vec<Qwen3_5OutputEvent>,
+        entry: ToolCallEntry,
+    ) {
+        let think_close_index = self
+            .pending_output
+            .find(THINK_END_MARKER)
+            .expect("resync requires a think close already found in the pending output");
+        let buffered_body = self.take_pending_prefix(think_close_index);
+        self.take_pending_prefix(THINK_END_MARKER.len());
+        let restored_prose = format!("{}{buffered_body}", entry.opener);
+        if entry.opened_in_reasoning {
+            output_events.push(Qwen3_5OutputEvent::ReasoningDelta(restored_prose));
+        } else {
+            self.has_streamed_visible_text = true;
+            output_events.push(Qwen3_5OutputEvent::TextDelta(restored_prose));
+        }
+        self.state = Qwen3_5OutputParserState::Text;
     }
 
     fn parse_tool_call(
@@ -372,7 +414,7 @@ impl Qwen3_5OutputParser {
         }))
     }
 
-    fn enter_state_after_start_marker(&mut self, marker: &str) {
+    fn enter_state_after_start_marker(&mut self, marker: &'static str, opened_in_reasoning: bool) {
         self.state = match marker {
             THINK_START_MARKER => {
                 if self.has_streamed_visible_text {
@@ -381,13 +423,21 @@ impl Qwen3_5OutputParser {
                     Qwen3_5OutputParserState::Reasoning
                 }
             }
-            TOOL_CALL_START_MARKER => {
-                Qwen3_5OutputParserState::ToolCall(ToolCallEntryKind::Envelope)
-            }
-            BARE_FUNCTION_START_MARKER => {
-                Qwen3_5OutputParserState::ToolCall(ToolCallEntryKind::BareFunction)
-            }
-            INVOKE_START_MARKER => Qwen3_5OutputParserState::ToolCall(ToolCallEntryKind::InvokeTag),
+            TOOL_CALL_START_MARKER => Qwen3_5OutputParserState::ToolCall(ToolCallEntry {
+                kind: ToolCallEntryKind::Envelope,
+                opener: TOOL_CALL_START_MARKER,
+                opened_in_reasoning,
+            }),
+            BARE_FUNCTION_START_MARKER => Qwen3_5OutputParserState::ToolCall(ToolCallEntry {
+                kind: ToolCallEntryKind::BareFunction,
+                opener: BARE_FUNCTION_START_MARKER,
+                opened_in_reasoning,
+            }),
+            INVOKE_START_MARKER => Qwen3_5OutputParserState::ToolCall(ToolCallEntry {
+                kind: ToolCallEntryKind::InvokeTag,
+                opener: INVOKE_START_MARKER,
+                opened_in_reasoning,
+            }),
             _ => Qwen3_5OutputParserState::Text,
         };
     }
@@ -449,8 +499,18 @@ impl Qwen3_5OutputParser {
 enum Qwen3_5OutputParserState {
     Text,
     Reasoning,
-    ToolCall(ToolCallEntryKind),
+    ToolCall(ToolCallEntry),
     SuppressedLateReasoning,
+}
+
+/// One entered tool-call attempt: its dialect kind, the exact opener marker to
+/// restore when the attempt turns out to be quoted prose, and the channel the
+/// opener appeared in.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct ToolCallEntry {
+    kind: ToolCallEntryKind,
+    opener: &'static str,
+    opened_in_reasoning: bool,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/crates/model-serving/src/qwen3_5/text/output_parser/salvage.rs
+++ b/crates/model-serving/src/qwen3_5/text/output_parser/salvage.rs
@@ -13,7 +13,7 @@ use super::{
 impl Qwen3_5OutputParser {
     pub(super) fn salvage_unclosed_tool_call(&mut self) -> Vec<Qwen3_5OutputEvent> {
         let entry = match self.state {
-            Qwen3_5OutputParserState::ToolCall(entry) => entry,
+            Qwen3_5OutputParserState::ToolCall(entry) => entry.kind,
             _ => ToolCallEntryKind::Envelope,
         };
         let remaining_body = std::mem::take(&mut self.pending_output);
@@ -21,9 +21,21 @@ impl Qwen3_5OutputParser {
         let tool_call_body = reconstruct_tool_call_body(entry, &remaining_body);
         match self.fail_open_closed_tool_call(&tool_call_body) {
             Some(salvaged_event) => {
+                log_salvaged_unclosed_tool_call(
+                    self.parse_tool_call(&tool_call_body).err().as_ref(),
+                    &tool_call_body,
+                    Some(&salvaged_event),
+                );
                 vec![self.emit_tool_call_or_visible_text(salvaged_event, tool_call_body)]
             }
-            None => Vec::new(),
+            None => {
+                log_salvaged_unclosed_tool_call(
+                    self.parse_tool_call(&tool_call_body).err().as_ref(),
+                    &tool_call_body,
+                    None,
+                );
+                Vec::new()
+            }
         }
     }
 
@@ -53,6 +65,32 @@ impl Qwen3_5OutputParser {
         self.completed_tool_call_count = next_completed_tool_call_count;
         true
     }
+}
+
+/// Salvaging drops the pending call from the state machine without the closed-path
+/// warning, so this log is the only production signal that a generation ended with
+/// an unclosed tool-call attempt.
+pub(super) fn log_salvaged_unclosed_tool_call(
+    parser_error: Option<&Qwen3_5OutputParserError>,
+    tool_call_body: &str,
+    salvaged_event: Option<&Qwen3_5OutputEvent>,
+) {
+    let (function_name, forwarded_arguments_json) = match salvaged_event {
+        Some(Qwen3_5OutputEvent::ToolCall(tool_call)) => (
+            tool_call.function_name.as_str(),
+            tool_call.arguments_json.as_str(),
+        ),
+        _ => ("", ""),
+    };
+    tracing::warn!(
+        diagnostic_code = parser_error
+            .map(Qwen3_5OutputParserError::diagnostic_code)
+            .unwrap_or("unclosed_tool_call"),
+        function_name,
+        forwarded_arguments_json,
+        unclosed_tool_call_body = bounded_fail_open_log_body(tool_call_body),
+        "salvaged unclosed Qwen3.5 tool call"
+    );
 }
 
 pub(super) fn log_fail_open_closed_tool_call(

--- a/crates/model-serving/tests/qwen3_5_hermetic/output_parser/mod.rs
+++ b/crates/model-serving/tests/qwen3_5_hermetic/output_parser/mod.rs
@@ -20,6 +20,7 @@ mod foreign_dialect;
 mod happy_path_permutations;
 mod marker_permutations;
 mod permissive_arguments;
+mod prose_marker_hijack;
 mod reasoning;
 mod schema_forms;
 mod support;

--- a/crates/model-serving/tests/qwen3_5_hermetic/output_parser/prose_marker_hijack.rs
+++ b/crates/model-serving/tests/qwen3_5_hermetic/output_parser/prose_marker_hijack.rs
@@ -1,0 +1,64 @@
+//! Tool-call markers quoted inside model prose must not hijack the parser.
+//!
+//! A quantized coding model that discusses tool-calling infrastructure quotes
+//! markers like `<invoke name=...>` inside its reasoning. The parser must treat
+//! the quoted opener as prose, stream the reasoning, and still deliver the
+//! model's real tool call that follows the think close.
+
+use super::support::{DECLARED_CHARACTER_FUNCTION, ROMEO_ARGUMENTS_JSON, literary_declared_tools};
+use super::{THINK_END, TOOL_CALL_END, TOOL_CALL_START};
+use astronomical_model_serving::{Qwen3_5OutputEvent, Qwen3_5OutputParser};
+
+#[test]
+fn should_resync_when_quoted_prose_markers_hijack_the_tool_call_state() {
+    let mut parser = Qwen3_5OutputParser::new_after_thinking_prefix(&literary_declared_tools())
+        .expect("Romeo and Juliet literary tools should construct a Qwen3.5 parser");
+
+    let reasoning_prose = "The diffstat shows the consolidation. The normalizer rewrites \
+markers like `<invoke name=...>` into the Qwen grammar before parsing. Let me verify the wiring.";
+    let mut events = parser
+        .push_fragment(reasoning_prose)
+        .expect("reasoning prose must not abort");
+
+    let remainder = format!(
+        "{THINK_END}\nNow let me isolate the shipped changes.\n\
+{TOOL_CALL_START}\n<function=find_character>\n<parameter=name>Romeo</parameter>\n{TOOL_CALL_END}\n"
+    );
+    events.extend(parser.push_fragment(&remainder).expect("remainder"));
+    events.extend(parser.finish().expect("finish"));
+
+    let tool_calls: Vec<_> = events
+        .iter()
+        .filter_map(|event| match event {
+            Qwen3_5OutputEvent::ToolCall(tool_call) => Some(tool_call),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        tool_calls.len(),
+        1,
+        "exactly the real tool call must reach the harness as a structured call; events: {events:?}"
+    );
+    assert_eq!(tool_calls[0].function_name, DECLARED_CHARACTER_FUNCTION);
+    assert_eq!(tool_calls[0].arguments_json, ROMEO_ARGUMENTS_JSON);
+
+    for event in &events {
+        if let Qwen3_5OutputEvent::TextDelta(text) = event {
+            assert!(
+                !text.contains(TOOL_CALL_START),
+                "tool-call marker leaked as visible text: {text:?}"
+            );
+            assert!(
+                !text.contains(THINK_END),
+                "think-close marker leaked as visible text: {text:?}"
+            );
+        }
+    }
+    assert!(
+        events.iter().any(|event| matches!(
+            event,
+            Qwen3_5OutputEvent::ReasoningDelta(text) if text.contains("<invoke name=...>")
+        )),
+        "the hijacked reasoning prose must still stream as reasoning; events: {events:?}"
+    );
+}


### PR DESCRIPTION
## Goal

Close #346. A coding client must receive the model real tool call as a structured tool call even when the same generation quotes tool-call syntax inside its reasoning or visible text. Generation must never abort; the harness owns rejection and retry.

## What changed

The shared Qwen3.5 output parser committed to tool-call state on any bare start marker, including one the model quoted inside prose. A think-close marker later in the stream then proved the opener was quoted prose, but nothing ended the spurious call: everything after it, including the think close and the real tool call, buffered as one spurious body and was dumped as a single text delta at generation end.

While inside a buffered tool-call body, the parser now also tracks the think-close marker. Seeing it before any dialect end marker is unambiguous proof the opener was quoted prose (a real call body cannot contain a think close). The parser restores the opener and the buffered text to their origin channel (reasoning delta or visible text), resumes channel scanning after the marker, and parses any real tool call that follows. The unclosed-call salvage path now emits a bounded warning diagnostic under the existing diagnostic-code convention on both salvage routes.

A small documentation clarification is included: the one-test-thread guard exists to keep GPU journeys from multiplying wired model weights, and hermetic CPU-only tests may keep using parallel test threads.

## Verification

- New hermetic reproduction test (Romeo and Juliet fixture, declared literary tools) is red on the shipped logic and green with this change: exactly one structured tool call reaches the harness, markers do not leak into visible text deltas, and the reasoning streams as reasoning.
- Existing hermetic suites stay green: closed-envelope fail-open (#292), unclosed salvage without abort (#305), and foreign dialects plus calls inside open thinking (#317).
- Local commit gate passed: formatting, repository contracts, and the required Rust boundaries (17/17 steps).

## Out of scope (unchanged)

Chat-template changes, sampling, REST fields, Laguna and Poolside parsing, and stricter entry validation beyond the existing foreign-syntax normalization path.

Fixes #346

## Linked issue

Fixes #346
