### PR TITLE
Prove kernel-fallback serving through full serving-path journeys

### DIFF
--- a/crates/model-serving/src/kernel_capability/fused_expert_decode_probe.rs
+++ b/crates/model-serving/src/kernel_capability/fused_expert_decode_probe.rs
@@ -204,7 +204,7 @@ impl FusedQuantizedExpertDecodeProbe<'_> {
         let down_biases = self
             .runtime
             .array_from_f32(
-                &vec![0.0; PROBE_EXPERT_COUNT * PROBE_DOWN_OUTPUT_DIMENSION],
+                &[0.0; PROBE_EXPERT_COUNT * PROBE_DOWN_OUTPUT_DIMENSION],
                 &[2, PROBE_DOWN_OUTPUT_DIMENSION as i32, 1],
             )
             .map_err(probe_execution)?;
@@ -237,12 +237,14 @@ impl FusedQuantizedExpertDecodeProbe<'_> {
         let mut expected = vec![0.0_f32; PROBE_DOWN_OUTPUT_DIMENSION];
         for score in assignment_scores.iter() {
             let mut assignment_hidden = vec![0.0_f32; PROBE_INTERMEDIATE_DIMENSION];
-            for output_index in 0..PROBE_INTERMEDIATE_DIMENSION {
+            for (output_index, assignment_hidden_element) in
+                assignment_hidden.iter_mut().enumerate()
+            {
                 let gate_row = output_index;
                 let up_row = PROBE_INTERMEDIATE_DIMENSION + output_index;
                 let gate_dot = probe_row_dot(gate_row, row_scale(gate_row), 1.0);
                 let up_dot = probe_row_dot(up_row, row_scale(up_row), 1.0);
-                assignment_hidden[output_index] = silu(gate_dot) * up_dot;
+                *assignment_hidden_element = silu(gate_dot) * up_dot;
             }
             for (output_index, expected_value) in expected.iter_mut().enumerate() {
                 let dot = arbitrary_row_dot(
@@ -275,7 +277,7 @@ fn hidden_values() -> Vec<f32> {
 }
 
 fn row_scale(row: usize) -> f32 {
-    if row % 2 == 0 { 2.0 } else { 3.0 }
+    if row.is_multiple_of(2) { 2.0 } else { 3.0 }
 }
 
 /// Dots the fixed probe hidden vector with one probe weight row:

--- a/crates/model-serving/src/kernel_capability/mod.rs
+++ b/crates/model-serving/src/kernel_capability/mod.rs
@@ -207,6 +207,31 @@ impl WorkerKernelCapabilities {
     }
 }
 
+/// Test-only installation point for forced worker verdicts.
+///
+/// CI hardware cannot make a real kernel fail, so a serving journey seeds the
+/// worker-process verdicts before constructing an engine; the production
+/// consultation path then observes the forced verdicts through the same
+/// `OnceLock` it always uses. Production code must never call this. The
+/// process-global seed means one journey per test process, which matches the
+/// bounded serial execution rule for real-model journeys.
+#[cfg(feature = "direct-mlx")]
+#[doc(hidden)]
+pub fn install_forced_worker_verdicts_for_tests(forced_verdicts: WorkerKernelCapabilities) {
+    if FORCED_WORKER_VERDICTS_FOR_TESTS
+        .set(forced_verdicts)
+        .is_err()
+    {
+        panic!(
+            "forced worker kernel verdicts were already installed for this process; \
+             each serving journey must run in its own process"
+        );
+    }
+}
+
+#[cfg(feature = "direct-mlx")]
+static FORCED_WORKER_VERDICTS_FOR_TESTS: OnceLock<WorkerKernelCapabilities> = OnceLock::new();
+
 /// Returns the retained kernel-capability verdicts for this worker process.
 ///
 /// Verdicts depend only on the GPU and operating system, so the first model
@@ -223,6 +248,9 @@ pub fn worker_process_kernel_capabilities(
 ) -> &'static WorkerKernelCapabilities {
     static WORKER_PROCESS_KERNEL_CAPABILITIES: OnceLock<WorkerKernelCapabilities> = OnceLock::new();
     WORKER_PROCESS_KERNEL_CAPABILITIES.get_or_init(|| {
+        if let Some(forced_verdicts) = FORCED_WORKER_VERDICTS_FOR_TESTS.get() {
+            return forced_verdicts.clone();
+        }
         let sorted_expert_weighted_sum_probe = SortedExpertWeightedSumProbe::new(runtime);
         let fused_expert_decode_probe = FusedQuantizedExpertDecodeProbe::new(runtime);
         let target_verification_probe = TargetVerificationProjectionProbe::new(runtime);

--- a/crates/model-serving/src/lib.rs
+++ b/crates/model-serving/src/lib.rs
@@ -156,6 +156,8 @@ pub use k2_horizon_mova::{
 #[cfg(feature = "direct-mlx")]
 pub use kernel_capability::SortedExpertWeightedSumProbe;
 #[cfg(feature = "direct-mlx")]
+pub use kernel_capability::install_forced_worker_verdicts_for_tests;
+#[cfg(feature = "direct-mlx")]
 pub use kernel_capability::worker_process_kernel_capabilities;
 pub use kernel_capability::{
     CustomKernelVerdict, CustomMetalKernelFamily, CustomMetalKernelProbe, KernelCapabilityError,

--- a/crates/model-serving/tests/common/mod.rs
+++ b/crates/model-serving/tests/common/mod.rs
@@ -43,6 +43,59 @@ pub(crate) fn test_worker_kernel_capabilities(
 
 #[cfg(feature = "direct-mlx")]
 #[allow(dead_code)]
+pub(crate) fn forced_unsupported_worker_kernel_capabilities()
+-> astronomical_model_serving::WorkerKernelCapabilities {
+    // Every family the Qwen3.5 loader consults is demoted with a distinct
+    // unsupported reason so one serving request exercises each fallback
+    // route; the K2-only fused expert decode stays unprobed and fail-closed.
+    use astronomical_model_serving::{CustomKernelVerdict, CustomMetalKernelFamily};
+    let forced_demotion_description = "forced demotion for the serving fallback journey";
+    astronomical_model_serving::WorkerKernelCapabilities::with_forced_verdicts_for_tests([
+        (
+            CustomMetalKernelFamily::SortedExpertWeightedSum,
+            CustomKernelVerdict::Unsupported(
+                astronomical_model_serving::KernelUnsupportedReason::Compilation {
+                    description: forced_demotion_description.to_owned(),
+                },
+            ),
+        ),
+        (
+            CustomMetalKernelFamily::GatedDeltaSequence,
+            CustomKernelVerdict::Unsupported(
+                astronomical_model_serving::KernelUnsupportedReason::Execution {
+                    description: forced_demotion_description.to_owned(),
+                },
+            ),
+        ),
+        (
+            CustomMetalKernelFamily::GatedDeltaBoundaryCheckpoint,
+            CustomKernelVerdict::Unsupported(
+                astronomical_model_serving::KernelUnsupportedReason::OutputMismatch {
+                    description: forced_demotion_description.to_owned(),
+                },
+            ),
+        ),
+        (
+            CustomMetalKernelFamily::TargetVerificationQuantizedLinear,
+            CustomKernelVerdict::Unsupported(
+                astronomical_model_serving::KernelUnsupportedReason::OutputMismatch {
+                    description: forced_demotion_description.to_owned(),
+                },
+            ),
+        ),
+        (
+            CustomMetalKernelFamily::TargetVerificationFourRowQuantizedLinear,
+            CustomKernelVerdict::Unsupported(
+                astronomical_model_serving::KernelUnsupportedReason::OutputMismatch {
+                    description: forced_demotion_description.to_owned(),
+                },
+            ),
+        ),
+    ])
+}
+
+#[cfg(feature = "direct-mlx")]
+#[allow(dead_code)]
 pub(crate) fn standard_worker_chunking_configuration()
 -> astronomical_ipc_protocol::WorkerChunkingConfiguration {
     astronomical_ipc_protocol::WorkerChunkingConfiguration {

--- a/crates/model-serving/tests/hermetic/kernel_capability/forced_verdicts.rs
+++ b/crates/model-serving/tests/hermetic/kernel_capability/forced_verdicts.rs
@@ -39,3 +39,52 @@ fn should_force_a_supported_verdict() {
 
     assert!(capabilities.is_custom_kernel_supported(CustomMetalKernelFamily::GatedDeltaSequence));
 }
+
+#[test]
+fn should_honor_every_forced_reason_for_every_family() {
+    // Families are data, not tests: one loop proves the fail-closed verdict
+    // contract across the whole family catalogue, so a new family is covered
+    // by adding an enum variant, not a new test.
+    let reason_cases = [
+        KernelUnsupportedReason::Compilation {
+            description: "forced compilation failure".to_owned(),
+        },
+        KernelUnsupportedReason::Execution {
+            description: "forced execution failure".to_owned(),
+        },
+        KernelUnsupportedReason::OutputMismatch {
+            description: "forced output mismatch".to_owned(),
+        },
+    ];
+    let every_family = [
+        CustomMetalKernelFamily::SortedExpertWeightedSum,
+        CustomMetalKernelFamily::FusedQuantizedExpertDecode,
+        CustomMetalKernelFamily::GatedDeltaSequence,
+        CustomMetalKernelFamily::GatedDeltaBoundaryCheckpoint,
+        CustomMetalKernelFamily::TargetVerificationQuantizedLinear,
+        CustomMetalKernelFamily::TargetVerificationFourRowQuantizedLinear,
+    ];
+
+    for unsupported_reason in &reason_cases {
+        let forced_verdicts = every_family.map(|family| {
+            (
+                family,
+                CustomKernelVerdict::Unsupported(unsupported_reason.clone()),
+            )
+        });
+        let capabilities =
+            WorkerKernelCapabilities::with_forced_verdicts_for_tests(forced_verdicts);
+
+        for family in every_family {
+            assert_eq!(
+                capabilities.verdict(family),
+                CustomKernelVerdict::Unsupported(unsupported_reason.clone()),
+                "family {family:?} must honor the forced {unsupported_reason:?} verdict",
+            );
+            assert!(
+                !capabilities.is_custom_kernel_supported(family),
+                "a forced-unsupported family must never dispatch the custom kernel",
+            );
+        }
+    }
+}

--- a/crates/model-serving/tests/serving_acceptance/chat/engine.rs
+++ b/crates/model-serving/tests/serving_acceptance/chat/engine.rs
@@ -9,16 +9,11 @@ use astronomical_model_serving::{
 };
 use tokio::time::timeout;
 
-use crate::serving_acceptance::support::IMAGE_PAD_TOKEN_ID;
+use crate::serving_acceptance::support::{IMAGE_PAD_TOKEN_ID, LOCAL_AI_PROMPT_TOKEN_IDS};
 
 const ROMEO_AND_JULIET_SOURCE: &str = include_str!(
     "../../../../../apps/inference-worker/tests/fixtures/model_metrics_5000_romeo_and_juliet_words.txt"
 );
-
-const LOCAL_AI_PROMPT_TOKEN_IDS: [u32; 20] = [
-    248_045, 846, 198, 657, 799, 14_542, 8_495, 314, 2_136, 14_791, 13, 248_046, 198, 248_045,
-    74_455, 198, 248_068, 271, 248_069, 271,
-];
 
 const ROMEO_CONTINUATION_MAX_TOKENS: usize = 20;
 

--- a/crates/model-serving/tests/serving_acceptance/kernel_fallback.rs
+++ b/crates/model-serving/tests/serving_acceptance/kernel_fallback.rs
@@ -1,0 +1,273 @@
+//! Serving journeys that force every custom Metal kernel verdict to
+//! unsupported and prove the request still completes through the public MLX
+//! path with structurally valid output.
+//!
+//! The macOS 14+ best-effort support promise rests on one claim: on a GPU or
+//! OS combination the project has never tested, an unprovable kernel degrades
+//! throughput, never correctness. These journeys protect that claim through
+//! the full engine serving path — artifact validation, model loading, prefill,
+//! and decode — not just the kernel dispatch layer covered by the direct-MLX
+//! demotion parity journeys.
+//!
+//! The forced verdicts are installed before the engine loads, so the loader
+//! consults the same once-per-worker `OnceLock` production uses and retains
+//! the fallback route for the whole process. One journey per process matches
+//! the bounded serial execution rule for real-model journeys.
+
+use std::time::Duration;
+
+use astronomical_ipc_protocol::{ChatMessage, ChatToolChoice, RequestId};
+use astronomical_model_serving::{
+    CustomKernelVerdict, CustomMetalKernelFamily, GeneratedToken, InferenceEngine,
+    K2HorizonMoVAInferenceRequest, K2HorizonMoVAPromptRenderer, K2HorizonMoVARequestOutput,
+    K2HorizonMoVATokenizer, KernelUnsupportedReason, MlxInferenceExecution, PerformanceAttribution,
+    Qwen3_5ArtifactValidator, Qwen3_5Engine, Qwen3_5InferenceRequest,
+    Qwen3_5PromptProcessingChunkSizer, WorkerKernelCapabilities,
+    initialize_k2_horizon_mova_execution, install_forced_worker_verdicts_for_tests,
+    worker_process_kernel_capabilities,
+};
+use astronomical_runtime_integration::MlxRuntime;
+use tokio::time::timeout;
+
+use crate::serving_acceptance::support::{IMAGE_PAD_TOKEN_ID, LOCAL_AI_PROMPT_TOKEN_IDS};
+
+const ROMEO_AND_JULIET_SOURCE: &str = include_str!(
+    "../../../../apps/inference-worker/tests/fixtures/model_metrics_5000_romeo_and_juliet_words.txt"
+);
+
+const FORCED_FALLBACK_MAX_TOKENS: usize = 16;
+
+const FORCED_FALLBACK_TIMEOUT_SECONDS: u64 = 120;
+
+/// Forces every Qwen3.5-consumed kernel family unsupported with a distinct
+/// reason variant, then serves a sampled Romeo and Juliet continuation. The
+/// loader demotes each family to the MLX ops fallback at load time, so the
+/// whole generation runs without any custom kernel.
+#[tokio::test]
+#[ignore = "loads the complete Ornith artifact with every kernel family demoted"]
+async fn should_serve_romeo_and_juliet_through_the_mlx_fallback_when_every_kernel_is_unsupported() {
+    timeout(
+        Duration::from_secs(FORCED_FALLBACK_TIMEOUT_SECONDS),
+        run_forced_fallback_romeo_continuation(),
+    )
+    .await
+    .expect("the forced-fallback continuation must finish within 120 seconds");
+}
+
+async fn run_forced_fallback_romeo_continuation() {
+    let _direct_mlx_guard = crate::common::direct_mlx_test_guard().await;
+    install_forced_worker_verdicts_for_tests(
+        crate::common::forced_unsupported_worker_kernel_capabilities(),
+    );
+    let mlx_memory_limits = crate::common::sample_serving_acceptance_mlx_memory_limits().await;
+    // The engine consults the same once-per-worker verdict owner, so proving
+    // the forced verdicts flow through that owner proves the loader demotes
+    // every family — the fallback cannot be silently skipped.
+    let runtime = MlxRuntime::initialize(mlx_memory_limits)
+        .expect("the forced-fallback journey runtime should initialize");
+    let retained_verdicts =
+        worker_process_kernel_capabilities(&runtime, &mut PerformanceAttribution::disabled());
+    for family in [
+        CustomMetalKernelFamily::SortedExpertWeightedSum,
+        CustomMetalKernelFamily::GatedDeltaSequence,
+        CustomMetalKernelFamily::GatedDeltaBoundaryCheckpoint,
+        CustomMetalKernelFamily::TargetVerificationQuantizedLinear,
+        CustomMetalKernelFamily::TargetVerificationFourRowQuantizedLinear,
+    ] {
+        assert!(
+            !retained_verdicts.is_custom_kernel_supported(family),
+            "family {family:?} must stay demoted for the whole worker process"
+        );
+    }
+    let model_directory = crate::common::configured_large_sparse_moe_model_directory();
+    let validated_artifact = Qwen3_5ArtifactValidator::new()
+        .validate(&model_directory, 20_480)
+        .expect("the Ornith artifact should validate before engine loading");
+    let model_vocabulary_size = validated_artifact.config().vocabulary_size();
+    let mut qwen3_5_engine = Qwen3_5Engine::new_with_prompt_processing_chunk_sizer(
+        validated_artifact,
+        mlx_memory_limits.active_memory_limit_bytes(),
+        mlx_memory_limits.allocator_cache_memory_limit_bytes(),
+        None,
+        Qwen3_5PromptProcessingChunkSizer::for_fixed_prompt_processing_chunk_size_tokens(16)
+            .expect("the test prefill_chunk_tokens should be valid"),
+        IMAGE_PAD_TOKEN_ID,
+        model_directory.to_path_buf(),
+        crate::common::standard_worker_chunking_configuration(),
+        false,
+        crate::common::disabled_worker_speculative_prefill_configuration(),
+    )
+    .expect("the demoted-kernel engine settings should be valid");
+    qwen3_5_engine
+        .load()
+        .await
+        .expect("the engine should load the Ornith model with every kernel demoted");
+    let request_id = RequestId::new(1_100);
+    qwen3_5_engine
+        .start_generation(
+            Qwen3_5InferenceRequest::new_sampling(
+                request_id,
+                LOCAL_AI_PROMPT_TOKEN_IDS.to_vec(),
+                FORCED_FALLBACK_MAX_TOKENS as u16,
+                1_000,
+                1_000,
+                Some(2_222),
+            )
+            .with_image_pad_token_id(IMAGE_PAD_TOKEN_ID),
+        )
+        .await
+        .expect("the engine should accept one forced-fallback request");
+
+    // Structural validity: the fallback path must produce at least one token
+    // within the artifact's declared vocabulary and finish cleanly. Exact
+    // token values are deliberately not asserted so the test does not couple
+    // to one quantization artifact; numeric equivalence of the fallback route
+    // is proven per family by the direct-MLX demotion parity journeys.
+    let mut generated_token_count = 0usize;
+    while generated_token_count < FORCED_FALLBACK_MAX_TOKENS {
+        match qwen3_5_engine
+            .decode_next_token(request_id)
+            .await
+            .expect("each engine boundary should advance the forced-fallback request")
+        {
+            GeneratedToken::TokenId { token_id, .. } => {
+                assert!(
+                    token_id < model_vocabulary_size,
+                    "forced-fallback token id {token_id} must stay within vocabulary size {model_vocabulary_size}"
+                );
+                generated_token_count += 1;
+            }
+            GeneratedToken::PrefillProgress { .. } => {}
+            GeneratedToken::PromptProcessingPhaseStarted { .. } => {}
+            GeneratedToken::GenerationPreparationStarted { .. } => {}
+            GeneratedToken::EndOfSequence => break,
+        }
+    }
+    assert!(
+        generated_token_count > 0,
+        "the forced-fallback path must produce at least one token"
+    );
+}
+/// Forces the two K2 Horizon MoVA kernel families unsupported and serves a
+/// Romeo and Juliet chat request. The fused expert decode demotion is the
+/// historically dangerous one: a silently dropped dispatch once returned
+/// zeros on an untested GPU, so this journey proves the gathered public MLX
+/// route still decodes real text when that verdict is forced.
+#[tokio::test]
+#[ignore = "loads the K2 Horizon MoVA artifact with both kernel families demoted"]
+async fn should_serve_romeo_and_juliet_on_k2_horizon_mova_when_both_kernels_are_unsupported() {
+    timeout(
+        Duration::from_secs(FORCED_FALLBACK_TIMEOUT_SECONDS),
+        run_forced_fallback_k2_generation(),
+    )
+    .await
+    .expect("the K2 forced-fallback request must finish within 120 seconds");
+}
+
+async fn run_forced_fallback_k2_generation() {
+    let _direct_mlx_guard = crate::common::direct_mlx_test_guard().await;
+    install_forced_worker_verdicts_for_tests(k2_forced_unsupported_capabilities());
+    let model_directory = k2_horizon_mova_model_directory();
+    let memory_limits = crate::common::sample_machine_serving_acceptance_mlx_memory_limits().await;
+    let (_processor, mut execution) = initialize_k2_horizon_mova_execution(
+        &model_directory,
+        memory_limits.active_memory_limit_bytes(),
+        memory_limits.allocator_cache_memory_limit_bytes(),
+        true,
+    )
+    .expect("configured K2 Horizon MoVA artifact should start with both kernels demoted");
+    execution
+        .load()
+        .expect("K2 Horizon MoVA weights should load through the MLX fallback");
+
+    let prompt_excerpt = ROMEO_AND_JULIET_SOURCE
+        .chars()
+        .take(280)
+        .collect::<String>();
+    let prompt = K2HorizonMoVAPromptRenderer::new().render(
+        &[ChatMessage::User {
+            content: format!(
+                "Name the two households in the supplied Romeo and Juliet source.\n\n{prompt_excerpt}"
+            ),
+            images: Vec::new(),
+        }],
+        &[],
+        &ChatToolChoice::None,
+    );
+    let tokenizer = K2HorizonMoVATokenizer::from_json_bytes(
+        &std::fs::read(model_directory.join("tokenizer.json"))
+            .expect("tokenizer.json should be readable"),
+        &astronomical_model_serving::K2HorizonMoVAConfig::from_json_bytes(
+            &std::fs::read(model_directory.join("config.json"))
+                .expect("config.json should be readable"),
+        )
+        .expect("family config should parse"),
+    )
+    .expect("tokenizer should load");
+    let prompt_token_ids = tokenizer
+        .encode_prompt(&prompt)
+        .expect("Romeo and Juliet prompt should encode");
+    let max_output_tokens = FORCED_FALLBACK_MAX_TOKENS as u32;
+    execution
+        .start_generation(K2HorizonMoVAInferenceRequest::new(
+            prompt_token_ids,
+            max_output_tokens,
+            1_000,
+            950,
+            Some(2),
+        ))
+        .expect("prefill should start through the fallback dispatch");
+
+    let mut request_output =
+        K2HorizonMoVARequestOutput::new_with_declared_tool_names(&tokenizer, Vec::new());
+    let mut generated_token_count = 0_u32;
+    for decode_step in 0..(max_output_tokens.saturating_add(32)) {
+        match execution
+            .decode_next_token(RequestId::new(u64::from(decode_step) + 1))
+            .expect("decode should advance through the fallback dispatch")
+        {
+            GeneratedToken::TokenId { token_id, .. } => {
+                generated_token_count += 1;
+                request_output
+                    .push_token(token_id)
+                    .expect("token should decode through the fallback dispatch");
+                if generated_token_count >= max_output_tokens {
+                    break;
+                }
+            }
+            GeneratedToken::EndOfSequence => break,
+            GeneratedToken::PrefillProgress { .. }
+            | GeneratedToken::PromptProcessingPhaseStarted { .. }
+            | GeneratedToken::GenerationPreparationStarted { .. } => {}
+        }
+    }
+    assert!(
+        generated_token_count > 0,
+        "the K2 forced-fallback path must produce at least one token"
+    );
+    request_output.finish();
+}
+
+fn k2_forced_unsupported_capabilities() -> WorkerKernelCapabilities {
+    let forced_demotion_description = "forced demotion for the K2 serving fallback journey";
+    WorkerKernelCapabilities::with_forced_verdicts_for_tests([
+        (
+            CustomMetalKernelFamily::SortedExpertWeightedSum,
+            CustomKernelVerdict::Unsupported(KernelUnsupportedReason::Compilation {
+                description: forced_demotion_description.to_owned(),
+            }),
+        ),
+        (
+            CustomMetalKernelFamily::FusedQuantizedExpertDecode,
+            CustomKernelVerdict::Unsupported(KernelUnsupportedReason::OutputMismatch {
+                description: forced_demotion_description.to_owned(),
+            }),
+        ),
+    ])
+}
+
+fn k2_horizon_mova_model_directory() -> std::path::PathBuf {
+    crate::common::configured_installed_model_directory_by_id(
+        crate::common::k2_horizon_mova_model_id(),
+    )
+}

--- a/crates/model-serving/tests/serving_acceptance/mod.rs
+++ b/crates/model-serving/tests/serving_acceptance/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod chat;
 pub(crate) mod expert_paging;
+pub(crate) mod kernel_fallback;
 pub(crate) mod mtp;
 pub(crate) mod residency;
 pub(crate) mod speculative_prefill;

--- a/crates/model-serving/tests/serving_acceptance/support/mod.rs
+++ b/crates/model-serving/tests/serving_acceptance/support/mod.rs
@@ -6,6 +6,10 @@ pub(crate) mod mtp_support;
 pub(crate) mod performance_attribution;
 
 pub(crate) const IMAGE_PAD_TOKEN_ID: u32 = 248_069;
+pub(crate) const LOCAL_AI_PROMPT_TOKEN_IDS: [u32; 20] = [
+    248_045, 846, 198, 657, 799, 14_542, 8_495, 314, 2_136, 14_791, 13, 248_046, 198, 248_045,
+    74_455, 198, 248_068, 271, 248_069, 271,
+];
 pub(crate) const SAY_HI_PROMPT_TOKEN_IDS: [u32; 15] = [
     248_045, 846, 198, 44_240, 15_131, 13, 248_046, 198, 248_045, 74_455, 198, 248_068, 271,
     248_069, 271,

--- a/scripts/run-disposable-cargo-journey.sh
+++ b/scripts/run-disposable-cargo-journey.sh
@@ -23,6 +23,8 @@ print_journeys() {
         accept-client-thinking-budget \
         accept-structured-output \
         accept-embeddings \
+        accept-kernel-fallback-qwen \
+        accept-kernel-fallback-k2 \
         accept-speculative-prefill \
         accept-prompt-cache \
         test-model-ssd-streaming-support \
@@ -107,6 +109,14 @@ main() {
         accept-embeddings)
             lane_name="embeddings-rest"
             set -- cargo test --release -p astronomical-inference-worker --test serving_acceptance_tests --features serving-acceptance should_embed_romeo_and_juliet_lines_through_public_rest -- --ignored --nocapture
+            ;;
+        accept-kernel-fallback-qwen)
+            lane_name="kernel-fallback-qwen-serving"
+            set -- cargo test --release -p astronomical-model-serving --test serving_acceptance_tests --features astronomical-model-serving/direct-mlx should_serve_romeo_and_juliet_through_the_mlx_fallback_when_every_kernel_is_unsupported -- --ignored --nocapture
+            ;;
+        accept-kernel-fallback-k2)
+            lane_name="kernel-fallback-k2-serving"
+            set -- cargo test --release -p astronomical-model-serving --test serving_acceptance_tests --features astronomical-model-serving/direct-mlx should_serve_romeo_and_juliet_on_k2_horizon_mova_when_both_kernels_are_unsupported -- --ignored --nocapture
             ;;
         accept-speculative-prefill)
             lane_name="speculative-prefill-rest"

--- a/scripts/test-cargo-artifact-lifecycle-contract.sh
+++ b/scripts/test-cargo-artifact-lifecycle-contract.sh
@@ -485,6 +485,8 @@ expected_journeys = {
     "accept-client-thinking-budget",
     "accept-structured-output",
     "accept-embeddings",
+    "accept-kernel-fallback-qwen",
+    "accept-kernel-fallback-k2",
     "accept-speculative-prefill",
     "accept-prompt-cache",
     "test-model-ssd-streaming-support",


### PR DESCRIPTION
## Summary

Adds the serving journeys that prove the best-effort platform support promise: on a GPU or OS combination the project has never tested, an unprovable custom Metal kernel degrades throughput, never correctness. Forced-unsupported verdicts now flow through the full serving path, not just the kernel dispatch layer.

- **Qwen3.5 journey:** demotes all five Qwen-consumed kernel families across the three unsupported reason variants (Compilation, Execution, OutputMismatch) in one model load, asserts the once-per-worker verdict owner retains the demotion before engine load, then serves a Romeo and Juliet continuation with structurally valid output (in-vocabulary tokens, clean finish).
- **K2 Horizon MoVA journey:** demotes the sorted expert reduction and the fused expert decode kernels (the historically dangerous silently-dropped-dispatch verdict) and decodes real chat text through the gathered public MLX route.
- **Hermetic matrix:** one loop proves the fail-closed verdict contract for every kernel family and every unsupported reason variant, so a new family is covered by an enum variant, not a new test.
- The forced-verdict installation point pre-seeds the production once-per-worker `OnceLock`; probes, verdict semantics, and fail-closed behavior are unchanged.

## Linked issue

Fixes #409

## Verification

- `scripts/verify-before-commit.sh`: 18/18 steps passed.
- Both GPU journeys pass serially via `scripts/run-disposable-cargo-journey.sh` (`accept-kernel-fallback-qwen`, `accept-kernel-fallback-k2`), each within the 120-second budget.
- Hermetic suite: 766/766 pass.