### PR TITLE
release: activate v0.2.26 update feed

### DIFF
--- a/site/appcast.xml
+++ b/site/appcast.xml
@@ -4,39 +4,32 @@ IMPORTANT: This file was signed by Sparkle. Any modifications to this file requi
     <channel>
         <title>Astronomical</title>
         <item>
-            <title>0.2.25</title>
-            <pubDate>Sun, 30 Aug 2026 16:50:07 -0400</pubDate>
-            <sparkle:version>384</sparkle:version>
-            <sparkle:shortVersionString>0.2.25</sparkle:shortVersionString>
+            <title>0.2.26</title>
+            <pubDate>Sun, 30 Aug 2026 22:24:59 -0400</pubDate>
+            <sparkle:version>387</sparkle:version>
+            <sparkle:shortVersionString>0.2.26</sparkle:shortVersionString>
             <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
             <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
-            <description sparkle:format="markdown"><![CDATA[## Astronomical 0.2.25
-
-A stability-focused release consolidating correctness fixes in expert-residency reporting and visual prompt-cache restoration, plus a reorganized acceptance suite that guards those behaviors.
+            <description sparkle:format="markdown"><![CDATA[## Astronomical 0.2.26
 
 ### Fixed
 
-- **Visual prompt-cache restore correctness (#336)**: restoring a cached visual prompt could change the first generated token of the resumed conversation. The restore path now preserves the exact first-token behavior.
-- **Honest expert-residency reporting (#337, #340)**: the expert-residency claim and the measured MLX memory snapshot now agree at every observed instant, including during live memory-ceiling changes while a conversation streams. Previously the claim could report the full seated expert payload while MLX held only a fraction of it. The pairing is enforced structurally in the serving engine and guarded by a permanent acceptance journey.
-
-### Improved
-
-- **Bounded tool-call completion log (#333)**: emitted tool calls are recorded in a bounded completion log, improving observability for agent-style sessions.
-- **Acceptance suite reorganization (#338, towards #334)**: real-model qualification journeys consolidated one per outcome, with hermetic discovery contracts. The full memory-management acceptance suite passes 12/12 serially, and real-model GPU journeys are now structurally guaranteed to run one at a time.
-- Agent instructions now bound CI oversight polling to ten-second intervals.
+- Tool calls from quantized Qwen3.5 models now survive generations that quote tool-call syntax inside reasoning or summary prose. A think-close marker inside a buffered tool-call body is treated as proof the opener was quoted; the quoted span returns to its origin channel (reasoning or visible text) and the model's real tool call that follows arrives as a structured tool call instead of literal text. (#346)
+- Salvaging an unclosed tool call now emits a bounded warning diagnostic, so unstructured output is observable instead of silent. (#346)
 
 ### Compatibility
 
-- macOS 26.0 or newer on Apple Silicon (arm64). No configuration migration required; existing user state and persistent prompt caches are preserved.
+- No REST API, configuration, or model-catalog changes. Client behavior is unchanged for generations that do not quote tool-call markers.
+- Saved conversations, model library state, and prompt caches are preserved by this update.
 
 ### Distribution
 
-- The app is Developer ID signed with Hardened Runtime, notarized by Apple, and delivered through a signed Sparkle update feed.
+- Signed, notarized macOS arm64 DMG with Hardened Runtime; Sparkle-signed update feed with Ed25519 enclosure signatures.
 ]]></description>
-            <enclosure url="https://github.com/aosama/astronomical/releases/download/v0.2.25/Astronomical-0.2.25-macOS-arm64.dmg" length="15787274" type="application/octet-stream" sparkle:edSignature="awxWaSwW8d/+lr/HQzCQpDhm2aE71w2DqYI2L098D1iigGLecR0G/BoOiOAsu+khICrwQ3qPpL7Mw/wHD6LxCQ=="></enclosure>
+            <enclosure url="https://github.com/aosama/astronomical/releases/download/v0.2.26/Astronomical-0.2.26-macOS-arm64.dmg" length="15771441" type="application/octet-stream" sparkle:edSignature="JBSLQX2RD8xe51gqwiwp+aqAafQboDKJVAD6bA3aHAv1N2GJ+WOJkEhDUXBTLgXpOEtcNVkhivK31cbCjMZDAw=="></enclosure>
         </item>
     </channel>
 </rss><!-- sparkle-signatures:
-edSignature: K8kB9l7FC1yMjl9aXNLCq8PZy5EHNTZ+23R2LBbSj52TsRziHkaZxzes9J/c7poNgv25A/7ek3pk10n2/vGaDg==
-length: 2986
+edSignature: KDsNAgGZXGvr4/dlZwWFmzTGLkrAFhcRV5oOaF0rpXJQqENahVVg5+OC4m5wWSUmvuOFTWuYVDCZZWUVoK3aBQ==
+length: 2200
 -->


### PR DESCRIPTION
## Goal

Activate the signed Sparkle update feed for Astronomical Stable 0.2.26. The tag is pushed and the public DMG release is already published; this pull request replaces the active Pages appcast with the signed feed advertising 0.2.26 (build 387).

The committed appcast is byte-identical to the prepared artifact in the release evidence directory, carries an Ed25519 enclosure signature and a signed-feed envelope, and was proven by the isolated Sparkle update acceptance journey plus the full local commit gate.

## Linked issue

Fixes #348
