### PR TITLE
Align public copy with the memory-ceiling product identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Run bigger local language and vision models on Apple Silicon without requiring every sparse expert to live in RAM.**
 
-Astronomical is a performance-first local model runner for Mac users who want serious models, private inference, and direct control over memory. Set the maximum model RAM your laptop can spare and Astronomical automatically balances hot expert weights, live context, runtime work, and solid-state-drive streaming under that ceiling.
+You set the model RAM your laptop can spare. Astronomical is a local model runner for Mac users who want serious models, private inference, and direct control over memory: it automatically balances hot expert weights, live context, runtime work, and solid-state-drive streaming under that ceiling.
 
 Read the product story and public engineering reports at [aosama.github.io/astronomical](https://aosama.github.io/astronomical/).
 
@@ -67,10 +67,10 @@ Prompts, responses, model files, and persistent prompt state stay on the local M
 Astronomical is experimental and deliberately focused:
 
 - Any Apple silicon M-series Mac.
-- macOS 14 (Sonoma) and later is the declared support spectrum; the current Stable release still requires macOS 26, and Sonoma support begins with the next Stable cut. Capability probes and public MLX fallbacks protect correctness across the range; combinations outside the tested set are supported best-effort.
-- Validated Qwen3.5/Qwen3.6 and Laguna artifacts supported by the repository.
+- macOS 14 (Sonoma) and later on any Apple silicon M-series Mac, declared best-effort. Capability probes and public MLX fallbacks protect correctness across the range; combinations outside the tested set are supported best-effort.
+- Validated Qwen3.5/Qwen3.6, Laguna, FLUX.2 Klein, and ModernBERT embedding artifacts supported by the repository.
 - One local user and one active generation at a time.
-- OpenAI-compatible chat completions, responses, model discovery, and server-sent event streaming over loopback only.
+- OpenAI-compatible chat completions, responses, embeddings, image generation, model discovery, and server-sent event streaming over loopback only.
 
 A supported model runs on every Apple silicon M-series Mac that meets the operating-system floor. Measured custom Metal kernels keep capable GPUs on their fastest path; where a GPU cannot run one, the same request completes through public MLX APIs with the output precision the model artifact specifies. Throughput still depends on the GPU generation, the memory ceiling, the model, and storage speed.
 

--- a/apps/supervisor/console/index.html
+++ b/apps/supervisor/console/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="Astronomical local model server status, telemetry, chat playground, and controls.">
+    <meta name="description" content="Astronomical Observatory: local model-runner status, telemetry, chat playground, and controls.">
     <title>Astronomical Observatory</title>
     <link rel="icon" href="data:,">
     <link rel="stylesheet" href="/console.css">

--- a/apps/supervisor/src/daemon_arguments.rs
+++ b/apps/supervisor/src/daemon_arguments.rs
@@ -4,7 +4,7 @@ use astronomical_config::{
     AstronomicalConfigError, AstronomicalInstancePaths, AstronomicalRuntimeInstance,
 };
 
-const HELP_TEXT: &str = "Astronomical local model server\n\nUsage: astronomicald [--instance stable|development] [--state-directory PATH]\n       astronomicald --help\n       astronomicald --version\n\nOptions:\n  --instance INSTANCE      Runtime instance (default: development)\n  --state-directory PATH   Absolute writable state root for this invocation\n  -h, --help               Show this help\n  --version                Show exact build identity\n";
+const HELP_TEXT: &str = "Astronomical local model runner\n\nUsage: astronomicald [--instance stable|development] [--state-directory PATH]\n       astronomicald --help\n       astronomicald --version\n\nOptions:\n  --instance INSTANCE      Runtime instance (default: development)\n  --state-directory PATH   Absolute writable state root for this invocation\n  -h, --help               Show this help\n  --version                Show exact build identity\n";
 
 pub(crate) enum DaemonCommand {
     Run(DaemonArguments),

--- a/docs/decisions/platform-support-spectrum.md
+++ b/docs/decisions/platform-support-spectrum.md
@@ -3,7 +3,7 @@
 - Status: proposed — accepted on merge (2026-09-05)
 - Origin: repository issue #406 — "Align M-series and macOS spectrum support with baseline correctness and probe-gated boosters"
 
-> Deployment note: the pins below apply to future builds. The current Stable release (0.2.29) still requires macOS 26; public copy states this transition explicitly, and the downloadable floor changes when the next Stable cut regenerates the Sparkle appcast with the 14.0 floor.
+> Deployment note: Stable 0.2.30 and later declare `minimumSystemVersion` 14.0 on the signed Sparkle feed. Earlier Stable cuts (through 0.2.29) required macOS 26.
 
 ## Decision
 

--- a/repo-discovery-guide-for-agents.md
+++ b/repo-discovery-guide-for-agents.md
@@ -4,11 +4,11 @@ Agent orientation map for non-obvious repository facts; this is not user-facing 
 
 ## Maintenance mandate
 
-Read this guide before substantive work and spot-check 2-3 key facts. Update it when paths, entry points, conventions, or expensive gotchas change. Treat it as suspect when Last verified is more than 90 days old. Last verified: 2026-09-06 (catalog schema 2 adds ModernBERT embeddings entries; native `POST /v1/embeddings` on ModernBERT 8-bit; MLX pin v0.32.2).
+Read this guide before substantive work and spot-check 2-3 key facts. Update it when paths, entry points, conventions, or expensive gotchas change. Treat it as suspect when Last verified is more than 90 days old. Last verified: 2026-09-06 (product identity is local model runner, not local model server; catalog schema 2; native embeddings; MLX pin v0.32.2).
 
 ## Project overview
 
-Astronomical is an Apple Silicon local model server. The active architecture is a localhost Rust HTTP/SSE process plus one Rust worker subprocess; the worker owns MLX, artifact validation, model state, and chat, image, or embedding inference. Only one model is resident in GPU memory at a time; the supervisor hot-swaps to a different discovered model when a request changes identity or modality.
+Astronomical is an Apple Silicon local model runner. The active architecture is a localhost Rust HTTP/SSE process plus one Rust worker subprocess; the worker owns MLX, artifact validation, model state, and chat, image, or embedding inference. Only one model is resident in GPU memory at a time; the supervisor hot-swaps to a different discovered model when a request changes identity or modality.
 
 ## Known gotchas
 
@@ -124,7 +124,7 @@ Astronomical is an Apple Silicon local model server. The active architecture is 
 - docs/expert-paging-cpu-gpu-ssd-execution-flow.md - verified map of Rust bounded expert streaming, ordinary Machine Learning framework for Apple silicon gathered projections, and SafeTensors source reads. Update it whenever those boundaries change.
 - apps/supervisor/ - localhost astronomicald, Axum REST/SSE, one WorkerHandle, one shared chat/image/embeddings FIFO, one concrete worker loop, and one WorkerProcess. `src/library/` owns catalog, durable download controls, publication, and discovery refresh; `src/supervisor_performance_attribution.rs` owns supervisor operation records. Image and embeddings request, event, and endpoint owners remain separate from chat streaming while sharing model swap, cancellation, containment, memory controls, and status. The embedded Astronomical Observatory serves named deep links including `/library`; GET /v1/system/telemetry exposes local GPU utilization and nullable macOS memory pressure.
 - apps/inference-worker/ - private worker executable; owns model startup and direct MLX serving.
-- apps/astronomical-menu/ - standalone macOS 26 Swift Package menu-bar application. Its bundle identity injects the expected channel, endpoint, state directory, version, and commit. It owns only that instance's bundled astronomicald, consumes the enriched /v1/status document, and renders the Astronomical-specific Orbital Telemetry popover. Build/test it with Swift Package Manager, not Cargo.
+- apps/astronomical-menu/ - standalone Swift Package menu-bar application (macOS 14 deployment target). Its bundle identity injects the expected channel, endpoint, state directory, version, and commit. It owns only that instance's bundled astronomicald, consumes the enriched /v1/status document, and renders the Astronomical-specific Orbital Telemetry popover. Build/test it with Swift Package Manager, not Cargo.
 - crates/config/ - strict standard-user configuration loader used by the daemon and supervisor resolver; workers receive resolved startup settings through IPC.
 - crates/rest-contract/ - public OpenAI-compatible REST/SSE DTOs.
 - crates/ipc-protocol/ - bounded supervisor/worker command and event DTOs.

--- a/site/index.html
+++ b/site/index.html
@@ -4,11 +4,11 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Astronomical | Local models without the memory wall</title>
-    <meta name="description" content="Astronomical is a local Mac app for language, vision, and image models. Set one memory ceiling, install a curated model, and keep every request on this laptop.">
+    <meta name="description" content="Set one memory ceiling. Astronomical runs language, vision, and image models on this Mac — sparse experts stream from SSD when they do not fit, without hidden quantization.">
     <meta name="theme-color" content="#10120f">
     <meta property="og:type" content="website">
     <meta property="og:title" content="Astronomical | Local models without the memory wall">
-    <meta property="og:description" content="A local Mac app for language, vision, and image models. One memory ceiling. Nothing leaves the laptop.">
+    <meta property="og:description" content="Set one memory ceiling. Sparse experts stream from SSD when they do not fit. Declared precision is preserved. Nothing leaves the laptop.">
     <meta property="og:url" content="https://aosama.github.io/astronomical/">
     <meta property="og:image" content="https://raw.githubusercontent.com/aosama/astronomical/main/.github/assets/astronomical-ram-ssd-streaming.jpeg">
     <meta name="twitter:card" content="summary_large_image">
@@ -35,9 +35,9 @@
     <main id="main">
       <section class="hero shell">
         <div class="hero-copy">
-          <p class="eyebrow"><span class="signal-dot"></span> Local Mac app / Apple silicon</p>
+          <p class="eyebrow"><span class="signal-dot"></span> One memory ceiling / Apple silicon</p>
           <h1>Run the model.<br><em>Not the memory bill.</em></h1>
-          <p class="hero-deck">Astronomical is a local app for language, vision, and image models. You set one memory ceiling. Sparse experts move between memory and solid-state storage. Every request stays on this Mac.</p>
+          <p class="hero-deck">You set one memory ceiling. Astronomical is a local model runner for language, vision, and image models: sparse experts move between memory and solid-state storage when they do not fit. Every request stays on this Mac.</p>
           <div class="hero-actions">
             <a class="button button-primary" href="https://github.com/aosama/astronomical/releases/latest">Get the Mac app</a>
             <a class="button button-secondary" href="#capabilities">See what it can do</a>
@@ -72,7 +72,7 @@
             <p class="section-index">01 / On this Mac</p>
             <h2 id="use-title">Install. Open Library. Point a local client.</h2>
           </div>
-          <p>Astronomical is a menu-bar app with an embedded local console. It serves one user on Apple silicon. The current Stable release requires macOS 26; macOS 14 (Sonoma) support begins with the next Stable release, declared best-effort.</p>
+          <p>Astronomical is a local model runner for one user on Apple silicon. You set one memory ceiling; sparse experts stream between unified memory and solid-state storage when the full payload does not fit. The native menu and Observatory console show that state. Stable requires macOS 14 (Sonoma) or later, declared best-effort across the M-series spectrum.</p>
         </div>
         <div class="use-grid">
           <article class="use-card">
@@ -219,7 +219,7 @@
         <img src="./assets/mark.svg" alt="" width="30" height="30">
         <span>Astronomical</span>
       </a>
-      <p>Local language, vision, and image serving for Apple silicon.</p>
+      <p>Local language, vision, and image models for Apple silicon.</p>
       <div><a href="https://github.com/aosama/astronomical">GitHub</a><a href="#capabilities">Capabilities</a><a href="#reports">Reports</a></div>
     </footer>
   </body>

--- a/site/privacy.html
+++ b/site/privacy.html
@@ -91,7 +91,7 @@
         <img src="./assets/mark.svg" alt="" width="30" height="30">
         <span>Astronomical</span>
       </a>
-      <p>Local language, vision, and image serving for Apple silicon.</p>
+      <p>Local language, vision, and image models for Apple silicon.</p>
       <div><a href="https://github.com/aosama/astronomical">GitHub</a><a href="./support.html">Support</a><a href="./index.html">Home</a></div>
     </footer>
   </body>

--- a/site/support.html
+++ b/site/support.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Support | Astronomical</title>
-    <meta name="description" content="Support for Astronomical, the local Mac app for language, vision, and image models. Get help, report bugs, and find answers to common questions.">
+    <meta name="description" content="Support for Astronomical, a local model runner for Apple silicon with one memory ceiling. Get help, report bugs, and find answers to common questions.">
     <meta name="theme-color" content="#10120f">
     <link rel="icon" href="./assets/mark.svg" type="image/svg+xml">
     <link rel="stylesheet" href="./styles.css">
@@ -47,7 +47,7 @@
 
           <h2>Before you report</h2>
           <ul>
-            <li><strong>System requirements.</strong> Astronomical needs an Apple silicon Mac (M1 or later). The current Stable release requires macOS 26 or later; macOS 14 (Sonoma) support begins with the next Stable release and is declared best-effort, with hardware features the GPU cannot prove falling back to public MLX paths with no loss of declared model precision. Memory needs depend on the model you load; the app shows a recommended ceiling before a model is admitted.</li>
+            <li><strong>System requirements.</strong> Astronomical needs an Apple silicon Mac (M1 or later) running macOS 14 (Sonoma) or later. Support across that spectrum is declared best-effort: hardware features the GPU cannot prove fall back to public MLX paths with no loss of declared model precision. Memory needs depend on the model you load; the app shows a recommended ceiling before a model is admitted.</li>
             <li><strong>Check your version.</strong> The menu-bar popover shows the app version and build number. Mention both when reporting.</li>
             <li><strong>Try the obvious fix.</strong> A stuck model download recovers by retrying the download; a wedged server responds to "Restart server" in the popover.</li>
           </ul>
@@ -85,7 +85,7 @@
         <img src="./assets/mark.svg" alt="" width="30" height="30">
         <span>Astronomical</span>
       </a>
-      <p>Local language, vision, and image serving for Apple silicon.</p>
+      <p>Local language, vision, and image models for Apple silicon.</p>
       <div><a href="https://github.com/aosama/astronomical">GitHub</a><a href="./privacy.html">Privacy</a><a href="./index.html">Home</a></div>
     </footer>
   </body>


### PR DESCRIPTION
## Linked issue

Fixes #421

## Problem

Public copy still defined Astronomical as a menu-bar app or local model server, and some pages still claimed the current Stable release required macOS 26 after 0.2.30 shipped the 14.0 floor. That buried the actual product: one user-set RAM ceiling, RAM↔SSD expert streaming, declared precision preserved.

## Change

Lead GitHub-facing and Pages copy with the ceiling. README, site meta/hero/support, Observatory meta, and `astronomicald --help` now use local model runner as the noun and the memory ceiling as the opening promise. Stale macOS 26 floor statements are corrected.

GitHub About description and the `moe` topic were updated on the repository settings (not in this diff).

## Verification

- `scripts/verify-before-commit.sh` (18/18)
- Copy-only change; no model-serving behavior change

## Safety

- [x] No credentials, personal paths, prompts, model inventories, proprietary artifacts, or machine logs are included.
- [x] Model precision and output semantics are preserved or explicitly justified.
- [x] Performance and memory effects are measured when the critical path changes.
- [x] Source reuse and third-party licensing are accurately attributed.