### PR TITLE
Add the App Store build channel to the macOS packaging pipeline

### DIFF
--- a/apps/astronomical-menu/Sources/AstronomicalMenuCore/ApplicationIdentity.swift
+++ b/apps/astronomical-menu/Sources/AstronomicalMenuCore/ApplicationIdentity.swift
@@ -3,17 +3,26 @@ import Foundation
 public enum ApplicationChannel: String, Equatable, Sendable {
   case stable
   case development
+  case appStore = "app-store"
 
-  var displayName: String { self == .stable ? "Stable" : "Development" }
-  var stateDirectoryName: String { self == .stable ? ".astronomical" : ".astronomical-dev" }
-  var defaultSupervisorPort: Int { self == .stable ? 6732 : 6733 }
+  // The App Store build is the Stable product distributed through the store,
+  // so it presents the Stable product identity.
+  var displayName: String { self == .development ? "Development" : "Stable" }
+  var stateDirectoryName: String? {
+    switch self {
+    case .stable: ".astronomical"
+    case .development: ".astronomical-dev"
+    case .appStore: nil
+    }
+  }
+  var defaultSupervisorPort: Int { self == .development ? 6733 : 6732 }
 }
 
 /// Immutable application identity injected by the app bundle and shared by every local boundary.
 struct ApplicationIdentity: Equatable, Sendable {
   let channel: ApplicationChannel
   let supervisorPort: Int
-  let stateDirectoryName: String
+  let stateDirectoryName: String?
   let version: String
   let buildNumber: String
   let commit: String
@@ -43,7 +52,19 @@ struct ApplicationIdentity: Equatable, Sendable {
   }
 
   func stateDirectoryURL(homeDirectoryURL: URL = FileManager.default.homeDirectoryForCurrentUser) -> URL {
-    homeDirectoryURL.appendingPathComponent(stateDirectoryName, isDirectory: true)
+    guard let stateDirectoryName else {
+      // App Store builds carry no state-directory name: their state root is the
+      // platform-standard Application Support directory, which the App Sandbox
+      // maps into the app container. The name matches the config crate's
+      // APPLICATION_SUPPORT_STABLE_DIRECTORY_NAME so both sides agree.
+      return Self.applicationSupportDirectoryURL(homeDirectoryURL: homeDirectoryURL)
+        .appendingPathComponent("Astronomical", isDirectory: true)
+    }
+    return homeDirectoryURL.appendingPathComponent(stateDirectoryName, isDirectory: true)
+  }
+
+  static func applicationSupportDirectoryURL(homeDirectoryURL: URL) -> URL {
+    homeDirectoryURL.appendingPathComponent("Library/Application Support", isDirectory: true)
   }
 
   func configFileURL(homeDirectoryURL: URL = FileManager.default.homeDirectoryForCurrentUser) -> URL {
@@ -54,11 +75,21 @@ struct ApplicationIdentity: Equatable, Sendable {
     stateDirectoryURL(homeDirectoryURL: homeDirectoryURL).appendingPathComponent("menu-owned-daemon.json")
   }
 
-  var daemonArguments: [String] { ["--instance", channel.rawValue] }
+  var daemonArguments: [String] {
+    // The App Store build runs the Stable runtime instance; the compiled
+    // app-store-state-root feature redirects its default state location.
+    ["--instance", channel == .development ? "development" : "stable"]
+  }
 
   /// Public status uses a privacy-safe home-relative label instead of exposing
-  /// the user's absolute home directory.
-  var expectedServerStateDirectory: String { "~/\(stateDirectoryName)" }
+  /// the user's absolute home directory. App Store builds live beneath the
+  /// platform-standard Application Support directory.
+  var expectedServerStateDirectory: String {
+    guard let stateDirectoryName else {
+      return "~/Library/Application Support/Astronomical"
+    }
+    return "~/\(stateDirectoryName)"
+  }
 
   var expectedConfigurationFile: String { "\(expectedServerStateDirectory)/config.json" }
 

--- a/apps/astronomical-menu/Sources/AstronomicalMenuCore/OrbitalTelemetryPopover.swift
+++ b/apps/astronomical-menu/Sources/AstronomicalMenuCore/OrbitalTelemetryPopover.swift
@@ -196,7 +196,7 @@ struct OrbitalTelemetryPopover: View {
             .font(.caption)
             .foregroundStyle(.orange)
         }
-        Text("Config: ~/\(applicationIdentity.stateDirectoryName)/config.json · Port \(applicationIdentity.supervisorPort)")
+        Text("Config: \(applicationIdentity.expectedConfigurationFile) · Port \(applicationIdentity.supervisorPort)")
           .font(.caption)
           .foregroundStyle(.secondary)
       }

--- a/apps/astronomical-menu/tests/AstronomicalMenuContractTests/AppStoreChannelIdentityTests.swift
+++ b/apps/astronomical-menu/tests/AstronomicalMenuContractTests/AppStoreChannelIdentityTests.swift
@@ -1,0 +1,70 @@
+// Pins the App Store channel identity: Stable product presentation, Stable
+// runtime instance, and Application Support state roots that the sandbox maps
+// into the app container.
+
+import Foundation
+import XCTest
+
+@testable import AstronomicalMenuCore
+
+@MainActor
+final class AppStoreChannelIdentityTests: XCTestCase {
+  private func appStoreIdentity() -> ApplicationIdentity {
+    ApplicationIdentity(
+      channel: .appStore,
+      supervisorPort: 6732,
+      stateDirectoryName: nil,
+      version: "0.3.0",
+      buildNumber: "500",
+      commit: "fixturecommit",
+      isDirty: false
+    )
+  }
+
+  func test_should_present_the_stable_product_identity_for_app_store_builds() {
+    XCTAssertEqual(appStoreIdentity().channel.displayName, "Stable")
+  }
+
+  func test_should_run_the_stable_runtime_instance_on_app_store_builds() {
+    XCTAssertEqual(appStoreIdentity().daemonArguments, ["--instance", "stable"])
+  }
+
+  func test_should_derive_app_store_state_from_the_application_support_directory() {
+    let fictionalHomeDirectory = URL(fileURLWithPath: "/Users/example", isDirectory: true)
+
+    let stateDirectoryURL = appStoreIdentity().stateDirectoryURL(
+      homeDirectoryURL: fictionalHomeDirectory)
+
+    XCTAssertEqual(
+      stateDirectoryURL,
+      fictionalHomeDirectory
+        .appendingPathComponent("Library/Application Support", isDirectory: true)
+        .appendingPathComponent("Astronomical", isDirectory: true)
+    )
+    XCTAssertEqual(
+      appStoreIdentity().configFileURL(homeDirectoryURL: fictionalHomeDirectory),
+      stateDirectoryURL.appendingPathComponent("config.json")
+    )
+    XCTAssertEqual(
+      appStoreIdentity().daemonOwnershipURL(homeDirectoryURL: fictionalHomeDirectory),
+      stateDirectoryURL.appendingPathComponent("menu-owned-daemon.json")
+    )
+  }
+
+  func test_should_keep_direct_channels_on_their_home_dot_folders() {
+    let fictionalHomeDirectory = URL(fileURLWithPath: "/Users/example", isDirectory: true)
+
+    XCTAssertEqual(ApplicationChannel.stable.stateDirectoryName, ".astronomical")
+    XCTAssertEqual(ApplicationChannel.development.stateDirectoryName, ".astronomical-dev")
+    XCTAssertNil(ApplicationChannel.appStore.stateDirectoryName)
+    XCTAssertEqual(
+      ApplicationChannel.stable.stateDirectoryName,
+      fictionalHomeDirectory
+        .appendingPathComponent(".astronomical", isDirectory: true).lastPathComponent
+    )
+  }
+
+  func test_should_resolve_the_app_store_channel_from_its_bundle_value() {
+    XCTAssertEqual(ApplicationChannel(rawValue: "app-store"), .appStore)
+  }
+}

--- a/scripts/internal/build-macos-app.sh
+++ b/scripts/internal/build-macos-app.sh
@@ -149,7 +149,7 @@ finish_phase() {
 remove_previous_app_bundle() {
     bundle_path="$1"
     case "$bundle_path" in
-        *"/target/astronomical-macos-development.noindex/Astronomical Development.app"|*"/target/astronomical-macos-stable.noindex/Astronomical.app")
+        *"/target/astronomical-macos-development.noindex/Astronomical Development.app"|*"/target/astronomical-macos-stable.noindex/Astronomical.app"|*"/target/astronomical-macos-app-store.noindex/Astronomical.app")
             rm -rf "$bundle_path"
             ;;
         *)
