### PR TITLE
chore: bump version to 0.2.31

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,7 +39,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "astronomical-config"
-version = "0.2.30"
+version = "0.2.31"
 dependencies = [
  "libc",
  "serde",
@@ -52,7 +52,7 @@ dependencies = [
 
 [[package]]
 name = "astronomical-experimental-aligned-expert-packs"
-version = "0.2.30"
+version = "0.2.31"
 dependencies = [
  "astronomical-config",
  "astronomical-model-serving",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "astronomical-inference-worker"
-version = "0.2.30"
+version = "0.2.31"
 dependencies = [
  "astronomical-config",
  "astronomical-ipc-protocol",
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "astronomical-ipc-protocol"
-version = "0.2.30"
+version = "0.2.31"
 dependencies = [
  "base64 0.23.1",
  "bytes",
@@ -109,7 +109,7 @@ dependencies = [
 
 [[package]]
 name = "astronomical-model-serving"
-version = "0.2.30"
+version = "0.2.31"
 dependencies = [
  "astronomical-config",
  "astronomical-ipc-protocol",
@@ -133,7 +133,7 @@ dependencies = [
 
 [[package]]
 name = "astronomical-rest-contract"
-version = "0.2.30"
+version = "0.2.31"
 dependencies = [
  "base64 0.23.1",
  "regex-automata",
@@ -144,7 +144,7 @@ dependencies = [
 
 [[package]]
 name = "astronomical-runtime-integration"
-version = "0.2.30"
+version = "0.2.31"
 dependencies = [
  "bindgen",
  "fs4",
@@ -156,7 +156,7 @@ dependencies = [
 
 [[package]]
 name = "astronomical-supervisor"
-version = "0.2.30"
+version = "0.2.31"
 dependencies = [
  "astronomical-config",
  "astronomical-ipc-protocol",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ license = "Apache-2.0"
 publish = false
 repository = "https://github.com/aosama/astronomical"
 rust-version = "1.97.1"
-version = "0.2.30"
+version = "0.2.31"
 
 [workspace.dependencies]
 async-openai = { version = "0.41.3", default-features = false, features = ["byot", "chat-completion"] }


### PR DESCRIPTION
## Linked issue

Refs #418

## Problem

The upcoming 0.2.31 stable release needs the workspace version bumped from 0.2.30.

## Change

Bump `[workspace.package].version` in `Cargo.toml` to 0.2.31 and regenerate `Cargo.lock` (only the eight Astronomical workspace package versions change).

## Verification

- `scripts/release/tests/test-release-contracts.sh`
- `scripts/verify-before-commit.sh` (18/18)
- `git diff` on `Cargo.lock` touches only Astronomical workspace package versions

## Safety

- [x] No credentials, personal paths, prompts, model inventories, proprietary artifacts, or machine logs are included.
- [x] Model precision and output semantics are preserved or explicitly justified.
- [x] Performance and memory effects are measured when the critical path changes.
- [x] Source reuse and third-party licensing are accurately attributed.