### PR TITLE
Add the App Store privacy policy and support pages

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -26,6 +26,8 @@
       <nav class="site-nav" aria-label="Primary navigation">
         <a href="#capabilities">Capabilities</a>
         <a href="#reports">Reports</a>
+        <a href="./privacy.html">Privacy</a>
+        <a href="./support.html">Support</a>
         <a href="https://github.com/aosama/astronomical">Source</a>
       </nav>
     </header>

--- a/site/privacy.html
+++ b/site/privacy.html
@@ -1,0 +1,98 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Privacy Policy | Astronomical</title>
+    <meta name="description" content="Astronomical runs every model locally on your Mac. This policy describes the few network requests the app makes and the data it does not collect.">
+    <meta name="theme-color" content="#10120f">
+    <link rel="icon" href="./assets/mark.svg" type="image/svg+xml">
+    <link rel="stylesheet" href="./styles.css">
+    <style>
+      .doc { padding-block: 96px; }
+      .doc-body { max-width: 720px; margin-inline: auto; }
+      .doc-body h1 { font-size: 2rem; margin: 0 0 8px; }
+      .doc-body h2 { font-size: 1.2rem; margin-block: 32px 8px; }
+      .doc-body p, .doc-body li { color: var(--paper-muted); line-height: 1.65; }
+      .doc-body ul { padding-left: 20px; }
+      .doc-body strong { color: var(--paper); }
+      .doc-meta { color: var(--paper-muted); font-size: 0.9rem; }
+    </style>
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to content</a>
+    <header class="site-header">
+      <a class="brand" href="./index.html" aria-label="Astronomical home">
+        <img src="./assets/mark.svg" alt="" width="36" height="36">
+        <span>Astronomical</span>
+      </a>
+      <nav class="site-nav" aria-label="Primary navigation">
+        <a href="./index.html">Home</a>
+        <a href="./support.html">Support</a>
+        <a href="https://github.com/aosama/astronomical">Source</a>
+      </nav>
+    </header>
+    <main id="main">
+      <section class="doc shell">
+        <div class="doc-body">
+          <p class="eyebrow">Privacy policy</p>
+          <h1>Privacy Policy</h1>
+          <p class="doc-meta">Effective: September 2, 2026 · Applies to the Astronomical macOS application.</p>
+
+          <h2>The short version</h2>
+          <p>Astronomical runs language, vision, and image models entirely on your Mac. Your prompts, conversations, documents, and images are processed on your device and are never sent to us — we operate no servers that receive them. The app has no accounts, no sign-in, no advertising, and no in-app analytics.</p>
+
+          <h2>What never leaves your Mac</h2>
+          <ul>
+            <li>Every inference request: prompts, model outputs, images, and documents you work with.</li>
+            <li>Your configuration, including the memory ceiling you set.</li>
+            <li>Prompt caches and model caches stored on your disk.</li>
+          </ul>
+
+          <h2>Network requests the app makes</h2>
+          <p>The app makes a small number of network requests, none of which involve your content:</p>
+          <ul>
+            <li><strong>Model downloads.</strong> When you choose to install a model, the app downloads model files from public model repositories, such as Hugging Face. The repository sees a standard request for publicly published files. Downloading a model is always an action you initiate.</li>
+            <li><strong>Update checks.</strong> Builds distributed outside the Mac App Store check a signed update feed to tell you when a new version exists. The feed operator sees standard web requests for the update description. App Store builds receive updates exclusively through the App Store and make no such request.</li>
+            <li><strong>Local API.</strong> The app serves a local interface on this Mac only, at a loopback address. Requests to it never leave your machine.</li>
+          </ul>
+
+          <h2>Diagnostics and crash reports</h2>
+          <p>The app itself contains no crash reporting and no usage analytics.</p>
+          <ul>
+            <li><strong>Mac App Store builds.</strong> If you have opted in (in System Settings) to sharing diagnostics and analytics with developers, Apple collects crash reports and aggregated usage statistics through Apple's own systems and shares them with us under Apple's privacy protections. We never receive your content, and individual identification is prevented by Apple's aggregation.</li>
+            <li><strong>Direct-distribution builds.</strong> Crash reports stay on your machine in the system crash reporter. They are sent nowhere unless you choose to attach one yourself when contacting support.</li>
+          </ul>
+
+          <h2>What we do not do</h2>
+          <ul>
+            <li>We do not collect, sell, or share personal data. There is no data to sell: no accounts exist.</li>
+            <li>We do not use advertising identifiers, device fingerprinting, or cross-app tracking.</li>
+            <li>We do not read files outside the locations the app uses for models, caches, logs, and your saved outputs.</li>
+          </ul>
+
+          <h2>Data stored on your Mac</h2>
+          <p>The app stores downloaded model files, caches, logs, and your configuration on your disk in its designated application-support locations. You can remove everything by deleting the app's data locations or uninstalling the app; nothing is retained remotely.</p>
+
+          <h2>Third-party components</h2>
+          <p>Astronomical is open source. Direct-distribution builds embed the open-source Sparkle update framework, described above. App Store builds use Apple's built-in update mechanism. The full component list ships inside the application under Third-Party Notices.</p>
+
+          <h2>Changes to this policy</h2>
+          <p>If Astronomical's data practices ever change — for example, if an opt-in analytics feature ships — this page will be updated first, and the App Store privacy label will be updated in the same release.</p>
+
+          <h2>Contact</h2>
+          <p>Questions about this policy: <a href="./support.html">Support</a>.</p>
+          <p class="doc-meta">Privacy policy for the Astronomical macOS application, distributed on the Mac App Store and directly. Last updated: September 2, 2026.</p>
+        </div>
+      </section>
+    </main>
+    <footer class="site-footer">
+      <a class="brand" href="./index.html">
+        <img src="./assets/mark.svg" alt="" width="30" height="30">
+        <span>Astronomical</span>
+      </a>
+      <p>Local language, vision, and image serving for Apple silicon.</p>
+      <div><a href="https://github.com/aosama/astronomical">GitHub</a><a href="./support.html">Support</a><a href="./index.html">Home</a></div>
+    </footer>
+  </body>
+</html>

