### PR TITLE
Update locked crc32fast dependency to 1.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -526,9 +526,9 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+checksum = "8498c871161e1742aaa9d52551b2d6ebdd4c3d45a3be423e3728f33b955be550"
 dependencies = [
  "cfg-if",
 ]

--- a/third-party/RUST_DEPENDENCY_NOTICES
+++ b/third-party/RUST_DEPENDENCY_NOTICES
@@ -2157,7 +2157,7 @@ Used by:
 Apache License 2.0
 
 Used by:
-- crc32fast 1.5.0
+- crc32fast 1.5.1
 - derive_builder 0.20.2
 - derive_builder_core 0.20.2
 - derive_builder_macro 0.20.2


### PR DESCRIPTION
## Linked issue

Closes #352

## Summary

Updates the locked `crc32fast` dependency from 1.5.0 to 1.5.1 in `Cargo.lock` and regenerates `third-party/RUST_DEPENDENCY_NOTICES` so the notices check passes.

crc32fast 1.5.1 is a performance-oriented patch release from upstream: widened x86 SIMD folding, a new 3-way ARM folding path, and faster small-input handling. The crate participates in compression and artifact I/O paths on the model-loading critical path.

## Changes

- `Cargo.lock`: `crc32fast` 1.5.0 → 1.5.1
- `third-party/RUST_DEPENDENCY_NOTICES`: version entry updated

## Verification

- `scripts/generate-rust-dependency-notices.sh --check` reports the checked-in notices are current.
- `scripts/verify-before-commit.sh` passes all 17 steps, including formatted sources, repository contracts, macOS menu and Observatory contracts, and the full hermetic plus REST API Rust boundaries (1,423 tests, 0 failures).