### PR TITLE
Prove lossless Laguna prompt-cache capture and restore (#105)

### DIFF
--- a/apps/inference-worker/tests/serving_acceptance/laguna/http_restore.rs
+++ b/apps/inference-worker/tests/serving_acceptance/laguna/http_restore.rs
@@ -32,7 +32,11 @@ async fn run_repeated_http_restore() {
     let public_model_id = laguna_xs_public_model_id();
     let isolated_development_home =
         tempfile::tempdir().expect("an isolated Laguna cache home should be created");
-    write_cache_enabled_config(isolated_development_home.path(), &model_directory);
+    write_cache_enabled_config(
+        isolated_development_home.path(),
+        &public_model_id,
+        &model_directory,
+    );
     let rest_server = launch_serving_rest_server_for_model(
         public_model_id,
         model_directory,
@@ -56,33 +60,73 @@ async fn run_repeated_http_restore() {
     .to_string();
 
     eprintln!("[laguna-http-restore] phase=cold");
+    let cold_started_at = std::time::Instant::now();
     let cold_response = post_chat_completion(server_address, request_body.clone()).await;
     assert_successful_streaming_chat_response(&cold_response);
     let cold_cache_stats = json_endpoint(server_address, "/v1/cache/stats").await;
     assert_eq!(cold_cache_stats["persistent_prompt_cache_tokens_saved"], 0);
+    eprintln!(
+        "[laguna-http-restore] phase=cold status=measured elapsed_seconds={:.2}",
+        cold_started_at.elapsed().as_secs_f32()
+    );
 
     eprintln!("[laguna-http-restore] phase=warm");
+    let warm_started_at = std::time::Instant::now();
     let warm_response = post_chat_completion(server_address, request_body).await;
     assert_successful_streaming_chat_response(&warm_response);
     let warm_cache_stats = json_endpoint(server_address, "/v1/cache/stats").await;
+    let restored_token_count = warm_cache_stats["persistent_prompt_cache_tokens_saved"]
+        .as_u64()
+        .unwrap_or(0);
     assert!(
-        warm_cache_stats["persistent_prompt_cache_tokens_saved"]
-            .as_u64()
-            .unwrap_or(0)
-            >= u64::from(PROMPT_CACHE_BLOCK_TOKEN_COUNT),
+        restored_token_count >= u64::from(PROMPT_CACHE_BLOCK_TOKEN_COUNT),
         "the repeated request must restore one cache block: {warm_cache_stats}"
+    );
+    eprintln!(
+        "[laguna-http-restore] phase=warm status=measured elapsed_seconds={:.2} restored_tokens={restored_token_count}",
+        warm_started_at.elapsed().as_secs_f32()
     );
     let status_document = json_endpoint(server_address, "/v1/status").await;
     assert_eq!(status_document["status"], "ready");
     stop_serving_rest_server(rest_server).await;
 }
 
-fn write_cache_enabled_config(isolated_home: &std::path::Path, model_directory: &std::path::Path) {
+fn write_cache_enabled_config(
+    isolated_home: &std::path::Path,
+    model_id: &str,
+    model_directory: &std::path::Path,
+) {
     let configuration_directory = isolated_home.join(".astronomical-dev");
-    fs::create_dir_all(&configuration_directory)
-        .expect("the isolated configuration directory should be created");
+    let models_root = configuration_directory.join("models");
+    // Laguna discovery derives its immutable revision from a Hugging Face
+    // cache entry, and the entry's shard links are relative to the entry
+    // root, so the whole entry is published into the isolated home. A single
+    // directory link keeps the multi-gigabyte weights on their original
+    // volume while the worker discovers them under the public leaf id.
+    let reference_cache_entry_directory = model_directory
+        .parent()
+        .and_then(|snapshots_directory| snapshots_directory.parent())
+        .expect("the resolved reference snapshot should live inside a Hugging Face cache entry");
+    let cache_entry_name = reference_cache_entry_directory
+        .file_name()
+        .and_then(|file_name| file_name.to_str())
+        .expect("the reference cache entry should be named");
+    let decoded_model_id =
+        astronomical_config::decode_huggingface_cache_directory_name(cache_entry_name)
+            .expect("the reference cache entry name should decode");
+    assert_eq!(
+        astronomical_config::leaf_model_id(&decoded_model_id),
+        model_id,
+        "the reference cache entry should decode to the public leaf model id"
+    );
+    fs::create_dir_all(&models_root).expect("the isolated models root should be created");
+    std::os::unix::fs::symlink(
+        reference_cache_entry_directory,
+        models_root.join(cache_entry_name),
+    )
+    .expect("the isolated reference cache entry link should publish");
     let configuration_document = json!({
-        "model_directories": [model_directory],
+        "model_directories": [models_root],
         "max_output_tokens": 8,
         "persistent_prompt_cache_enabled": true,
         "prompt_cache_max_size_gb": 80,

--- a/crates/model-serving/tests/common/laguna.rs
+++ b/crates/model-serving/tests/common/laguna.rs
@@ -1,0 +1,176 @@
+//! Shared synthetic Laguna fixtures for direct-MLX decoder-state journeys.
+//!
+//! One tiny mixed contract (a full-attention append-only layer followed by a
+//! sliding-window rotating layer) keeps capture/restore journeys cheap while
+//! exercising both persistent state kinds in one synthetic, non-pinned layer
+//! ordering. The fixture is intentionally independent of any downloaded model
+//! artifact so mismatch-rejection proofs never require extra downloads.
+
+use std::collections::HashMap;
+
+use astronomical_model_serving::{
+    LagunaAttentionProjection, LagunaExpertProjection, LagunaGlobalTensorRole,
+    LagunaLayerTensorRole, LagunaNativeWeights, LagunaTargetContract, LagunaTargetNormalizer,
+    LagunaTensorComponent, LagunaTensorId,
+};
+use astronomical_runtime_integration::{MlxArray, MlxRuntime};
+use serde_json::json;
+
+/// A two-layer Laguna contract: layer 0 is full attention (append-only state)
+/// and layer 1 is sliding-window attention (rotating state with window 4).
+pub(crate) fn tiny_mixed_contract() -> LagunaTargetContract {
+    let config = json!({
+        "architectures": ["LagunaForCausalLM"],
+        "model_type": "laguna",
+        "vocab_size": 8,
+        "hidden_size": 8,
+        "intermediate_size": 16,
+        "num_hidden_layers": 2,
+        "num_attention_heads": 4,
+        "num_key_value_heads": 2,
+        "head_dim": 2,
+        "max_position_embeddings": 32,
+        "rms_norm_eps": 0.00001,
+        "tie_word_embeddings": false,
+        "torch_dtype": "float32",
+        "layer_types": ["full", "sliding"],
+        "sliding_window": 4,
+        "mlp_layer_types": ["dense", "dense"],
+        "gating_types": ["per_head", "none"],
+        "rope_parameters": {
+            "rope_type": "default",
+            "rope_theta": 10000.0,
+            "partial_rotary_factor": 1.0
+        }
+    });
+    LagunaTargetNormalizer::normalize(&serde_json::to_vec(&config).expect("config bytes"))
+        .expect("tiny mixed Laguna contract should normalize")
+}
+
+/// Binds deterministic synthetic weights shaped by the tiny mixed contract.
+pub(crate) fn bind_tiny_weights(
+    runtime: &MlxRuntime,
+    contract: &LagunaTargetContract,
+) -> LagunaNativeWeights {
+    let mut tensors = HashMap::new();
+    tensors.insert(
+        weight_id(LagunaGlobalTensorRole::TokenEmbedding),
+        ones(runtime, &[8, 8]),
+    );
+    tensors.insert(
+        weight_id(LagunaGlobalTensorRole::FinalNormalization),
+        ones(runtime, &[8]),
+    );
+    tensors.insert(
+        weight_id(LagunaGlobalTensorRole::OutputHead),
+        ones(runtime, &[8, 8]),
+    );
+    for layer_index in 0..2 {
+        tensors.insert(
+            layer_weight_id(layer_index, LagunaLayerTensorRole::InputNormalization),
+            ones(runtime, &[8]),
+        );
+        tensors.insert(
+            layer_weight_id(
+                layer_index,
+                LagunaLayerTensorRole::PostAttentionNormalization,
+            ),
+            ones(runtime, &[8]),
+        );
+        tensors.insert(
+            layer_weight_id(
+                layer_index,
+                LagunaLayerTensorRole::Attention(LagunaAttentionProjection::Query),
+            ),
+            ones(runtime, &[8, 8]),
+        );
+        tensors.insert(
+            layer_weight_id(
+                layer_index,
+                LagunaLayerTensorRole::Attention(LagunaAttentionProjection::Key),
+            ),
+            ones(runtime, &[4, 8]),
+        );
+        tensors.insert(
+            layer_weight_id(
+                layer_index,
+                LagunaLayerTensorRole::Attention(LagunaAttentionProjection::Value),
+            ),
+            ones(runtime, &[4, 8]),
+        );
+        tensors.insert(
+            layer_weight_id(
+                layer_index,
+                LagunaLayerTensorRole::Attention(LagunaAttentionProjection::Output),
+            ),
+            ones(runtime, &[8, 8]),
+        );
+        tensors.insert(
+            layer_weight_id(
+                layer_index,
+                LagunaLayerTensorRole::AttentionQueryNormalization,
+            ),
+            ones(runtime, &[2]),
+        );
+        tensors.insert(
+            layer_weight_id(
+                layer_index,
+                LagunaLayerTensorRole::AttentionKeyNormalization,
+            ),
+            ones(runtime, &[2]),
+        );
+        if layer_index == 0 {
+            tensors.insert(
+                layer_weight_id(
+                    layer_index,
+                    LagunaLayerTensorRole::Attention(LagunaAttentionProjection::Gate),
+                ),
+                ones(runtime, &[4, 8]),
+            );
+        }
+        tensors.insert(
+            layer_weight_id(
+                layer_index,
+                LagunaLayerTensorRole::DenseFeedForward(LagunaExpertProjection::Gate),
+            ),
+            ones(runtime, &[16, 8]),
+        );
+        tensors.insert(
+            layer_weight_id(
+                layer_index,
+                LagunaLayerTensorRole::DenseFeedForward(LagunaExpertProjection::Up),
+            ),
+            ones(runtime, &[16, 8]),
+        );
+        tensors.insert(
+            layer_weight_id(
+                layer_index,
+                LagunaLayerTensorRole::DenseFeedForward(LagunaExpertProjection::Down),
+            ),
+            ones(runtime, &[8, 16]),
+        );
+    }
+    LagunaNativeWeights::bind(runtime, tensors, contract).expect("tiny native weights should bind")
+}
+
+fn ones(runtime: &MlxRuntime, shape: &[i32]) -> MlxArray {
+    let element_count = shape.iter().product::<i32>() as usize;
+    runtime
+        .array_from_f32(&vec![0.05; element_count], shape)
+        .expect("a dense ones-scaled tensor should be valid")
+}
+
+fn weight_id(role: LagunaGlobalTensorRole) -> LagunaTensorId {
+    LagunaTensorId::Global {
+        role,
+        component: LagunaTensorComponent::Weight,
+    }
+}
+
+fn layer_weight_id(layer_index: usize, role: LagunaLayerTensorRole) -> LagunaTensorId {
+    LagunaTensorId::Layer {
+        layer_index,
+        role,
+        component: LagunaTensorComponent::Weight,
+    }
+}

--- a/crates/model-serving/tests/common/mod.rs
+++ b/crates/model-serving/tests/common/mod.rs
@@ -34,6 +34,10 @@ pub(crate) mod qwen3_5_moe;
 
 #[cfg(feature = "direct-mlx")]
 #[allow(dead_code)]
+pub(crate) mod laguna;
+
+#[cfg(feature = "direct-mlx")]
+#[allow(dead_code)]
 pub(crate) fn test_worker_kernel_capabilities(
     runtime: &astronomical_runtime_integration::MlxRuntime,
 ) -> &'static astronomical_model_serving::WorkerKernelCapabilities {

--- a/crates/model-serving/tests/direct_mlx/laguna/decoder_cache_bridge.rs
+++ b/crates/model-serving/tests/direct_mlx/laguna/decoder_cache_bridge.rs
@@ -1,0 +1,299 @@
+//! Laguna-owned capture/restore bridge journeys for persistent prompt-cache
+//! blocks, driven entirely by synthetic fixtures.
+//!
+//! The neutral disk store, block manifests, and storage-contract fingerprints
+//! already prove model/revision/ancestry mismatch rejection in the shared
+//! persistent-cache tests. This file proves what only Laguna owns: the mixed
+//! append-only plus rotating state must round-trip exactly through
+//! `extract_cache_block_tensors` and `restore_from_cache_blocks`, and every
+//! corrupted block variant must fail loudly instead of restoring stale state.
+
+use std::collections::HashMap;
+
+use astronomical_model_serving::{LagunaDecoderState, LagunaModel, PerformanceAttribution};
+use astronomical_runtime_integration::{MlxArray, MlxDtype, MlxMemoryLimits, MlxRuntime};
+
+use crate::common::laguna::{bind_tiny_weights, tiny_mixed_contract};
+use crate::common::{
+    DIRECT_MLX_TEST_ACTIVE_MEMORY_LIMIT_BYTES, DIRECT_MLX_TEST_ALLOCATOR_CACHE_MEMORY_LIMIT_BYTES,
+};
+
+const BLOCK_TOKEN_COUNT: usize = 2;
+
+type TensorMap = HashMap<String, MlxArray>;
+
+fn test_runtime() -> MlxRuntime {
+    MlxRuntime::initialize(
+        MlxMemoryLimits::new(
+            DIRECT_MLX_TEST_ACTIVE_MEMORY_LIMIT_BYTES,
+            DIRECT_MLX_TEST_ALLOCATOR_CACHE_MEMORY_LIMIT_BYTES,
+        )
+        .expect("Laguna bridge test memory limits should be valid"),
+    )
+    .expect("the direct MLX runtime should initialize")
+}
+
+fn mixed_model(runtime: &MlxRuntime) -> LagunaModel {
+    let contract = tiny_mixed_contract();
+    let weights = bind_tiny_weights(runtime, &contract);
+    LagunaModel::new(
+        contract,
+        weights,
+        crate::common::test_worker_kernel_capabilities(runtime),
+    )
+    .expect("the tiny mixed Laguna model should construct")
+}
+
+/// Runs one four-token prefill so both state kinds sit exactly on the second
+/// block boundary, then captures each two-token sequence block plus the newest
+/// boundary snapshot from the populated state.
+fn capture_two_blocks(
+    runtime: &MlxRuntime,
+    model: &LagunaModel,
+    decoder_state: &mut LagunaDecoderState,
+    performance_attribution: &mut PerformanceAttribution,
+) -> (TensorMap, TensorMap, TensorMap) {
+    let prompt_tokens = runtime
+        .array_from_u32(&[1, 2, 3, 4], &[4])
+        .expect("the four-token prompt should build");
+    model
+        .forward(
+            runtime,
+            &prompt_tokens,
+            decoder_state,
+            performance_attribution,
+        )
+        .expect("the four-token prefill should execute");
+    let (first_sequence_block, _) = decoder_state
+        .extract_cache_block_tensors(runtime, 0, BLOCK_TOKEN_COUNT)
+        .expect("the first complete block should capture");
+    let (second_sequence_block, boundary_snapshot) = decoder_state
+        .extract_cache_block_tensors(runtime, BLOCK_TOKEN_COUNT, 2 * BLOCK_TOKEN_COUNT)
+        .expect("the second complete block should capture");
+    (
+        first_sequence_block,
+        second_sequence_block,
+        boundary_snapshot,
+    )
+}
+
+fn fresh_captured_sequence_block(
+    runtime: &MlxRuntime,
+    model: &LagunaModel,
+    performance_attribution: &mut PerformanceAttribution,
+) -> TensorMap {
+    let mut source_state = LagunaDecoderState::empty(model.contract())
+        .expect("the capture source state should allocate");
+    let (first_sequence_block, _, _) =
+        capture_two_blocks(runtime, model, &mut source_state, performance_attribution);
+    first_sequence_block
+}
+
+fn fresh_boundary_snapshot(
+    runtime: &MlxRuntime,
+    model: &LagunaModel,
+    performance_attribution: &mut PerformanceAttribution,
+) -> TensorMap {
+    let mut source_state = LagunaDecoderState::empty(model.contract())
+        .expect("the snapshot source state should allocate");
+    let (_, _, boundary_snapshot) =
+        capture_two_blocks(runtime, model, &mut source_state, performance_attribution);
+    boundary_snapshot
+}
+
+fn fresh_state(model: &LagunaModel) -> LagunaDecoderState {
+    LagunaDecoderState::empty(model.contract()).expect("the fresh decoder state should allocate")
+}
+
+#[tokio::test]
+async fn should_round_trip_a_synthetic_mixed_layer_ordering_through_capture_and_restore() {
+    let _direct_mlx_guard = crate::common::direct_mlx_test_guard().await;
+    let runtime = test_runtime();
+    let model = mixed_model(&runtime);
+    let mut performance_attribution = PerformanceAttribution::enabled();
+
+    let mut original_state = fresh_state(&model);
+    let (first_sequence_block, second_sequence_block, mut boundary_snapshot) = capture_two_blocks(
+        &runtime,
+        &model,
+        &mut original_state,
+        &mut performance_attribution,
+    );
+
+    let mut restored_state = fresh_state(&model);
+    let mut sequence_blocks = vec![first_sequence_block, second_sequence_block];
+    restored_state
+        .restore_from_cache_blocks(&runtime, &mut sequence_blocks, &mut boundary_snapshot)
+        .expect("the captured blocks should restore into a fresh state");
+
+    // The synthetic mixed ordering must round-trip with exact per-layer state:
+    // the append-only layer at the block boundary, and the rotating layer with
+    // its committed window, absolute position, and ring write index intact.
+    assert_eq!(
+        restored_state.absolute_position(0),
+        original_state.absolute_position(0),
+        "the append-only layer must resume at the captured absolute position"
+    );
+    assert_eq!(
+        restored_state.committed_token_count(1),
+        original_state.committed_token_count(1),
+        "the rotating layer must restore its committed token count"
+    );
+    assert_eq!(
+        restored_state.ring_write_index(1),
+        original_state.ring_write_index(1),
+        "the rotating layer must restore its ring write index"
+    );
+
+    // Lossless continuation: after restore, the same next token must produce
+    // bit-identical logits from both states.
+    let next_tokens = runtime
+        .array_from_u32(&[5], &[1])
+        .expect("the continuation token should build");
+    let original_logits = model
+        .forward(
+            &runtime,
+            &next_tokens,
+            &mut original_state,
+            &mut performance_attribution,
+        )
+        .expect("the original continuation should execute");
+    let restored_logits = model
+        .forward(
+            &runtime,
+            &next_tokens,
+            &mut restored_state,
+            &mut performance_attribution,
+        )
+        .expect("the restored continuation should execute");
+    assert_eq!(
+        original_logits.to_vec_f32().expect("original logits"),
+        restored_logits.to_vec_f32().expect("restored logits"),
+        "a restored state must continue generation bit-identically"
+    );
+}
+
+#[tokio::test]
+async fn should_reject_bridge_mismatches_instead_of_restoring_stale_state() {
+    let _direct_mlx_guard = crate::common::direct_mlx_test_guard().await;
+    let runtime = test_runtime();
+    let model = mixed_model(&runtime);
+    let mut performance_attribution = PerformanceAttribution::enabled();
+
+    // An empty state cannot capture: the append-only layer holds no keys yet.
+    let empty_state = fresh_state(&model);
+    let capture_rejection = empty_state
+        .extract_cache_block_tensors(&runtime, 0, BLOCK_TOKEN_COUNT)
+        .expect_err("capturing from an empty append-only layer must fail");
+    assert!(
+        format!("{capture_rejection:?}").contains("missing keys during capture"),
+        "the capture rejection should name the missing append-only keys: {capture_rejection:?}"
+    );
+
+    // A sequence block missing one tensor must fail before the layer restores.
+    let mut incomplete_first_block =
+        fresh_captured_sequence_block(&runtime, &model, &mut performance_attribution);
+    incomplete_first_block
+        .remove("layer_0_attention.keys")
+        .expect("the captured keys tensor should be present");
+    let mut sequence_blocks = vec![incomplete_first_block];
+    let mut snapshot = fresh_boundary_snapshot(&runtime, &model, &mut performance_attribution);
+    let missing_tensor_rejection = fresh_state(&model)
+        .restore_from_cache_blocks(&runtime, &mut sequence_blocks, &mut snapshot)
+        .expect_err("a sequence block missing a tensor must fail");
+    assert!(
+        format!("{missing_tensor_rejection:?}").contains("missing a tensor"),
+        "the rejection should name the missing sequence tensor: {missing_tensor_rejection:?}"
+    );
+
+    // A boundary snapshot missing the rotating keys must fail.
+    let mut keys_missing_snapshot =
+        fresh_boundary_snapshot(&runtime, &model, &mut performance_attribution);
+    keys_missing_snapshot
+        .remove("layer_1_attention.keys")
+        .expect("the rotating keys should be present");
+    let mut sequence_blocks = vec![fresh_captured_sequence_block(
+        &runtime,
+        &model,
+        &mut performance_attribution,
+    )];
+    let missing_keys_rejection = fresh_state(&model)
+        .restore_from_cache_blocks(&runtime, &mut sequence_blocks, &mut keys_missing_snapshot)
+        .expect_err("a snapshot missing rotating keys must fail");
+    assert!(
+        format!("{missing_keys_rejection:?}").contains("missing keys"),
+        "the rejection should name the missing rotating keys: {missing_keys_rejection:?}"
+    );
+
+    // A boundary snapshot missing a rotating counter must fail.
+    let mut counter_missing_snapshot =
+        fresh_boundary_snapshot(&runtime, &model, &mut performance_attribution);
+    counter_missing_snapshot
+        .remove("layer_1_attention.absolute_position")
+        .expect("the absolute position counter should be present");
+    let mut sequence_blocks = vec![fresh_captured_sequence_block(
+        &runtime,
+        &model,
+        &mut performance_attribution,
+    )];
+    let missing_counter_rejection = fresh_state(&model)
+        .restore_from_cache_blocks(
+            &runtime,
+            &mut sequence_blocks,
+            &mut counter_missing_snapshot,
+        )
+        .expect_err("a snapshot missing a rotating counter must fail");
+    assert!(
+        format!("{missing_counter_rejection:?}").contains("counter tensor is missing"),
+        "the rejection should name the missing counter: {missing_counter_rejection:?}"
+    );
+
+    // A counter stored with a foreign dtype must fail before restoration.
+    let mut foreign_dtype_snapshot =
+        fresh_boundary_snapshot(&runtime, &model, &mut performance_attribution);
+    let float16_counter_array = foreign_dtype_snapshot
+        .remove("layer_1_attention.ring_write_index")
+        .expect("the ring write index counter should be present");
+    let float16_counter = runtime
+        .astype(&float16_counter_array, MlxDtype::Float16)
+        .expect("the float16 counter should build");
+    foreign_dtype_snapshot.insert(
+        "layer_1_attention.ring_write_index".to_owned(),
+        float16_counter,
+    );
+    let mut sequence_blocks = vec![fresh_captured_sequence_block(
+        &runtime,
+        &model,
+        &mut performance_attribution,
+    )];
+    let foreign_dtype_rejection = fresh_state(&model)
+        .restore_from_cache_blocks(&runtime, &mut sequence_blocks, &mut foreign_dtype_snapshot)
+        .expect_err("a non-float32 rotating counter must fail");
+    assert!(
+        format!("{foreign_dtype_rejection:?}").contains("float32"),
+        "the rejection should name the counter dtype: {foreign_dtype_rejection:?}"
+    );
+
+    // A zero absolute position claims a restore with no live tokens.
+    let mut zero_position_snapshot =
+        fresh_boundary_snapshot(&runtime, &model, &mut performance_attribution);
+    let zero_counter = runtime
+        .array_from_f32(&[0.0], &[1])
+        .expect("the zero counter should build");
+    zero_position_snapshot.insert(
+        "layer_1_attention.absolute_position".to_owned(),
+        zero_counter,
+    );
+    let mut sequence_blocks = vec![fresh_captured_sequence_block(
+        &runtime,
+        &model,
+        &mut performance_attribution,
+    )];
+    let zero_position_rejection = fresh_state(&model)
+        .restore_from_cache_blocks(&runtime, &mut sequence_blocks, &mut zero_position_snapshot)
+        .expect_err("a restore claiming zero live tokens must fail");
+    assert!(
+        format!("{zero_position_rejection:?}").contains("at least one token"),
+        "the rejection should name the empty rotating restore: {zero_position_rejection:?}"
+    );
+}

--- a/crates/model-serving/tests/direct_mlx/laguna/hybrid_attention.rs
+++ b/crates/model-serving/tests/direct_mlx/laguna/hybrid_attention.rs
@@ -1,13 +1,12 @@
 use std::collections::HashMap;
 
 use astronomical_model_serving::{
-    LagunaAttentionProjection, LagunaDecoderState, LagunaExpertProjection, LagunaGlobalTensorRole,
-    LagunaLayerTensorRole, LagunaModel, LagunaNativeWeights, LagunaTargetNormalizer,
-    LagunaTensorComponent, LagunaTensorId, PerformanceAttribution, PerformanceOperation,
+    LagunaDecoderState, LagunaModel, LagunaNativeWeights, PerformanceAttribution,
+    PerformanceOperation,
 };
-use astronomical_runtime_integration::{MlxArray, MlxMemoryLimits, MlxRuntime};
-use serde_json::json;
+use astronomical_runtime_integration::{MlxMemoryLimits, MlxRuntime};
 
+use crate::common::laguna::{bind_tiny_weights, tiny_mixed_contract};
 use crate::common::{
     DIRECT_MLX_TEST_ACTIVE_MEMORY_LIMIT_BYTES, DIRECT_MLX_TEST_ALLOCATOR_CACHE_MEMORY_LIMIT_BYTES,
 };
@@ -21,162 +20,6 @@ fn test_runtime() -> MlxRuntime {
         .expect("Laguna execution test memory limits should be valid"),
     )
     .expect("the direct MLX runtime should initialize")
-}
-
-fn ones(runtime: &MlxRuntime, shape: &[i32]) -> MlxArray {
-    let element_count = shape.iter().product::<i32>() as usize;
-    runtime
-        .array_from_f32(&vec![0.05; element_count], shape)
-        .expect("a dense ones-scaled tensor should be valid")
-}
-
-fn weight_id(role: LagunaGlobalTensorRole) -> LagunaTensorId {
-    LagunaTensorId::Global {
-        role,
-        component: LagunaTensorComponent::Weight,
-    }
-}
-
-fn layer_weight_id(layer_index: usize, role: LagunaLayerTensorRole) -> LagunaTensorId {
-    LagunaTensorId::Layer {
-        layer_index,
-        role,
-        component: LagunaTensorComponent::Weight,
-    }
-}
-
-fn tiny_mixed_contract() -> astronomical_model_serving::LagunaTargetContract {
-    let config = json!({
-        "architectures": ["LagunaForCausalLM"],
-        "model_type": "laguna",
-        "vocab_size": 8,
-        "hidden_size": 8,
-        "intermediate_size": 16,
-        "num_hidden_layers": 2,
-        "num_attention_heads": 4,
-        "num_key_value_heads": 2,
-        "head_dim": 2,
-        "max_position_embeddings": 32,
-        "rms_norm_eps": 0.00001,
-        "tie_word_embeddings": false,
-        "torch_dtype": "float32",
-        "layer_types": ["full", "sliding"],
-        "sliding_window": 4,
-        "mlp_layer_types": ["dense", "dense"],
-        "gating_types": ["per_head", "none"],
-        "rope_parameters": {
-            "rope_type": "default",
-            "rope_theta": 10000.0,
-            "partial_rotary_factor": 1.0
-        }
-    });
-    LagunaTargetNormalizer::normalize(&serde_json::to_vec(&config).expect("config bytes"))
-        .expect("tiny mixed Laguna contract should normalize")
-}
-
-fn bind_tiny_weights(
-    runtime: &MlxRuntime,
-    contract: &astronomical_model_serving::LagunaTargetContract,
-) -> LagunaNativeWeights {
-    let mut tensors = HashMap::new();
-    tensors.insert(
-        weight_id(LagunaGlobalTensorRole::TokenEmbedding),
-        ones(runtime, &[8, 8]),
-    );
-    tensors.insert(
-        weight_id(LagunaGlobalTensorRole::FinalNormalization),
-        ones(runtime, &[8]),
-    );
-    tensors.insert(
-        weight_id(LagunaGlobalTensorRole::OutputHead),
-        ones(runtime, &[8, 8]),
-    );
-    for layer_index in 0..2 {
-        tensors.insert(
-            layer_weight_id(layer_index, LagunaLayerTensorRole::InputNormalization),
-            ones(runtime, &[8]),
-        );
-        tensors.insert(
-            layer_weight_id(
-                layer_index,
-                LagunaLayerTensorRole::PostAttentionNormalization,
-            ),
-            ones(runtime, &[8]),
-        );
-        tensors.insert(
-            layer_weight_id(
-                layer_index,
-                LagunaLayerTensorRole::Attention(LagunaAttentionProjection::Query),
-            ),
-            ones(runtime, &[8, 8]),
-        );
-        tensors.insert(
-            layer_weight_id(
-                layer_index,
-                LagunaLayerTensorRole::Attention(LagunaAttentionProjection::Key),
-            ),
-            ones(runtime, &[4, 8]),
-        );
-        tensors.insert(
-            layer_weight_id(
-                layer_index,
-                LagunaLayerTensorRole::Attention(LagunaAttentionProjection::Value),
-            ),
-            ones(runtime, &[4, 8]),
-        );
-        tensors.insert(
-            layer_weight_id(
-                layer_index,
-                LagunaLayerTensorRole::Attention(LagunaAttentionProjection::Output),
-            ),
-            ones(runtime, &[8, 8]),
-        );
-        tensors.insert(
-            layer_weight_id(
-                layer_index,
-                LagunaLayerTensorRole::AttentionQueryNormalization,
-            ),
-            ones(runtime, &[2]),
-        );
-        tensors.insert(
-            layer_weight_id(
-                layer_index,
-                LagunaLayerTensorRole::AttentionKeyNormalization,
-            ),
-            ones(runtime, &[2]),
-        );
-        if layer_index == 0 {
-            tensors.insert(
-                layer_weight_id(
-                    layer_index,
-                    LagunaLayerTensorRole::Attention(LagunaAttentionProjection::Gate),
-                ),
-                ones(runtime, &[4, 8]),
-            );
-        }
-        tensors.insert(
-            layer_weight_id(
-                layer_index,
-                LagunaLayerTensorRole::DenseFeedForward(LagunaExpertProjection::Gate),
-            ),
-            ones(runtime, &[16, 8]),
-        );
-        tensors.insert(
-            layer_weight_id(
-                layer_index,
-                LagunaLayerTensorRole::DenseFeedForward(LagunaExpertProjection::Up),
-            ),
-            ones(runtime, &[16, 8]),
-        );
-        tensors.insert(
-            layer_weight_id(
-                layer_index,
-                LagunaLayerTensorRole::DenseFeedForward(LagunaExpertProjection::Down),
-            ),
-            ones(runtime, &[8, 16]),
-        );
-    }
-    LagunaNativeWeights::bind(runtime, tensors, contract).expect("tiny native weights should bind")
 }
 
 #[tokio::test]

--- a/crates/model-serving/tests/direct_mlx/laguna/mod.rs
+++ b/crates/model-serving/tests/direct_mlx/laguna/mod.rs
@@ -1,5 +1,6 @@
 mod affine_moe;
 mod affine_moe_demotion;
+mod decoder_cache_bridge;
 mod hybrid_attention;
 mod hybrid_attention_reference;
 mod memory_policy;


### PR DESCRIPTION
## Linked issue

Closes #105

## Summary

The Laguna lossless persistent prompt-cache work had two unproven acceptance rows: the mismatch-rejection checks on the Laguna-owned capture/restore bridge, and one Romeo and Juliet restore journey on the Laguna XS reference artifact with a recorded measurement. This pull request closes both with test evidence only — no production code changes.

## What changed

- **New bridge journeys** (`crates/model-serving/tests/direct_mlx/laguna/decoder_cache_bridge.rs`), driven by synthetic fixtures:
  - A synthetic non-pinned mixed ordering (append-only layer + rotating layer) round-trips through capture and restore with exact absolute position, ring write index, and **bit-identical continuation logits**.
  - Mismatch rejection: a missing sequence tensor, missing rotating keys, a missing rotating counter, a non-float32 counter, and a zero-live-token restore all fail loudly; capture from an empty state fails. No stale state is restored.
- **Shared fixture**: the tiny mixed Laguna contract moves into `tests/common/laguna.rs` so the bridge journeys and the existing hybrid-attention journeys use one fixture.
- **HTTP restore harness fix** (`serving_acceptance/laguna/http_restore.rs`): the reference artifact is published into the isolated worker home as its own Hugging Face cache entry. Laguna discovery derives its immutable revision from cache ancestry, and the entry's shard links are relative to the entry root, so the whole entry is linked rather than the snapshot directory. The journey now also reports the measured cold and warm phase timings and the restored token count on every run.

## Evidence

- Full local commit gate: 18/18 steps green, including the direct-MLX lane (291 + 73 tests) with the new bridge journeys.
- Romeo and Juliet restore journey on the installed `mlx-community/Laguna-XS-2.1-6bit` reference artifact (affine 6-bit, group 64), inside the 115-second journey boundary:
  - Cold request: 5.22 s (full prefill, zero tokens saved)
  - Repeated identical request: 0.43 s with 1024 tokens restored from the SSD prompt cache (four 256-token blocks)
  - Worker remained ready across both requests
- Artifact validation journey `should_validate_installed_laguna_xs` passes against the downloaded artifact (family classification, public discovery, full artifact validation, Romeo and Juliet prompt preparation).
