### PR TITLE
Add the App Store installer packaging step

### DIFF
--- a/scripts/internal/package-app-store-pkg.sh
+++ b/scripts/internal/package-app-store-pkg.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env sh
+
+# Packages a validated App Store channel app bundle into the signed installer
+# package that App Store Connect accepts.
+#
+# The bundle must already be assembled and signed by
+# scripts/internal/build-macos-app.sh --channel app-store. The installer
+# package is signed with the third-party Mac Developer Installer certificate;
+# App Store Connect rejects unsigned or Developer ID-signed packages.
+
+set -eu
+
+APP_BUNDLE_PATH=""
+INSTALLER_IDENTITY=""
+OUTPUT_PKG_PATH=""
+
+print_error() {
+    printf '%s\n' "Error: $1" >&2
+}
+
+print_usage() {
+    printf '%s\n' "Usage: scripts/internal/package-app-store-pkg.sh --app-bundle PATH --installer-identity NAME [--output-pkg PATH]"
+}
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --app-bundle)
+            [ "$#" -ge 2 ] || { print_error "--app-bundle requires a value"; exit 2; }
+            [ -z "$APP_BUNDLE_PATH" ] || { print_error "--app-bundle may be supplied only once"; exit 2; }
+            APP_BUNDLE_PATH="$2"
+            shift 2
+            ;;
+        --installer-identity)
+            [ "$#" -ge 2 ] || { print_error "--installer-identity requires a value"; exit 2; }
+            [ -z "$INSTALLER_IDENTITY" ] || { print_error "--installer-identity may be supplied only once"; exit 2; }
+            INSTALLER_IDENTITY="$2"
+            shift 2
+            ;;
+        --output-pkg)
+            [ "$#" -ge 2 ] || { print_error "--output-pkg requires a value"; exit 2; }
+            [ -z "$OUTPUT_PKG_PATH" ] || { print_error "--output-pkg may be supplied only once"; exit 2; }
+            OUTPUT_PKG_PATH="$2"
+            shift 2
+            ;;
+        --help|-h)
+            print_usage
+            exit 0
+            ;;
+        *)
+            print_error "unrecognized argument: $1"
+            print_usage >&2
+            exit 2
+            ;;
+    esac
+done
+
+[ -d "$APP_BUNDLE_PATH" ] || { print_error "app bundle not found: ${APP_BUNDLE_PATH}"; exit 2; }
+[ -n "$INSTALLER_IDENTITY" ] || { print_error "an installer identity is required"; exit 2; }
+
+info_plist="${APP_BUNDLE_PATH}/Contents/Info.plist"
+[ -s "$info_plist" ] || { print_error "bundle Info.plist is unavailable: ${info_plist}"; exit 1; }
+bundle_channel="$(plutil -extract AstronomicalChannel raw -o - "$info_plist" 2>/dev/null)" || {
+    print_error "bundle does not declare an Astronomical channel"
+    exit 1
+}
+[ "$bundle_channel" = "app-store" ] || {
+    print_error "only App Store channel bundles can be packaged for App Store Connect; this bundle declares ${bundle_channel}"
+    exit 1
+}
+application_version="$(plutil -extract CFBundleShortVersionString raw -o - "$info_plist")"
+
+if ! security find-identity -v | grep -F -- "\"${INSTALLER_IDENTITY}\"" >/dev/null; then
+    print_error "installer identity is not available as a valid code signing identity: ${INSTALLER_IDENTITY}"
+    exit 1
+fi
+
+if [ -z "$OUTPUT_PKG_PATH" ]; then
+    bundle_parent_directory="$(dirname -- "$APP_BUNDLE_PATH")"
+    OUTPUT_PKG_PATH="${bundle_parent_directory}/Astronomical-${application_version}-app-store.pkg"
+fi
+case "$OUTPUT_PKG_PATH" in
+    /*) ;;
+    *) OUTPUT_PKG_PATH="$(pwd -P)/${OUTPUT_PKG_PATH}" ;;
+esac
+
+printf '%s operation=package-app-store-pkg status=start identity_present=true\n' \
+    "$(date '+%Y-%m-%dT%H:%M:%S%z')"
+xcrun productbuild \
+    --component "$APP_BUNDLE_PATH" /Applications \
+    --sign "$INSTALLER_IDENTITY" \
+    "$OUTPUT_PKG_PATH"
+pkgutil --check-signature "$OUTPUT_PKG_PATH"
+printf '%s operation=package-app-store-pkg status=success output=%s\n' \
+    "$(date '+%Y-%m-%dT%H:%M:%S%z')" "$OUTPUT_PKG_PATH"
+printf '%s\n' "Signed App Store installer package: ${OUTPUT_PKG_PATH}"
+printf '%s\n' "Upload it to App Store Connect to submit for review."

--- a/scripts/release/tests/test-package-app-store-pkg.sh
+++ b/scripts/release/tests/test-package-app-store-pkg.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env sh
+
+# Verifies the App Store installer packaging contract: only app-store channel
+# bundles are accepted, the installer identity must exist, and the package is
+# built and signature-checked through productbuild.
+
+set -eu
+
+SUBJECT_TIMEOUT_SECONDS=30
+SANDBOX_DIRECTORY=""
+
+print_error() {
+    printf '%s\n' "Error: $1" >&2
+}
+
+cleanup() {
+    if [ -n "${SANDBOX_DIRECTORY:-}" ] && [ -d "$SANDBOX_DIRECTORY" ]; then
+        case "$SANDBOX_DIRECTORY" in
+            /|.|..) print_error "refusing to remove unsafe packaging test sandbox" ;;
+            *) rm -rf "$SANDBOX_DIRECTORY" ;;
+        esac
+    fi
+}
+trap cleanup 0
+
+main() {
+    repository_root="$(CDPATH='' cd -- "$(dirname -- "$0")/../../.." && pwd -P)"
+    SANDBOX_DIRECTORY="$(mktemp -d "${TMPDIR:-/tmp}/astronomical-app-store-packager.XXXXXX")"
+    fake_command_directory="${SANDBOX_DIRECTORY}/fake-bin"
+    fixture_bundle="${SANDBOX_DIRECTORY}/Astronomical.app"
+    mkdir -p "$fake_command_directory" \
+        "${fixture_bundle}/Contents/MacOS" \
+        "${fixture_bundle}/Contents/Resources"
+    cp "${repository_root}/scripts/internal/package-app-store-pkg.sh" \
+        "${SANDBOX_DIRECTORY}/package-app-store-pkg.sh"
+    chmod +x "${SANDBOX_DIRECTORY}/package-app-store-pkg.sh"
+
+    printf 'fixture-menu' > "${fixture_bundle}/Contents/MacOS/astronomical-menu"
+    printf 'fixture-daemon' > "${fixture_bundle}/Contents/MacOS/astronomicald"
+    printf 'fixture-worker' > "${fixture_bundle}/Contents/MacOS/astronomical-inference-worker"
+    chmod +x "${fixture_bundle}/Contents/MacOS/"*
+    {
+        printf '%s\n' '<?xml version="1.0" encoding="UTF-8"?>'
+        printf '%s\n' '<plist version="1.0"><dict>'
+        printf '%s\n' '<key>AstronomicalChannel</key><string>app-store</string>'
+        printf '%s\n' '<key>CFBundleShortVersionString</key><string>0.3.0</string>'
+        printf '%s\n' '</dict></plist>'
+    } > "${fixture_bundle}/Contents/Info.plist"
+
+    cat > "${fake_command_directory}/plutil" <<'PLUTIL'
+#!/usr/bin/env sh
+if [ "${1:-}" != "-extract" ]; then exit 1; fi
+# The channel answer depends on which bundle was passed, so the reject case
+# can present a non-App-Store bundle to the packager.
+case "${6:-}" in
+    *Direct.app*)
+        case "${2:-}" in
+            AstronomicalChannel) printf '%s\n' stable ;;
+            CFBundleShortVersionString) printf '%s\n' 0.3.0 ;;
+            *) exit 1 ;;
+        esac
+        ;;
+    *)
+        case "${2:-}" in
+            AstronomicalChannel) printf '%s\n' app-store ;;
+            CFBundleShortVersionString) printf '%s\n' 0.3.0 ;;
+            *) exit 1 ;;
+        esac
+        ;;
+esac
+PLUTIL
+    cat > "${fake_command_directory}/security" <<'SECURITY'
+#!/usr/bin/env sh
+if [ "${1:-}" = "find-identity" ]; then
+    printf '%s\n' '  1) ABCDEF1234 "3rd Party Mac Developer Installer: Example (ABCDE12345)"'
+    printf '%s\n' '     1 valid identities found'
+    exit 0
+fi
+exit 1
+SECURITY
+    cat > "${fake_command_directory}/xcrun" <<'XCRUN'
+#!/usr/bin/env sh
+if [ "${1:-}" != "productbuild" ]; then exit 1; fi
+printf '%s\n' "$*" >> "${FAKE_PRODUCTBUILD_LOG:?}"
+# find the trailing output package path (last argument)
+output_path=""
+prev=""
+for argument in "$@"; do
+    output_path="$argument"
+done
+mkdir -p "$(dirname -- "$output_path")"
+printf '%s\n' 'fixture-pkg' > "$output_path"
+exit 0
+XCRUN
+    cat > "${fake_command_directory}/pkgutil" <<'PKGUTIL'
+#!/usr/bin/env sh
+printf '%s\n' "Package \"fixture\": signed with 3rd Party Mac Developer Installer"
+exit 0
+PKGUTIL
+    chmod +x "${fake_command_directory}"/*
+
+    run_packager() {
+        (CDPATH='' cd -- "$SANDBOX_DIRECTORY" && \
+            FAKE_PRODUCTBUILD_LOG="${SANDBOX_DIRECTORY}/productbuild.log" \
+            PATH="${fake_command_directory}:${PATH}" timeout "$SUBJECT_TIMEOUT_SECONDS" \
+            "${SANDBOX_DIRECTORY}/package-app-store-pkg.sh" "$@")
+    }
+
+    printf '%s\n' '[app-store-packager-test] case=rejects-non-app-store-bundle status=start'
+    non_store_bundle="${SANDBOX_DIRECTORY}/Direct.app"
+    mkdir -p "${non_store_bundle}/Contents"
+    cp "${fixture_bundle}/Contents/Info.plist" "${non_store_bundle}/Contents/Info.plist"
+    sed -i '' 's/<string>app-store<\/string>/<string>stable<\/string>/' \
+        "${non_store_bundle}/Contents/Info.plist"
+    if run_packager --app-bundle "$non_store_bundle" \
+        --installer-identity "3rd Party Mac Developer Installer: Example (ABCDE12345)" \
+        > "${SANDBOX_DIRECTORY}/reject.log" 2>&1; then
+        print_error "packager accepted a non-App-Store bundle"
+        exit 1
+    fi
+    grep -F "only App Store channel bundles can be packaged" \
+        "${SANDBOX_DIRECTORY}/reject.log" >/dev/null || {
+        print_error "packager did not explain the channel rejection"
+        exit 1
+    }
+    printf '%s\n' '[app-store-packager-test] case=rejects-non-app-store-bundle status=success'
+
+    printf '%s\n' '[app-store-packager-test] case=rejects-missing-installer-identity status=start'
+    sed -i '' '/3rd Party Mac Developer Installer/d' "${fake_command_directory}/security"
+    if run_packager --app-bundle "$fixture_bundle" \
+        --installer-identity "3rd Party Mac Developer Installer: Example (ABCDE12345)" \
+        > "${SANDBOX_DIRECTORY}/identity.log" 2>&1; then
+        print_error "packager accepted a missing installer identity"
+        exit 1
+    fi
+    grep -F "installer identity is not available as a valid code signing identity" \
+        "${SANDBOX_DIRECTORY}/identity.log" >/dev/null || {
+        print_error "packager did not explain the identity rejection"
+        exit 1
+    }
+    printf '%s\n' '[app-store-packager-test] case=rejects-missing-installer-identity status=success'
+
+    printf '%s\n' '[app-store-packager-test] case=packages-and-signs status=start'
+    # restore the identity fixture for the successful case
+    sed -i '' 's/     1 valid identities found/     1 valid identities found/' "${fake_command_directory}/security"
+    cat > "${fake_command_directory}/security" <<'SECURITY'
+#!/usr/bin/env sh
+if [ "${1:-}" = "find-identity" ]; then
+    printf '%s\n' '  1) ABCDEF1234 "3rd Party Mac Developer Installer: Example (ABCDE12345)"'
+    printf '%s\n' '     1 valid identities found'
+    exit 0
+fi
+exit 1
+SECURITY
+    run_packager --app-bundle "$fixture_bundle" \
+        --installer-identity "3rd Party Mac Developer Installer: Example (ABCDE12345)" \
+        --output-pkg "${SANDBOX_DIRECTORY}/out/Astronomical-app-store.pkg"
+    [ -s "${SANDBOX_DIRECTORY}/out/Astronomical-app-store.pkg" ] || {
+        print_error "signed installer package was not produced"
+        exit 1
+    }
+    grep -F -- '--component' "${SANDBOX_DIRECTORY}/productbuild.log" >/dev/null || {
+        print_error "productbuild was not invoked with the app component"
+        exit 1
+    }
+    grep -F -- '--sign 3rd Party Mac Developer Installer: Example (ABCDE12345)' \
+        "${SANDBOX_DIRECTORY}/productbuild.log" >/dev/null || {
+        print_error "productbuild was not invoked with the installer identity"
+        exit 1
+    }
+    printf '%s\n' '[app-store-packager-test] case=packages-and-signs status=success'
+}
+
+main "$@"

--- a/scripts/release/tests/test-release-contracts.sh
+++ b/scripts/release/tests/test-release-contracts.sh
@@ -9,6 +9,7 @@ repository_root="$(CDPATH='' cd -- "$(dirname -- "$0")/../../.." && pwd -P)"
 for contract_test in \
     test-render-app-icon.sh \
     test-build-macos-app.sh \
+    test-package-app-store-pkg.sh \
     test-create-dmg.sh \
     test-validate-distribution-app.sh \
     test-notarize-dmg.sh \


### PR DESCRIPTION
# Add the App Store installer packaging step

## Linked issue

Refs #381

## What changed

The App Store submission flow gains its final local artifact: a signed installer package. `scripts/internal/package-app-store-pkg.sh` takes an App Store channel bundle and:

- refuses anything that does not declare the `app-store` channel,
- requires the third-party Mac Developer Installer identity to exist as a valid code signing identity,
- builds the package with `productbuild` against `/Applications`,
- verifies the signature with `pkgutil` before reporting the upload-ready path.

App Store Connect rejects unsigned or Developer ID-signed packages, which is why the packaging script enforces the installer identity instead of trusting whatever signature the bundle already carries.

## Verification

- New contract test `test-package-app-store-pkg.sh` (registered in the release contract suite): rejects non-App-Store bundles with an explanatory error, rejects missing installer identities, and asserts `productbuild` receives the app component and the installer identity — three cases, all green.
- `scripts/verify-before-commit.sh`: 18/18 steps green.
