### PR TITLE
Match entitlement assertions against both codesign output shapes

### DIFF
--- a/scripts/internal/validate-macos-app.sh
+++ b/scripts/internal/validate-macos-app.sh
@@ -133,7 +133,10 @@ assert_sandbox_entitlement() {
     executable_path="$1"
     entitlement_key="$2"
     executable_label="$3"
-    if codesign -d --entitlements - "$executable_path" 2>/dev/null         | grep -F "<key>${entitlement_key}</key>" >/dev/null 2>&1; then
+    # codesign renders DER entitlements in its decoded [Key] form rather than
+    # the XML source form, so match the bare key name against either shape.
+    if codesign -d --entitlements - "$executable_path" 2>/dev/null \
+        | grep -F "${entitlement_key}" >/dev/null 2>&1; then
         return 0
     fi
     print_error "App Store executable ${executable_label} is missing the ${entitlement_key} entitlement"


### PR DESCRIPTION
## Linked issue

Refs #381

## What changed

The App Store validator's entitlement assertions grepped for the XML `<key>…</key>` shape, but `codesign -d --entitlements -` renders DER entitlements in its decoded bracket form. A correctly signed App Store bundle therefore failed validation. The assertion now matches the bare key name, which appears in both renderings.

Found during the first real end-to-end `--channel app-store` build: the bundle was correctly signed with the Apple Distribution identity and carried all three entitlements, but the validator rejected it.

## Verification

- `scripts/test-validate-macos-app-contract.sh`: all cases green.
- `scripts/verify-before-commit.sh`: 18/18 steps green.