### PR TITLE
chore: bump version to 0.2.32

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,7 +39,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "astronomical-config"
-version = "0.2.31"
+version = "0.2.32"
 dependencies = [
  "libc",
  "serde",
@@ -52,7 +52,7 @@ dependencies = [
 
 [[package]]
 name = "astronomical-experimental-aligned-expert-packs"
-version = "0.2.31"
+version = "0.2.32"
 dependencies = [
  "astronomical-config",
  "astronomical-model-serving",
@@ -68,7 +68,7 @@ dependencies = [
 
 [[package]]
 name = "astronomical-inference-worker"
-version = "0.2.31"
+version = "0.2.32"
 dependencies = [
  "astronomical-config",
  "astronomical-ipc-protocol",
@@ -94,7 +94,7 @@ dependencies = [
 
 [[package]]
 name = "astronomical-ipc-protocol"
-version = "0.2.31"
+version = "0.2.32"
 dependencies = [
  "base64 0.23.1",
  "bytes",
@@ -110,7 +110,7 @@ dependencies = [
 
 [[package]]
 name = "astronomical-model-serving"
-version = "0.2.31"
+version = "0.2.32"
 dependencies = [
  "astronomical-config",
  "astronomical-ipc-protocol",
@@ -134,7 +134,7 @@ dependencies = [
 
 [[package]]
 name = "astronomical-rest-contract"
-version = "0.2.31"
+version = "0.2.32"
 dependencies = [
  "base64 0.23.1",
  "regex-automata",
@@ -145,7 +145,7 @@ dependencies = [
 
 [[package]]
 name = "astronomical-runtime-integration"
-version = "0.2.31"
+version = "0.2.32"
 dependencies = [
  "bindgen",
  "fs4",
@@ -157,7 +157,7 @@ dependencies = [
 
 [[package]]
 name = "astronomical-supervisor"
-version = "0.2.31"
+version = "0.2.32"
 dependencies = [
  "astronomical-config",
  "astronomical-ipc-protocol",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ license = "Apache-2.0"
 publish = false
 repository = "https://github.com/aosama/astronomical"
 rust-version = "1.97.1"
-version = "0.2.31"
+version = "0.2.32"
 
 [workspace.dependencies]
 async-openai = { version = "0.41.3", default-features = false, features = ["byot", "chat-completion"] }


### PR DESCRIPTION
## Summary

Bump the workspace version to 0.2.32 for the next Stable release. No source changes; `Cargo.lock` moves only Astronomical workspace package versions.

Release notes and the digest-bound artifact set are prepared under the release issue.

## Linked issue

Refs #433