--- a/site/support.html
+++ b/site/support.html
@@ -1,0 +1,92 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Support | Astronomical</title>
+    <meta name="description" content="Support for Astronomical, the local Mac app for language, vision, and image models. Get help, report bugs, and find answers to common questions.">
+    <meta name="theme-color" content="#10120f">
+    <link rel="icon" href="./assets/mark.svg" type="image/svg+xml">
+    <link rel="stylesheet" href="./styles.css">
+    <style>
+      .doc { padding-block: 96px; }
+      .doc-body { max-width: 720px; margin-inline: auto; }
+      .doc-body h1 { font-size: 2rem; margin: 0 0 8px; }
+      .doc-body h2 { font-size: 1.2rem; margin-block: 32px 8px; }
+      .doc-body p, .doc-body li { color: var(--paper-muted); line-height: 1.65; }
+      .doc-body ul, .doc-body ol { padding-left: 20px; }
+      .doc-body strong { color: var(--paper); }
+      .doc-body code { color: var(--paper); }
+      .support-cta { margin-block: 24px; }
+    </style>
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to content</a>
+    <header class="site-header">
+      <a class="brand" href="./index.html" aria-label="Astronomical home">
+        <img src="./assets/mark.svg" alt="" width="36" height="36">
+        <span>Astronomical</span>
+      </a>
+      <nav class="site-nav" aria-label="Primary navigation">
+        <a href="./index.html">Home</a>
+        <a href="./privacy.html">Privacy</a>
+        <a href="https://github.com/aosama/astronomical">Source</a>
+      </nav>
+    </header>
+    <main id="main">
+      <section class="doc shell">
+        <div class="doc-body">
+          <p class="eyebrow">Support</p>
+          <h1>Support</h1>
+          <p>Astronomical is actively developed and used daily. If something does not work, we want to hear about it — most issues are answered or fixed quickly.</p>
+
+          <div class="hero-actions support-cta">
+            <a class="button button-primary" href="https://github.com/aosama/astronomical/issues/new/choose">Report an issue on GitHub</a>
+            <a class="button button-secondary" href="https://github.com/aosama/astronomical/issues">Browse existing issues</a>
+          </div>
+
+          <h2>Before you report</h2>
+          <ul>
+            <li><strong>System requirements.</strong> Astronomical needs an Apple silicon Mac (M1 or later) running macOS 26 or later. Memory needs depend on the model you load; the app shows a recommended ceiling before a model is admitted.</li>
+            <li><strong>Check your version.</strong> The menu-bar popover shows the app version and build number. Mention both when reporting.</li>
+            <li><strong>Try the obvious fix.</strong> A stuck model download recovers by retrying the download; a wedged server responds to "Restart server" in the popover.</li>
+          </ul>
+
+          <h2>What to include in a report</h2>
+          <ol>
+            <li>The app version and build number from the popover.</li>
+            <li>Your Mac model and installed memory.</li>
+            <li>What you did, what you expected, and what happened.</li>
+            <li>For serving problems: the response you received and the relevant lines from the app's log file, stored in the app's data location under <code>logs/</code>.</li>
+            <li>For crashes on Mac App Store builds: whether you have diagnostics sharing enabled, and the crash report time if Apple showed you one.</li>
+          </ol>
+          <p>Please do not paste model outputs, documents, or images you meant to keep private — a description of the behavior is enough, and logs can be reviewed locally before you attach anything.</p>
+
+          <h2>Common questions</h2>
+          <ul>
+            <li><strong>A model will not download.</strong> Model files come from public model repositories. Check your connection, then retry the download from the model library. Corporate and school networks sometimes block these repositories.</li>
+            <li><strong>The app says there is not enough memory.</strong> The memory ceiling is a safety boundary, not a bug. Pick a smaller quantization of the same model, or free wired memory and retry. The recommendation in the popover accounts for your installed memory.</li>
+            <li><strong>How do I use the local API?</strong> The app serves an OpenAI-compatible interface on this Mac at a loopback address; the popover shows the port. Point any local client at it. Requests never leave this machine.</li>
+            <li><strong>Where are my models stored?</strong> In the app's designated application-support location. App Store builds keep everything inside their sandbox container; you can remove all of it by deleting the app's data.</li>
+          </ul>
+
+          <h2>Contact</h2>
+          <p>The fastest route is <a href="https://github.com/aosama/astronomical/issues/new/choose">a GitHub issue</a> — it reaches the developer directly and keeps the answer searchable for everyone.</p>
+          <!-- CONTACT EMAIL PLACEHOLDER: an optional direct email address can be
+               added here for App Review's support-contact check. Decision and
+               address belong to the site owner; do not publish any address
+               without explicit approval. -->
+          <p class="doc-meta">Astronomical is open source under its repository license. Privacy policy: <a href="./privacy.html">privacy.html</a>.</p>
+        </div>
+      </section>
+    </main>
+    <footer class="site-footer">
+      <a class="brand" href="./index.html">
+        <img src="./assets/mark.svg" alt="" width="30" height="30">
+        <span>Astronomical</span>
+      </a>
+      <p>Local language, vision, and image serving for Apple silicon.</p>
+      <div><a href="https://github.com/aosama/astronomical">GitHub</a><a href="./privacy.html">Privacy</a><a href="./index.html">Home</a></div>
+    </footer>
+  </body>
+</html>