@@ -181,6 +181,7 @@ github_pages_feed_url() {
 
 sign_code_object() {
     code_object_path="$1"
+    entitlements_file="${2:-}"
     [ -e "$code_object_path" ] || {
         print_error "required code object is unavailable: ${code_object_path}"
         exit 1
@@ -189,7 +190,17 @@ sign_code_object() {
     signing_started_at="$(date +%s)"
     printf '%s operation=code-sign object="%s" status=start\n' \
         "$(date '+%Y-%m-%dT%H:%M:%S%z')" "$code_object_name"
-    if [ -n "$SIGNING_IDENTITY" ]; then
+    if [ -n "$entitlements_file" ]; then
+        # Store-channel signing: every Mach-O carries its sandbox entitlements
+        # explicitly, because the App Sandbox is established from signature
+        # entitlements rather than bundle layout.
+        if [ -n "$SIGNING_IDENTITY" ]; then
+            codesign --force --sign "$SIGNING_IDENTITY" --options runtime --timestamp \
+                --entitlements "$entitlements_file" "$code_object_path"
+        else
+            codesign --force --sign - --entitlements "$entitlements_file" "$code_object_path"
+        fi
+    elif [ -n "$SIGNING_IDENTITY" ]; then
         codesign --force --sign "$SIGNING_IDENTITY" --options runtime --timestamp \
             --preserve-metadata=entitlements "$code_object_path"
     else
@@ -277,6 +288,9 @@ main() {
             bundle_identifier="dev.astronomical.app.development"
             supervisor_port="6733"
             state_directory_name=".astronomical-dev"
+            icon_channel="development"
+            menu_swift_product="astronomical-menu"
+            supervisor_cargo_features=""
             ;;
         stable)
             # Only the promoted ~/Applications copy should appear in Spotlight.
@@ -286,14 +300,37 @@ main() {
             bundle_identifier="dev.astronomical.app"
             supervisor_port="6732"
             state_directory_name=".astronomical"
+            icon_channel="stable"
+            menu_swift_product="astronomical-menu"
+            supervisor_cargo_features=""
+            ;;
+        app-store)
+            # The Mac App Store distribution variant of the Stable product.
+            # Sparkle is structurally absent, every Mach-O carries sandbox
+            # entitlements, and state derives from Application Support (the
+            # app-store-state-root feature), so no state directory name is
+            # embedded in the bundle.
+            release_directory="${repository_root}/target/astronomical-macos-app-store.noindex"
+            app_bundle_path="${release_directory}/Astronomical.app"
+            bundle_name="Astronomical"
+            bundle_identifier="dev.astronomical.app.appstore"
+            supervisor_port="6732"
+            state_directory_name=""
+            icon_channel="stable"
+            menu_swift_product="astronomical-menu-app-store"
+            supervisor_cargo_features="--features astronomical-supervisor/app-store-state-root"
             ;;
         *)
-            print_error "channel must be development or stable"
+            print_error "channel must be development, stable, or app-store"
             exit 2
             ;;
     esac
-    if [ -n "$SIGNING_IDENTITY" ] && [ "$APPLICATION_CHANNEL" != "stable" ]; then
+    if [ -n "$SIGNING_IDENTITY" ] && [ "$APPLICATION_CHANNEL" != "stable" ] && [ "$APPLICATION_CHANNEL" != "app-store" ]; then
         print_error "Developer ID signing is reserved for Stable release bundles"
+        exit 2
+    fi
+    if [ "$APPLICATION_CHANNEL" = "app-store" ] && [ -z "$SIGNING_IDENTITY" ]; then
+        print_error "App Store builds require --signing-identity because every executable must carry sandbox entitlements over a real signature"
         exit 2
     fi
     cargo_workspace_metadata="$(cargo metadata --no-deps --format-version 1)"
@@ -310,8 +347,8 @@ main() {
     else
         build_dirty="false"
     fi
-    if [ "$APPLICATION_CHANNEL" = "stable" ] && [ "$build_dirty" = "true" ]; then
-        print_error "Stable builds require a clean worktree; build Development or commit the intended changes"
+    if [ "$APPLICATION_CHANNEL" != "development" ] && [ "$build_dirty" = "true" ]; then
+        print_error "${APPLICATION_CHANNEL} builds require a clean worktree; build Development or commit the intended changes"
         exit 1
     fi
     export ASTRONOMICAL_BUILD_COMMIT="$build_commit"
@@ -345,8 +382,10 @@ main() {
     # Cargo prints its own live compilation progress to stderr.
     cargo build --release --target "$host_target_triple" \
         -p astronomical-inference-worker --bin astronomical-inference-worker \
-        -p astronomical-supervisor --bin astronomicald
-    swift build --configuration release --package-path "${repository_root}/apps/astronomical-menu"
+        -p astronomical-supervisor --bin astronomicald \
+        $supervisor_cargo_features
+    swift build --configuration release --package-path "${repository_root}/apps/astronomical-menu" \
+        --product "$menu_swift_product"
     finish_phase "success"
 
     # ── Phase 4: Assemble and sign app bundle ────────────────────────────
@@ -370,19 +409,23 @@ main() {
         printf '  <key>CFBundleShortVersionString</key><string>%s</string>\n' "$application_version"
         printf '  <key>LSMinimumSystemVersion</key><string>26.0</string>\n'
         printf '%s\n' '  <key>CFBundleIconFile</key><string>Astronomical.icns</string>'
-        printf '  <key>SUFeedURL</key><string>%s</string>\n' "$sparkle_update_feed_url"
-        printf '  <key>SUPublicEDKey</key><string>%s</string>\n' "$SPARKLE_PUBLIC_ED25519_KEY"
-        printf '%s\n' '  <key>SUVerifyUpdateBeforeExtraction</key><true/>'
-        printf '%s\n' '  <key>SURequireSignedFeed</key><true/>'
-        printf '%s\n' '  <key>SUSignedFeedFailureExpirationInterval</key><integer>0</integer>'
-        printf '%s\n' '  <key>SUEnableAutomaticChecks</key><true/>'
-        printf '%s\n' '  <key>SUScheduledCheckInterval</key><integer>86400</integer>'
-        printf '%s\n' '  <key>SUAutomaticallyUpdate</key><false/>'
-        printf '%s\n' '  <key>SUEnableSystemProfiling</key><false/>'
+        if [ "$APPLICATION_CHANNEL" != "app-store" ]; then
+            printf '  <key>SUFeedURL</key><string>%s</string>\n' "$sparkle_update_feed_url"
+            printf '  <key>SUPublicEDKey</key><string>%s</string>\n' "$SPARKLE_PUBLIC_ED25519_KEY"
+            printf '%s\n' '  <key>SUVerifyUpdateBeforeExtraction</key><true/>'
+            printf '%s\n' '  <key>SURequireSignedFeed</key><true/>'
+            printf '%s\n' '  <key>SUSignedFeedFailureExpirationInterval</key><integer>0</integer>'
+            printf '%s\n' '  <key>SUEnableAutomaticChecks</key><true/>'
+            printf '%s\n' '  <key>SUScheduledCheckInterval</key><integer>86400</integer>'
+            printf '%s\n' '  <key>SUAutomaticallyUpdate</key><false/>'
+            printf '%s\n' '  <key>SUEnableSystemProfiling</key><false/>'
+        fi
         printf '  <key>AstronomicalChannel</key><string>%s</string>\n' "$APPLICATION_CHANNEL"
         printf '  <key>AstronomicalBuildDate</key><string>%s</string>\n' "$build_date_utc"
         printf '  <key>AstronomicalSupervisorPort</key><integer>%s</integer>\n' "$supervisor_port"
-        printf '  <key>AstronomicalStateDirectoryName</key><string>%s</string>\n' "$state_directory_name"
+        if [ -n "$state_directory_name" ]; then
+            printf '  <key>AstronomicalStateDirectoryName</key><string>%s</string>\n' "$state_directory_name"
+        fi
         printf '  <key>AstronomicalBuildCommit</key><string>%s</string>\n' "$build_commit"
         if [ "$build_dirty" = "true" ]; then
             printf '%s\n' '  <key>AstronomicalBuildDirty</key><true/>'
@@ -395,7 +438,7 @@ main() {
         printf '%s\n' '</plist>'
     } > "${app_bundle_path}/Contents/Info.plist"
 
-    cp "${repository_root}/apps/astronomical-menu/.build/release/astronomical-menu" \
+    cp "${repository_root}/apps/astronomical-menu/.build/release/${menu_swift_product}" \
        "${app_bundle_path}/Contents/MacOS/astronomical-menu"
     cargo_release_directory="${CARGO_TARGET_DIR}/${host_target_triple}/release"
     cp "${cargo_release_directory}/astronomicald" \
@@ -409,26 +452,31 @@ main() {
     cp "${repository_root}/third-party/RUST_DEPENDENCY_NOTICES" \
        "${app_bundle_path}/Contents/Resources/RUST_DEPENDENCY_NOTICES"
     sparkle_license_source="${repository_root}/apps/astronomical-menu/.build/checkouts/Sparkle/LICENSE"
-    [ -s "$sparkle_license_source" ] || {
-        print_error "Sparkle license is unavailable after the Swift package build: ${sparkle_license_source}"
-        exit 1
-    }
-    cp "$sparkle_license_source" "${app_bundle_path}/Contents/Resources/SPARKLE_LICENSE"
+    if [ "$APPLICATION_CHANNEL" != "app-store" ]; then
+        [ -s "$sparkle_license_source" ] || {
+            print_error "Sparkle license is unavailable after the Swift package build: ${sparkle_license_source}"
+            exit 1
+        }
+        cp "$sparkle_license_source" "${app_bundle_path}/Contents/Resources/SPARKLE_LICENSE"
+    fi
     package_mlx_metallib "$repository_root" "$app_bundle_path" "$host_target_triple"
-    sparkle_framework_source="${repository_root}/apps/astronomical-menu/.build/release/Sparkle.framework"
-    sparkle_framework_destination="${app_bundle_path}/Contents/Frameworks/Sparkle.framework"
-    [ -d "$sparkle_framework_source" ] || {
-        print_error "Sparkle framework is unavailable after the Swift package build: ${sparkle_framework_source}"
-        exit 1
-    }
-    ditto "$sparkle_framework_source" "$sparkle_framework_destination"
+    if [ "$APPLICATION_CHANNEL" != "app-store" ]; then
+        sparkle_framework_source="${repository_root}/apps/astronomical-menu/.build/release/Sparkle.framework"
+        sparkle_framework_destination="${app_bundle_path}/Contents/Frameworks/Sparkle.framework"
+        [ -d "$sparkle_framework_source" ] || {
+            print_error "Sparkle framework is unavailable after the Swift package build: ${sparkle_framework_source}"
+            exit 1
+        }
+        ditto "$sparkle_framework_source" "$sparkle_framework_destination"
+    fi
 
-    # Stable keeps one timeless product identity; Development remains visibly distinct.
+    # Stable keeps one timeless product identity; Development remains visibly distinct;
+    # the App Store channel ships the Stable product identity as well.
     iconset_directory="${app_bundle_path}/Contents/Resources/Astronomical.iconset"
     icon_resource="${app_bundle_path}/Contents/Resources/Astronomical.icns"
     swift "${repository_root}/scripts/internal/render-macos-app-icon.swift" \
         --output-directory "$iconset_directory" \
-        --channel "$APPLICATION_CHANNEL"
+        --channel "$icon_channel"
     iconutil --convert icns --output "$icon_resource" "$iconset_directory"
     case "$iconset_directory" in
         "${app_bundle_path}/Contents/Resources/Astronomical.iconset") rm -rf "$iconset_directory" ;;
@@ -441,29 +489,48 @@ main() {
     chmod +x "${app_bundle_path}/Contents/MacOS/astronomical-menu"
     chmod +x "${app_bundle_path}/Contents/MacOS/astronomicald"
     chmod +x "${app_bundle_path}/Contents/MacOS/astronomical-inference-worker"
-    # Swift Package Manager links Sparkle through @loader_path. The packaged
-    # application keeps frameworks in Contents/Frameworks, so add the standard
-    # bundle rpath before signing the executable and enclosing bundle.
-    install_name_tool -add_rpath "@executable_path/../Frameworks" \
-        "${app_bundle_path}/Contents/MacOS/astronomical-menu"
+    if [ "$APPLICATION_CHANNEL" != "app-store" ]; then
+        # Swift Package Manager links Sparkle through @loader_path. The packaged
+        # application keeps frameworks in Contents/Frameworks, so add the standard
+        # bundle rpath before signing the executable and enclosing bundle. Store
+        # builds link no framework and need no rpath.
+        install_name_tool -add_rpath "@executable_path/../Frameworks" \
+            "${app_bundle_path}/Contents/MacOS/astronomical-menu"
+    fi
 
-    printf '  signing embedded Sparkle code inside-out...\n'
-    sparkle_version_directory="${sparkle_framework_destination}/Versions/B"
-    sign_code_object "${sparkle_version_directory}/Autoupdate"
-    sign_code_object "${sparkle_version_directory}/Updater.app"
-    sign_code_object "${sparkle_version_directory}/XPCServices/Downloader.xpc"
-    sign_code_object "${sparkle_version_directory}/XPCServices/Installer.xpc"
-    sign_code_object "$sparkle_framework_destination"
+    if [ "$APPLICATION_CHANNEL" != "app-store" ]; then
+        printf '  signing embedded Sparkle code inside-out...\n'
+        sparkle_version_directory="${sparkle_framework_destination}/Versions/B"
+        sign_code_object "${sparkle_version_directory}/Autoupdate"
+        sign_code_object "${sparkle_version_directory}/Updater.app"
+        sign_code_object "${sparkle_version_directory}/XPCServices/Downloader.xpc"
+        sign_code_object "${sparkle_version_directory}/XPCServices/Installer.xpc"
+        sign_code_object "$sparkle_framework_destination"
+    fi
 
     printf '  signing Astronomical executables...\n'
     # Leaf-first signing keeps every executable attributable before the app seal is created.
-    for bundled_executable_name in astronomical-menu astronomicald astronomical-inference-worker; do
-        sign_code_object "${app_bundle_path}/Contents/MacOS/${bundled_executable_name}"
-    done
+    if [ "$APPLICATION_CHANNEL" = "app-store" ]; then
+        # The main executable carries the sandbox profile; the spawned daemon and
+        # worker join it through inherited-sandbox entitlements.
+        application_entitlements="${repository_root}/scripts/internal/entitlements/app-store-application.entitlements"
+        inherited_entitlements="${repository_root}/scripts/internal/entitlements/app-store-inherited.entitlements"
+        sign_code_object "${app_bundle_path}/Contents/MacOS/astronomical-menu" "$application_entitlements"
+        sign_code_object "${app_bundle_path}/Contents/MacOS/astronomicald" "$inherited_entitlements"
+        sign_code_object "${app_bundle_path}/Contents/MacOS/astronomical-inference-worker" "$inherited_entitlements"
+    else
+        for bundled_executable_name in astronomical-menu astronomicald astronomical-inference-worker; do
+            sign_code_object "${app_bundle_path}/Contents/MacOS/${bundled_executable_name}"
+        done
+    fi
 
     printf '  signing app bundle...\n'
     plutil -lint "${app_bundle_path}/Contents/Info.plist"
-    sign_code_object "$app_bundle_path"
+    if [ "$APPLICATION_CHANNEL" = "app-store" ]; then
+        sign_code_object "$app_bundle_path" "$application_entitlements"
+    else
+        sign_code_object "$app_bundle_path"
+    fi
     codesign --verify --deep --strict "$app_bundle_path"
     finish_phase "success"
 
@@ -473,7 +540,7 @@ main() {
     validate_script="${repository_root}/scripts/internal/validate-macos-app.sh"
     if [ -x "$validate_script" ]; then
         validation_exit_code=0
-        if [ "$APPLICATION_CHANNEL" = "stable" ]; then
+        if [ "$APPLICATION_CHANNEL" = "stable" ] || [ "$APPLICATION_CHANNEL" = "app-store" ]; then
             "$validate_script" --app-bundle "$app_bundle_path" --bundle-only || validation_exit_code=$?
         else
             "$validate_script" --app-bundle "$app_bundle_path" || validation_exit_code=$?

--- a/scripts/internal/entitlements/app-store-application.entitlements
+++ b/scripts/internal/entitlements/app-store-application.entitlements
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.app-sandbox</key>
+    <true/>
+    <key>com.apple.security.network.client</key>
+    <true/>
+    <key>com.apple.security.network.server</key>
+    <true/>
+</dict>
+</plist>

--- a/scripts/internal/entitlements/app-store-inherited.entitlements
+++ b/scripts/internal/entitlements/app-store-inherited.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.inherit</key>
+    <true/>
+</dict>
+</plist>

--- a/scripts/internal/validate-macos-app.sh
+++ b/scripts/internal/validate-macos-app.sh
@@ -129,6 +129,17 @@ read_plist_value() {
     plutil -extract "$1" raw -o - "${APP_BUNDLE_PATH}/Contents/Info.plist"
 }
 
+assert_sandbox_entitlement() {
+    executable_path="$1"
+    entitlement_key="$2"
+    executable_label="$3"
+    if codesign -d --entitlements - "$executable_path" 2>/dev/null         | grep -F "<key>${entitlement_key}</key>" >/dev/null 2>&1; then
+        return 0
+    fi
+    print_error "App Store executable ${executable_label} is missing the ${entitlement_key} entitlement"
+    exit 1
+}
+
 validate_real_model() {
     start_step "real-model-romeo-and-juliet"
     printf '%s\n' "  Shared GPU and wired memory are not isolated; this explicit journey may affect Stable latency."
@@ -210,13 +221,39 @@ main() {
     for bundled_executable in "$daemon_executable" "$menu_executable" "$worker_executable"; do
         [ -x "$bundled_executable" ] || { print_error "bundled executable is unavailable: ${bundled_executable}"; exit 1; }
     done
-    [ -d "$sparkle_framework" ] || { print_error "bundled Sparkle framework is unavailable: ${sparkle_framework}"; exit 1; }
-    for packaged_resource in LICENSE THIRD_PARTY_NOTICES RUST_DEPENDENCY_NOTICES SPARKLE_LICENSE Astronomical.icns; do
+    application_channel_early="$(read_plist_value AstronomicalChannel)"
+    if [ "$application_channel_early" = "app-store" ]; then
+        # Store builds are structurally Sparkle-free: no framework, no update
+        # keys, no Sparkle license. Their absence is the contract.
+        [ ! -e "$sparkle_framework" ] || { print_error "App Store bundle must not embed the Sparkle framework"; exit 1; }
+        [ ! -s "${APP_BUNDLE_PATH}/Contents/Resources/SPARKLE_LICENSE" ] || {
+            print_error "App Store bundle must not carry the Sparkle license resource"; exit 1
+        }
+        for sparkle_plist_key in SUFeedURL SUPublicEDKey SUEnableAutomaticChecks; do
+            if grep -F "<key>${sparkle_plist_key}</key>" "${APP_BUNDLE_PATH}/Contents/Info.plist" >/dev/null 2>&1; then
+                print_error "App Store bundle must not contain the ${sparkle_plist_key} update key"
+                exit 1
+            fi
+        done
+        if otool -L "$menu_executable" | grep -qi sparkle; then
+            print_error "App Store menu executable must not link the Sparkle framework"
+            exit 1
+        fi
+    else
+        [ -d "$sparkle_framework" ] || { print_error "bundled Sparkle framework is unavailable: ${sparkle_framework}"; exit 1; }
+    fi
+    for packaged_resource in LICENSE THIRD_PARTY_NOTICES RUST_DEPENDENCY_NOTICES Astronomical.icns; do
         [ -s "${APP_BUNDLE_PATH}/Contents/Resources/${packaged_resource}" ] || {
             print_error "required bundled resource is unavailable: ${packaged_resource}"
             exit 1
         }
     done
+    if [ "$application_channel_early" != "app-store" ]; then
+        [ -s "${APP_BUNDLE_PATH}/Contents/Resources/SPARKLE_LICENSE" ] || {
+            print_error "required bundled resource is unavailable: SPARKLE_LICENSE"
+            exit 1
+        }
+    fi
     bundled_metallib_path="${APP_BUNDLE_PATH}/Contents/Resources/share/mlx/mlx.metallib"
     if [ -L "$bundled_metallib_path" ] || [ ! -s "$bundled_metallib_path" ]; then
         print_error "required bundled MLX AOT metallib is unavailable"
@@ -233,7 +270,7 @@ main() {
     bundle_identifier="$(read_plist_value CFBundleIdentifier)"
     bundle_icon_file="$(read_plist_value CFBundleIconFile)"
     supervisor_port="$(read_plist_value AstronomicalSupervisorPort)"
-    state_directory_name="$(read_plist_value AstronomicalStateDirectoryName)"
+    state_directory_name=""
     case "$application_channel" in
         stable)
             expected_supervisor_port="6732"
@@ -246,6 +283,17 @@ main() {
             expected_state_directory_name=".astronomical-dev"
             expected_bundle_identifier="dev.astronomical.app.development"
             ;;
+        app-store)
+            expected_supervisor_port="6732"
+            expected_bundle_identifier="dev.astronomical.app.appstore"
+            # App Store bundles carry no state-directory name: state derives from
+            # Application Support. A present key is the failure, so its absence
+            # is proven by the extraction itself failing.
+            if read_plist_value AstronomicalStateDirectoryName >/dev/null 2>&1; then
+                print_error "App Store bundle must not embed a state directory name; state derives from Application Support"
+                exit 1
+            fi
+            ;;
         *) print_error "invalid bundle channel"; exit 1 ;;
     esac
     case "$supervisor_port" in ''|*[!0-9]*) print_error "invalid bundle supervisor port"; exit 1 ;; esac
@@ -257,8 +305,21 @@ main() {
     [ "$bundle_icon_file" = "Astronomical.icns" ] || { print_error "bundle icon identity is invalid"; exit 1; }
     case "$application_is_dirty" in true|false) ;; *) print_error "invalid bundle dirty marker"; exit 1 ;; esac
     [ "$supervisor_port" = "$expected_supervisor_port" ] || { print_error "bundle channel and supervisor port disagree"; exit 1; }
-    [ "$state_directory_name" = "$expected_state_directory_name" ] || { print_error "bundle channel and state directory disagree"; exit 1; }
+    if [ "$application_channel" != "app-store" ]; then
+        state_directory_name="$(read_plist_value AstronomicalStateDirectoryName)"
+        [ "$state_directory_name" = "$expected_state_directory_name" ] || {
+            print_error "bundle channel and state directory disagree"; exit 1
+        }
+    fi
     [ "$bundle_identifier" = "$expected_bundle_identifier" ] || { print_error "bundle channel and identifier disagree"; exit 1; }
+    if [ "$application_channel" = "app-store" ]; then
+        assert_sandbox_entitlement "$menu_executable" "com.apple.security.app-sandbox" "menu"
+        assert_sandbox_entitlement "$menu_executable" "com.apple.security.network.client" "menu"
+        assert_sandbox_entitlement "$menu_executable" "com.apple.security.network.server" "menu"
+        for inherited_executable in "$daemon_executable" "$worker_executable"; do
+            assert_sandbox_entitlement "$inherited_executable" "com.apple.security.inherit" "$(basename "$inherited_executable")"
+        done
+    fi
     codesign --verify --deep --strict "$APP_BUNDLE_PATH"
     codesign --verify --deep --strict "$sparkle_framework"
     daemon_version_output="$("$daemon_executable" --version)"

--- a/scripts/release/tests/test-build-macos-app.sh
+++ b/scripts/release/tests/test-build-macos-app.sh
@@ -137,6 +137,9 @@ main() {
         "${sandbox_internal_scripts_directory}/build-macos-app.sh"
     cp "${repository_root}/scripts/run-in-disposable-cargo-target.sh" \
         "${sandbox_scripts_directory}/run-in-disposable-cargo-target.sh"
+    mkdir -p "${sandbox_internal_scripts_directory}/entitlements"
+    cp "${repository_root}/scripts/internal/entitlements/"*.entitlements \
+        "${sandbox_internal_scripts_directory}/entitlements/"
     chmod +x "${sandbox_internal_scripts_directory}/build-macos-app.sh" \
         "${sandbox_scripts_directory}/run-in-disposable-cargo-target.sh"
     printf '%s\n' fixture > "${sandbox_repository}/LICENSE"
@@ -147,6 +150,7 @@ main() {
 
     cat > "${fake_command_directory}/cargo" <<'CARGO'
 #!/usr/bin/env sh
+printf '%s\n' "$*" >> "${FAKE_CARGO_ARGS_LOG:?}"
 if [ "${1:-}" = "metadata" ]; then
     printf '%s\n' '{"packages":[{"name":"astronomical-supervisor","version":"0.2.0","repository":"https://github.com/example/astronomical"}]}'
     exit 0
@@ -213,9 +217,17 @@ while [ "$#" -gt 0 ]; do
     fi
     shift
 done
+menu_product="astronomical-menu"
+while [ "$#" -gt 0 ]; do
+    if [ "$1" = "--product" ]; then
+        menu_product="$2"
+        break
+    fi
+    shift
+done
 mkdir -p "${package_path:?package path is required}/.build/release"
-printf '%s\n' '#!/usr/bin/env sh' 'exit 0' > "${package_path}/.build/release/astronomical-menu"
-chmod +x "${package_path}/.build/release/astronomical-menu"
+printf '%s\n' '#!/usr/bin/env sh' 'exit 0' > "${package_path}/.build/release/${menu_product}"
+chmod +x "${package_path}/.build/release/${menu_product}"
 SWIFT
     cat > "${fake_command_directory}/iconutil" <<'ICONUTIL'
 #!/usr/bin/env sh
@@ -267,6 +279,8 @@ CODESIGN
     mkdir -p "$cargo_lane_root"
     fixture_metallib="${SANDBOX_DIRECTORY}/mlx.metallib"
     printf '%s\n' 'fixture-metallib' > "$fixture_metallib"
+    : > "${SANDBOX_DIRECTORY}/fake-cargo-args.log"
+    export FAKE_CARGO_ARGS_LOG="${SANDBOX_DIRECTORY}/fake-cargo-args.log"
 
     printf '%s\n' '[app-builder-test] case=missing-metallib-source-is-rejected status=start'
     if (CDPATH='' cd -- "$sandbox_repository" && \
@@ -348,6 +362,87 @@ CODESIGN
         exit 1
     }
     printf '%s\n' '[app-builder-test] case=stable-output-is-noindex status=success'
+
+    printf '%s\n' '[app-builder-test] case=app-store-output-is-sandbox-clean status=start'
+    app_store_cargo_target_record="${SANDBOX_DIRECTORY}/app-store-cargo-target"
+    (CDPATH='' cd -- "$sandbox_repository" && \
+        FAKE_CODESIGN_LOG="${SANDBOX_DIRECTORY}/app-store-codesign.log" \
+            FAKE_CARGO_TARGET_RECORD="$app_store_cargo_target_record" \
+            ASTRONOMICAL_CARGO_LANE_ROOT="$cargo_lane_root" \
+            ASTRONOMICAL_MLX_METALLIB_PATH="$fixture_metallib" \
+            PATH="${fake_command_directory}:${PATH}" timeout "$SUBJECT_TIMEOUT_SECONDS" \
+            "${sandbox_internal_scripts_directory}/build-macos-app.sh" --channel app-store \
+                --signing-identity "Apple Distribution: Example (ABCDE12345)")
+    app_store_app_bundle="${sandbox_repository}/target/astronomical-macos-app-store.noindex/Astronomical.app"
+    [ -x "${app_store_app_bundle}/Contents/MacOS/astronomical-menu" ] || {
+        print_error "App Store bundle lacks the menu executable"
+        exit 1
+    }
+    [ ! -d "${app_store_app_bundle}/Contents/Frameworks/Sparkle.framework" ] || {
+        print_error "App Store bundle unexpectedly embeds the Sparkle framework"
+        exit 1
+    }
+    [ ! -s "${app_store_app_bundle}/Contents/Resources/SPARKLE_LICENSE" ] || {
+        print_error "App Store bundle unexpectedly carries the Sparkle license"
+        exit 1
+    }
+    for sparkle_plist_key in SUFeedURL SUPublicEDKey SUEnableAutomaticChecks AstronomicalStateDirectoryName; do
+        if grep -F "<key>${sparkle_plist_key}</key>" \
+            "${app_store_app_bundle}/Contents/Info.plist" >/dev/null 2>&1; then
+            print_error "App Store bundle unexpectedly embeds ${sparkle_plist_key}"
+            exit 1
+        fi
+    done
+    grep -F '<key>AstronomicalChannel</key><string>app-store</string>' \
+        "${app_store_app_bundle}/Contents/Info.plist" >/dev/null || {
+        print_error "App Store bundle does not declare the app-store channel"
+        exit 1
+    }
+    grep -F '<key>CFBundleIdentifier</key><string>dev.astronomical.app.appstore</string>' \
+        "${app_store_app_bundle}/Contents/Info.plist" >/dev/null || {
+        print_error "App Store bundle does not carry the app-store bundle identifier"
+        exit 1
+    }
+    if otool -L "${app_store_app_bundle}/Contents/MacOS/astronomical-menu" 2>/dev/null | grep -qi sparkle; then
+        print_error "App Store menu binary unexpectedly links Sparkle"
+        exit 1
+    fi
+    # The fake codesign only records its arguments, so the entitlement contract
+    # is asserted from the signing log: the main executable and the bundle seal
+    # carry the sandbox profile; helpers join it through inheritance.
+    app_store_entitlements_log="${SANDBOX_DIRECTORY}/app-store-codesign.log"
+    for pair in \
+        "app-store-application.entitlements astronomical-menu" \
+        "app-store-inherited.entitlements astronomicald" \
+        "app-store-inherited.entitlements astronomical-inference-worker" \
+        "app-store-application.entitlements Astronomical.app"
+    do
+        set -- $pair
+        entitlements_file_name="$1"
+        code_object_name="$2"
+        grep -E -- "--entitlements .*${entitlements_file_name}.*${code_object_name}" \
+            "$app_store_entitlements_log" >/dev/null || {
+            print_error "App Store ${code_object_name} was not signed with ${entitlements_file_name}"
+            exit 1
+        }
+    done
+    grep -F -- '--features astronomical-supervisor/app-store-state-root' \
+        "${SANDBOX_DIRECTORY}/fake-cargo-args.log" >/dev/null || {
+        print_error "App Store build did not enable the app-store-state-root feature"
+        exit 1
+    }
+    stable_cargo_args_count=$(grep -cF -- '--features astronomical-supervisor/app-store-state-root' \
+        "${SANDBOX_DIRECTORY}/fake-cargo-args.log" || true)
+    [ "$stable_cargo_args_count" = "1" ] || {
+        print_error "the app-store-state-root feature must be enabled only for the App Store build"
+        exit 1
+    }
+    app_store_cargo_target="$(cat "$app_store_cargo_target_record")"
+    [ ! -e "$app_store_cargo_target" ] || {
+        print_error "App Store build retained its disposable Cargo target"
+        exit 1
+    }
+    printf '%s\n' '[app-builder-test] case=app-store-output-is-sandbox-clean status=success'
 }
 
 main "$@"


### PR DESCRIPTION
# Add the App Store build channel to the macOS packaging pipeline

## Linked issue

Refs #381

## What changed

`scripts/internal/build-macos-app.sh` gains a third channel: `app-store`, the Mac App Store distribution variant of the Stable product.

- Bundle identity: `dev.astronomical.app.appstore`, Stable supervisor port and endpoint guards.
- **Sparkle structurally absent**: no framework copy, no inside-out Sparkle signing, no license resource, no `SU*` keys in Info.plist, no bundle rpath (nothing to resolve).
- **No embedded state-directory name**: state derives from Application Support through the `app-store-state-root` feature, enabled only on the supervisor build for this channel (`--features astronomical-supervisor/app-store-state-root`).
- **Explicit sandbox entitlements**: the menu executable carries `app-sandbox` plus network client and server grants; the spawned daemon and worker join its sandbox through `com.apple.security.inherit`. Signing uses `--entitlements` per Mach-O, and the channel requires a signing identity so the sandbox is established over a real signature.
- The menu binary is packaged from the `astronomical-menu-app-store` product; icon and build-date handling reuse the Stable product identity.
- Direct channels (development/stable) are byte-identical in behavior.

The validator (`validate-macos-app.sh`) learns the same contract: for App Store bundles it asserts the Sparkle framework's absence, the absence of `SUFeedURL`/`SUPublicEDKey`/`SUEnableAutomaticChecks`, the absence of an embedded state-directory name (proven by the extraction failing), the per-executable sandbox entitlements, and that the menu binary does not link Sparkle.

The menu application resolves the `app-store` channel: Stable product presentation, the Stable runtime instance (`--instance stable`), and Application Support state paths so the menu and the daemon agree on one state root inside the container.

## Verification

- `scripts/release/tests/test-build-macos-app.sh`: new `app-store-output-is-sandbox-clean` case asserts the Sparkle-free structure, missing update keys and state-directory key, entitlement-bearing signing log, and that the state-root feature is enabled for that channel only; all four builder cases green.
- `scripts/test-validate-macos-app-contract.sh`: all validator cases green.
- Menu Swift suite: 101/101, zero warnings — including new App Store channel identity tests.
- `scripts/verify-before-commit.sh`: 18/18 steps green.