### PR TITLE
Skip the Sparkle signature check for App Store bundles

### DIFF
--- a/scripts/internal/validate-macos-app.sh
+++ b/scripts/internal/validate-macos-app.sh
@@ -324,7 +324,9 @@ main() {
         done
     fi
     codesign --verify --deep --strict "$APP_BUNDLE_PATH"
-    codesign --verify --deep --strict "$sparkle_framework"
+    if [ "$application_channel" != "app-store" ]; then
+        codesign --verify --deep --strict "$sparkle_framework"
+    fi
     daemon_version_output="$("$daemon_executable" --version)"
     case "$daemon_version_output" in
         *"${application_version}"*"${application_commit}"*) ;;


### PR DESCRIPTION
## Linked issue

Refs #381

## What changed

The validator's signature step verified the embedded Sparkle framework unconditionally. App Store bundles carry no Sparkle framework by design (guideline 2.4.5(vii) exclusion from #383/#384), so the check failed after the channel-specific checks had already passed. The signature verification now runs only for channels that ship the framework.

## Verification

- Found by the first real end-to-end `--channel app-store` build; the bundle now validates: `Validated 0.2.28 app-store bundle without launching it`.
- `scripts/test-validate-macos-app-contract.sh`: all cases green.