### PR TITLE
Classify owned daemon death as an early exit, not a readiness timeout

### DIFF
--- a/apps/astronomical-menu/Sources/AstronomicalMenuCore/DaemonLifecycleController.swift
+++ b/apps/astronomical-menu/Sources/AstronomicalMenuCore/DaemonLifecycleController.swift
@@ -189,6 +189,7 @@ final class DaemonLifecycleController {
       return
     }
     try startOwnedDaemon(menuExecutableURL: menuExecutableURL, daemonExecutableURL: daemonExecutableURL)
+    try throwIfOwnedDaemonExited()
     try await waitForExpectedInstanceReadiness()
   }
 
@@ -212,6 +213,7 @@ final class DaemonLifecycleController {
       throw DaemonLifecycleError.bundledDaemonUnavailable
     }
     try startOwnedDaemon(menuExecutableURL: menuExecutableURL, daemonExecutableURL: daemonExecutableURL)
+    try throwIfOwnedDaemonExited()
     try await waitForExpectedInstanceReadiness()
     return "Server restarted"
   }
@@ -258,22 +260,39 @@ final class DaemonLifecycleController {
     let readinessClock = ContinuousClock()
     let readinessDeadline = readinessClock.now.advanced(by: readinessTimeout)
     while readinessClock.now < readinessDeadline {
+      // A dead child must win over a health poll. Otherwise a fast exit can be
+      // reported as a readiness timeout after SIGTERM reaps a zombie.
+      try throwIfOwnedDaemonExited()
       if await supervisorClient.expectedInstanceIsHealthy() { return }
-      if ownedDaemonProcess?.reapIfExited() == true {
-        clearOwnedDaemonState()
-        throw DaemonLifecycleError.daemonExitedBeforeReady(
-          applicationIdentity.expectedConfigurationFile)
-      }
+      try throwIfOwnedDaemonExited()
       try await Task.sleep(for: readinessPollInterval)
     }
     if await supervisorClient.expectedInstanceIsHealthy() { return }
-    if ownedDaemonProcess?.reapIfExited() == true {
-      clearOwnedDaemonState()
-      throw DaemonLifecycleError.daemonExitedBeforeReady(
-        applicationIdentity.expectedConfigurationFile)
+    try throwIfOwnedDaemonExited()
+    if reapOwnedDaemonWithin(.milliseconds(50)) {
+      try throwIfOwnedDaemonExited()
     }
     await stopUnreadyOwnedDaemon()
     throw DaemonLifecycleError.readinessTimedOut(applicationIdentity.expectedConfigurationFile)
+  }
+
+  private func throwIfOwnedDaemonExited() throws {
+    guard ownedDaemonProcess?.reapIfExited() == true else { return }
+    clearOwnedDaemonState()
+    throw DaemonLifecycleError.daemonExitedBeforeReady(
+      applicationIdentity.expectedConfigurationFile)
+  }
+
+  private func reapOwnedDaemonWithin(_ gracePeriod: Duration) -> Bool {
+    guard let ownedDaemonProcess else { return false }
+    if ownedDaemonProcess.reapIfExited() { return true }
+    let reapClock = ContinuousClock()
+    let reapDeadline = reapClock.now.advanced(by: gracePeriod)
+    while reapClock.now < reapDeadline {
+      if ownedDaemonProcess.reapIfExited() { return true }
+      usleep(1_000)
+    }
+    return ownedDaemonProcess.reapIfExited()
   }
 
   private func waitForExistingInstanceReadiness() async throws {

--- a/apps/astronomical-menu/tests/AstronomicalMenuContractTests/DaemonControlTests.swift
+++ b/apps/astronomical-menu/tests/AstronomicalMenuContractTests/DaemonControlTests.swift
@@ -214,6 +214,28 @@ final class DaemonControlTests: XCTestCase {
   }
 
   @MainActor
+  func test_should_classify_an_immediate_daemon_exit_as_early_exit_when_readiness_timeout_is_short()
+    async throws
+  {
+    let testContext = try DaemonLifecycleTestContext(daemonExecutablePath: "/usr/bin/false")
+    defer { testContext.removeTemporaryDirectory() }
+    let daemonLifecycleController = testContext.makeController(
+      supervisorClient: DelayedReadinessSupervisorClient(readyAfterCheckCount: .max),
+      readinessTimeout: .milliseconds(10))
+
+    do {
+      try await daemonLifecycleController.startDaemonIfNeeded()
+      XCTFail("An exited daemon must not be reported as ready")
+    } catch let lifecycleError as DaemonLifecycleError {
+      guard case let .daemonExitedBeforeReady(configurationFileLabel) = lifecycleError else {
+        return XCTFail("Expected an early-exit error, received \(lifecycleError)")
+      }
+      XCTAssertEqual(configurationFileLabel, "~/.astronomical/config.json")
+    }
+    XCTAssertFalse(daemonLifecycleController.ownsDaemon)
+  }
+
+  @MainActor
   func test_should_keep_stable_and_development_configuration_labels_isolated() async throws {
     for (applicationIdentity, expectedConfigurationLabel, otherConfigurationLabel) in [
       (


### PR DESCRIPTION
## Linked issue

Fixes #396

## Problem

When the owned server process exits before it is healthy, startup could report a readiness timeout as if the process were still running. Post-merge menu contracts failed that way: `/usr/bin/false` was classified as `readinessTimedOut` instead of `daemonExitedBeforeReady`. Health polls ran before reaping, a fast zombie could be missed until SIGTERM, and timeout was thrown anyway.

## Change

Treat owned-daemon death as an early exit through the start-and-wait path: immediately after spawn, on every readiness poll before the health check, and after the deadline with a short blocking reap before SIGTERM. A process that remains alive and never becomes healthy is still a readiness timeout.

## Verification

- `scripts/test-macos-menu-contracts.sh` (103 tests)
- `scripts/verify-before-commit.sh`

## Safety

- [x] No credentials, personal paths, prompts, model inventories, proprietary artifacts, or machine logs are included.
- [x] Model precision and output semantics are preserved or explicitly justified.
- [x] Performance and memory effects are measured when the critical path changes.
- [x] Source reuse and third-party licensing are accurately attributed.
