### PR TITLE
Show Restoring… while prompt-cache restore has no prefill progress yet

### DIFF
--- a/apps/astronomical-menu/Sources/AstronomicalMenuCore/SupervisorStatusPresentation.swift
+++ b/apps/astronomical-menu/Sources/AstronomicalMenuCore/SupervisorStatusPresentation.swift
@@ -9,6 +9,14 @@ extension SupervisorStatusDocument {
       || activity == "generating" || activity == "image_generation"
   }
 
+  // Prompt-processing activity is published as soon as the request starts, but
+  // the first PrefillProgress event arrives only after prompt-cache restore
+  // returns. Missing progress in that window is restore work, not idle and not
+  // expert SSD streaming.
+  private var isRestoringPromptCache: Bool {
+    activity == "prompt_processing" && progress == nil
+  }
+
   // The status endpoint supplies request-elapsed time during prompt processing and phase-elapsed
   // time during generation, so only token progress can produce a meaningful token rate.
   var currentPhaseTokensPerSecond: Double? {
@@ -32,6 +40,7 @@ extension SupervisorStatusDocument {
         : "Image · \(progress.shortImagePhaseTitle)"
     }
     if activity == "generation_preparation" { return "Preparing…" }
+    if isRestoringPromptCache { return "Restoring…" }
     guard activity == "prompt_processing", let progress else { return "" }
     let completionPercentageTitle = progress.completionPercentageTitle
     if progress.phase == "drafter" { return "Drafting…" }
@@ -52,6 +61,7 @@ extension SupervisorStatusDocument {
         : progress.imagePhaseTitle
     }
     if activity == "generation_preparation" { return "Preparing generation…" }
+    if isRestoringPromptCache { return "Restoring prompt cache" }
     guard let progress else { return phaseTitle }
     if progress.phase == "drafter" { return "Drafting…" }
     guard let currentPhaseTokensPerSecond else {
@@ -64,7 +74,9 @@ extension SupervisorStatusDocument {
     switch activity {
     case "generating": "Generating"
     case "generation_preparation": "Preparing generation"
-    case "prompt_processing": progress?.phase == "drafter" ? "Drafting…" : "Prompt processing"
+    case "prompt_processing" where isRestoringPromptCache: "Restoring prompt cache"
+    case "prompt_processing" where progress?.phase == "drafter": "Drafting…"
+    case "prompt_processing": "Prompt processing"
     case "image_generation": progress?.imagePhaseTitle ?? "Generating image"
     default:
       switch status {
@@ -99,7 +111,9 @@ extension SupervisorStatusDocument {
   }
 
   var progressTitle: String {
-    guard let progress else { return "Standing by" }
+    guard let progress else {
+      return isRestoringPromptCache ? "Restoring prompt cache" : "Standing by"
+    }
     if progress.unit == .steps {
       guard progress.phase == "denoising" else { return progress.imagePhaseTitle }
       if progress.hasCompletedDenoising { return "Denoising complete" }
@@ -120,6 +134,7 @@ extension SupervisorStatusDocument {
   }
 
   var elapsedTimeTitle: String {
+    if isRestoringPromptCache { return "Calculating" }
     guard let progress else { return "Not active" }
     let elapsedSeconds = Double(progress.elapsedMilliseconds) / 1_000
     guard progress.unit != .steps && progress.phase != "generation"
@@ -139,6 +154,7 @@ extension SupervisorStatusDocument {
   }
 
   var hasDeterminateProgress: Bool {
+    if isRestoringPromptCache { return false }
     guard let progress else { return true }
     return progress.unit != .steps || progress.phase == "denoising"
   }

--- a/apps/astronomical-menu/tests/AstronomicalMenuContractTests/PromptCacheRestorePresentationTests.swift
+++ b/apps/astronomical-menu/tests/AstronomicalMenuContractTests/PromptCacheRestorePresentationTests.swift
@@ -1,0 +1,27 @@
+// Journey: a request is already active, but the first prefill progress event has
+// not arrived yet. The menu extra and popover must name prompt-cache restore
+// instead of looking idle. Prompt and GEN titles after progress exists stay in
+// StatusPresentationContractTests.
+
+import XCTest
+
+@testable import AstronomicalMenuCore
+
+final class PromptCacheRestorePresentationTests: XCTestCase {
+  func test_should_name_prompt_processing_without_progress_as_prompt_cache_restore() throws {
+    let statusDocument = try JSONDecoder().decode(
+      SupervisorStatusDocument.self,
+      from: Data(#"{"status":"ready","activity":"prompt_processing"}"#.utf8)
+    )
+
+    XCTAssertEqual(statusDocument.menuBarTitle, "Restoring…")
+    XCTAssertEqual(statusDocument.phaseTitle, "Restoring prompt cache")
+    XCTAssertEqual(statusDocument.flightTitle, "Restoring prompt cache")
+    XCTAssertEqual(statusDocument.progressTitle, "Restoring prompt cache")
+    XCTAssertFalse(
+      statusDocument.hasDeterminateProgress,
+      "restore has no token totals yet, so the popover must not draw a 0% bar"
+    )
+    XCTAssertEqual(statusDocument.elapsedTimeTitle, "Calculating")
+  }
+}


### PR DESCRIPTION
## Linked issue

Fixes #392

## What changed

When a chat request is already active but the first prefill progress event has not arrived, the menu extra showed a blank title and the popover could look idle. That window is prompt-cache restore, not expert paging.

The extra now shows `Restoring…` and the popover shows `Restoring prompt cache`, with an indeterminate progress bar until the first prefill event. After that, existing Prompt percentage and GEN copy are unchanged.

## Verification

- `scripts/test-macos-menu-contracts.sh`
- `scripts/verify-before-commit.sh`
