### PR TITLE
Auto-refresh stale third-party notices on default-branch builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,9 +302,18 @@ jobs:
               printf '%s\n' "Automated dependency pull request: refreshing third-party/RUST_DEPENDENCY_NOTICES in place (bots cannot commit the regenerated file)."
               scripts/generate-rust-dependency-notices.sh
               ;;
-            *)
+            pull_request:*)
               printf '%s\n' "Error: third-party/RUST_DEPENDENCY_NOTICES is stale; run scripts/generate-rust-dependency-notices.sh and commit the result" >&2
               exit 1
+              ;;
+            *)
+              # Default-branch pushes can carry a bot-merged dependency update
+              # whose committed notices file is one regeneration behind. The
+              # bundled app must never ship stale notices, so refresh in
+              # place; the next human commit restores the committed copy
+              # through the strict pre-commit verification.
+              printf '%s\n' "Default-branch build: refreshing third-party/RUST_DEPENDENCY_NOTICES in place."
+              scripts/generate-rust-dependency-notices.sh
               ;;
           esac
         timeout-minutes: 2


### PR DESCRIPTION
## Summary

Bot-merged dependency updates land on the default branch with the committed `third-party/RUST_DEPENDENCY_NOTICES` one regeneration behind (bots cannot commit the regenerated file — see #444). A strict staleness check on default-branch pushes would therefore leave main red after every merged dependency update until the next human commit.

Default-branch builds now refresh the notices file in place and bundle the regenerated content, so a shipped app always carries accurate third-party notices regardless of committed-file drift. The strict regenerate-and-commit contract remains exactly where it belongs: human pull requests and the pre-commit verification that gates every release-prep commit.

## Linked issue

Refs #444