### PR TITLE
Bump version to 0.2.34

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,7 +39,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "astronomical-config"
-version = "0.2.33"
+version = "0.2.34"
 dependencies = [
  "libc",
  "serde",
@@ -52,7 +52,7 @@ dependencies = [
 
 [[package]]
 name = "astronomical-experimental-aligned-expert-packs"
-version = "0.2.33"
+version = "0.2.34"
 dependencies = [
  "astronomical-config",
  "astronomical-model-serving",
@@ -68,7 +68,7 @@ dependencies = [
 
 [[package]]
 name = "astronomical-inference-worker"
-version = "0.2.33"
+version = "0.2.34"
 dependencies = [
  "astronomical-config",
  "astronomical-ipc-protocol",
@@ -94,7 +94,7 @@ dependencies = [
 
 [[package]]
 name = "astronomical-ipc-protocol"
-version = "0.2.33"
+version = "0.2.34"
 dependencies = [
  "base64 0.23.1",
  "bytes",
@@ -110,7 +110,7 @@ dependencies = [
 
 [[package]]
 name = "astronomical-model-serving"
-version = "0.2.33"
+version = "0.2.34"
 dependencies = [
  "astronomical-config",
  "astronomical-ipc-protocol",
@@ -134,7 +134,7 @@ dependencies = [
 
 [[package]]
 name = "astronomical-rest-contract"
-version = "0.2.33"
+version = "0.2.34"
 dependencies = [
  "base64 0.23.1",
  "regex-automata",
@@ -145,7 +145,7 @@ dependencies = [
 
 [[package]]
 name = "astronomical-runtime-integration"
-version = "0.2.33"
+version = "0.2.34"
 dependencies = [
  "bindgen",
  "fs4",
@@ -157,7 +157,7 @@ dependencies = [
 
 [[package]]
 name = "astronomical-supervisor"
-version = "0.2.33"
+version = "0.2.34"
 dependencies = [
  "astronomical-config",
  "astronomical-ipc-protocol",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ license = "Apache-2.0"
 publish = false
 repository = "https://github.com/aosama/astronomical"
 rust-version = "1.97.1"
-version = "0.2.33"
+version = "0.2.34"
 
 [workspace.dependencies]
 async-openai = { version = "0.41.3", default-features = false, features = ["byot", "chat-completion"] }

--- a/third-party/RUST_DEPENDENCY_NOTICES
+++ b/third-party/RUST_DEPENDENCY_NOTICES
@@ -1737,7 +1737,7 @@ Used by:
 - rustls-platform-verifier 0.7.0
 - safetensors 0.8.0
 - spm_precompiled 0.1.4
-- tokenizers 0.23.1
+- tokenizers 0.23.2
 - zune-core 0.5.1
 - zune-jpeg 0.5.15
 
@@ -2373,14 +2373,14 @@ Used by:
 Apache License 2.0
 
 Used by:
-- futures-channel 0.3.33
-- futures-core 0.3.33
+- futures-channel 0.3.34
+- futures-core 0.3.34
 - futures-executor 0.3.33
-- futures-io 0.3.33
-- futures-macro 0.3.33
-- futures-sink 0.3.33
-- futures-task 0.3.33
-- futures-util 0.3.33
+- futures-io 0.3.34
+- futures-macro 0.3.34
+- futures-sink 0.3.34
+- futures-task 0.3.34
+- futures-util 0.3.34
 - futures 0.3.33
 
                               Apache License
@@ -3899,7 +3899,7 @@ Used by:
 - rayon-cond 0.4.0
 - rayon-core 1.13.0
 - rayon 1.12.0
-- regex-automata 0.4.16
+- regex-automata 0.4.18
 - regex-syntax 0.8.11
 - regex 1.13.1
 - rustc_version 0.4.1
@@ -5250,7 +5250,7 @@ Apache License 2.0
 Used by:
 - allocator-api2 0.2.21
 - aws-lc-sys 0.44.0
-- daachorse 1.0.1
+- daachorse 3.0.3
 - dary_heap 0.3.9
 - dunce 1.0.5
 - eventsource-stream 0.2.3


### PR DESCRIPTION
## Summary

Bumps the workspace package version to 0.2.34 and regenerates `third-party/RUST_DEPENDENCY_NOTICES` so the committed copy matches the lockfile.

User-visible product changes already on main: concurrent Library payload transfers with in-file segments, an executable-identity download gate, and two new catalog models (Qwen 3.5 0.8B 4-bit and Ornith 1.5 35B A3B OptiQ Static 5.5bpw).

## Linked issue

Refs #447
