### PR TITLE
Bump workspace version to 0.2.28

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,7 +39,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "astronomical-config"
-version = "0.2.27"
+version = "0.2.28"
 dependencies = [
  "libc",
  "serde",
@@ -52,7 +52,7 @@ dependencies = [
 
 [[package]]
 name = "astronomical-experimental-aligned-expert-packs"
-version = "0.2.27"
+version = "0.2.28"
 dependencies = [
  "astronomical-config",
  "astronomical-model-serving",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "astronomical-inference-worker"
-version = "0.2.27"
+version = "0.2.28"
 dependencies = [
  "astronomical-config",
  "astronomical-ipc-protocol",
@@ -92,7 +92,7 @@ dependencies = [
 
 [[package]]
 name = "astronomical-ipc-protocol"
-version = "0.2.27"
+version = "0.2.28"
 dependencies = [
  "base64 0.23.1",
  "bytes",
@@ -108,7 +108,7 @@ dependencies = [
 
 [[package]]
 name = "astronomical-model-serving"
-version = "0.2.27"
+version = "0.2.28"
 dependencies = [
  "astronomical-config",
  "astronomical-ipc-protocol",
@@ -131,7 +131,7 @@ dependencies = [
 
 [[package]]
 name = "astronomical-rest-contract"
-version = "0.2.27"
+version = "0.2.28"
 dependencies = [
  "base64 0.23.1",
  "serde",
@@ -141,7 +141,7 @@ dependencies = [
 
 [[package]]
 name = "astronomical-runtime-integration"
-version = "0.2.27"
+version = "0.2.28"
 dependencies = [
  "bindgen",
  "fs4",
@@ -153,7 +153,7 @@ dependencies = [
 
 [[package]]
 name = "astronomical-supervisor"
-version = "0.2.27"
+version = "0.2.28"
 dependencies = [
  "astronomical-config",
  "astronomical-ipc-protocol",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ license = "Apache-2.0"
 publish = false
 repository = "https://github.com/aosama/astronomical"
 rust-version = "1.97.1"
-version = "0.2.27"
+version = "0.2.28"
 
 [workspace.dependencies]
 async-openai = { version = "0.41.3", default-features = false, features = ["byot", "chat-completion"] }


### PR DESCRIPTION
# Bump workspace version to 0.2.28

## Linked issue

Refs #378

## What changed

- `[workspace.package].version` in `Cargo.toml` moves from `0.2.27` to `0.2.28`.
- `cargo update --workspace` rewrote only the eight `astronomical-*` workspace package versions in `Cargo.lock`; no third-party dependency changed.
- Release notes for 0.2.28 were prepared covering the kernel-capability fallback serving, decode-time hot-expert caching, plan-composed retained-ceiling enforcement, and the SpecPrefill drafter journey fixes proven by `v0.2.27..HEAD`.

## Verification

- `scripts/release/tests/test-release-contracts.sh`: 240 successful cases, 0 failures.
- `scripts/verify-before-commit.sh`: 18/18 steps green.