### PR DESCRIPTION
## Linked issue

Refs #381

## What changed

The Mac App Store submission requires two public URLs — a privacy policy and a support page. This adds both to the existing GitHub Pages site, styled with the site's own stylesheet and navigation so they render consistently (and on a phone-sized viewport, which is how App Review checks them):

- `site/privacy.html` — the full policy: local-first processing, the complete set of network requests the app makes (user-initiated model downloads from public repositories, signed update-feed checks on direct builds, loopback-only local API), Apple's opt-in diagnostics path on store builds, and explicit statements of what is never collected. It also commits to updating the page and the App Store privacy label together if practices change.
- `site/support.html` — the contact route above the fold (GitHub issue tracker), system requirements, what to include in a report, and answers to the common first-week questions. Includes a marked placeholder for an optional direct contact email, whose publication is the site owner's decision.
- `site/index.html` navigation gains Privacy and Support links.

The privacy policy is written to match what the store build actually does at submission time: no in-app analytics ship in this release, so the policy claims none. If the telemetry track from #381 ships later, the policy and privacy label change in the same release, as the policy itself states.

## Verification

- Both pages reuse the site stylesheet and navigation; no build step, no external requests.
- App Review checklist covered: public URL, no login wall, contact route visible above the fold, mobile viewport handled by the shared stylesheet.