### PR TITLE
Bind the App Store channel to app.astronomical.appstore

### DIFF
--- a/scripts/internal/build-macos-app.sh
+++ b/scripts/internal/build-macos-app.sh
@@ -313,7 +313,7 @@ main() {
             release_directory="${repository_root}/target/astronomical-macos-app-store.noindex"
             app_bundle_path="${release_directory}/Astronomical.app"
             bundle_name="Astronomical"
-            bundle_identifier="dev.astronomical.app.appstore"
+            bundle_identifier="app.astronomical.appstore"
             supervisor_port="6732"
             state_directory_name=""
             icon_channel="stable"

--- a/scripts/internal/validate-macos-app.sh
+++ b/scripts/internal/validate-macos-app.sh
@@ -288,7 +288,7 @@ main() {
             ;;
         app-store)
             expected_supervisor_port="6732"
-            expected_bundle_identifier="dev.astronomical.app.appstore"
+            expected_bundle_identifier="app.astronomical.appstore"
             # App Store bundles carry no state-directory name: state derives from
             # Application Support. A present key is the failure, so its absence
             # is proven by the extraction itself failing.

--- a/scripts/release/tests/test-build-macos-app.sh
+++ b/scripts/release/tests/test-build-macos-app.sh
@@ -398,7 +398,7 @@ CODESIGN
         print_error "App Store bundle does not declare the app-store channel"
         exit 1
     }
-    grep -F '<key>CFBundleIdentifier</key><string>dev.astronomical.app.appstore</string>' \
+    grep -F '<key>CFBundleIdentifier</key><string>app.astronomical.appstore</string>' \
         "${app_store_app_bundle}/Contents/Info.plist" >/dev/null || {
         print_error "App Store bundle does not carry the app-store bundle identifier"
         exit 1


### PR DESCRIPTION
## Linked issue

Refs #381

## What changed

The App Store channel's bundle identifier is decided and applied across the packaging pipeline: `app.astronomical.appstore` in the build script's channel case, the validator's expected identity, and the builder contract test's assertion. The direct channel keeps `dev.astronomical.app`.

## Verification

- Builder contract suite: all four cases green, including the app-store case asserting the new identifier in the generated Info.plist.
- Validator contract suite: all cases green.