### PR TITLE
Wait for the natural worker exit before snapshotting exit diagnostics

### DIFF
--- a/apps/supervisor/src/worker_process.rs
+++ b/apps/supervisor/src/worker_process.rs
@@ -19,6 +19,12 @@ use crate::{WorkerControlError, worker_stderr_tail::WorkerStderrTail};
 
 const WORKER_STDERR_READ_BYTES: usize = 1_024;
 const WORKER_EXIT_DIAGNOSTIC_SETTLE_TIMEOUT: Duration = Duration::from_secs(1);
+// A worker that just closed its stdout is milliseconds from exiting. The
+// exit diagnostic waits this long for the natural exit before falling back
+// to the "still running" snapshot, so the reported status is the real exit
+// code even when the kernel has not reaped the child at the instant of the
+// first check.
+const WORKER_NATURAL_EXIT_GRACE_TIMEOUT: Duration = Duration::from_secs(1);
 
 /// Outcome reported after a worker process is terminated and reaped.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -393,10 +399,23 @@ impl WorkerProcess {
                 }
             }
         }
-        let process_exit_status = match self.worker_process.try_wait() {
-            Ok(Some(worker_exit_status)) => worker_exit_status_description(worker_exit_status),
-            Ok(None) => "process still running after closing stdout".to_owned(),
-            Err(wait_error) => format!("failed to inspect process exit status: {wait_error}"),
+        let process_exit_status = match timeout(
+            WORKER_NATURAL_EXIT_GRACE_TIMEOUT,
+            self.worker_process.wait(),
+        )
+        .await
+        {
+            Ok(Ok(worker_exit_status)) => worker_exit_status_description(worker_exit_status),
+            Ok(Err(wait_error)) => {
+                format!("failed to inspect process exit status: {wait_error}")
+            }
+            Err(_) => match self.worker_process.try_wait() {
+                Ok(Some(worker_exit_status)) => worker_exit_status_description(worker_exit_status),
+                Ok(None) => "process still running after closing stdout".to_owned(),
+                Err(wait_error) => {
+                    format!("failed to inspect process exit status: {wait_error}")
+                }
+            },
         };
         WorkerControlError::WorkerProcessExited {
             process_exit_status,


### PR DESCRIPTION
## Linked issue

Refs #381

## What changed

Surfaced by a post-merge CI run that flaked this exact test. The worker exit-diagnostic collector probed the child with a single non-blocking `try_wait()` immediately after the event stream closed. A worker that has just closed its stdout is milliseconds from exiting, and on a loaded runner the kernel frequently has not reaped the child at that instant — so the diagnostic wrongly reported `process still running after closing stdout` for a worker that exited normally a moment later. That wrong diagnostic flaked the `worker_launch` hermetic test on CI (the PR run passed, the post-merge run failed on the identical commit) and misreports the exit reason to operators.

The collector now waits up to a bounded one-second grace period for the natural exit (the worker is by definition already exiting), falling back to the still-running snapshot only if the grace period expires. A hung worker is still reported as hung; an exiting worker is now reported with its true exit code, deterministically.

## Verification

- `worker_launch` group: 8/8 green, five consecutive runs.
- Full supervisor hermetic suite green.
- `scripts/verify-before-commit.sh` to run on this branch before merge (18 steps).


