### PR TITLE
Offer the Laguna XS 2.1 variants in the Library catalog (#463)

### DIFF
--- a/apps/inference-worker/tests/serving_acceptance/laguna/validate.rs
+++ b/apps/inference-worker/tests/serving_acceptance/laguna/validate.rs
@@ -329,3 +329,58 @@ fn romeo_and_juliet_source_with_character_limit(maximum_characters: usize) -> &'
 pub(crate) fn resolve_reference_model_directory() -> PathBuf {
     crate::support::configured_installed_model_directory_by_id(laguna_xs_public_model_id())
 }
+
+/// Validates every installed Laguna catalog variant against its own pinned
+/// revision. The reference 6-bit artifact is required; the smaller catalog
+/// variants validate only when their downloads are present, so machines that
+/// have not installed them still exercise the family contract they do have.
+#[test]
+#[ignore = "validates every installed Laguna catalog variant against its pinned revision"]
+fn should_validate_installed_laguna_catalog_variants() {
+    let discovered_laguna_directories: std::collections::HashMap<String, PathBuf> =
+        crate::support::configured_discovered_models()
+            .into_iter()
+            .filter(|discovered_model| discovered_model.model_family == ModelFamily::Laguna)
+            .map(|discovered_model| (discovered_model.model_id, discovered_model.model_directory))
+            .collect();
+
+    let started_at = Instant::now();
+    let mut validated_model_ids = Vec::new();
+    for (variant_model_id, is_required) in [
+        (laguna_xs_public_model_id(), true),
+        (crate::support::laguna_xs_5bit_model_id(), false),
+        (crate::support::laguna_xs_4bit_model_id(), false),
+    ] {
+        let Some(model_directory) = discovered_laguna_directories.get(variant_model_id) else {
+            assert!(
+                !is_required,
+                "the reference Laguna artifact {variant_model_id} must be discoverable"
+            );
+            eprintln!(
+                "[laguna-variants] status=skipped reason=not-installed model={variant_model_id}"
+            );
+            continue;
+        };
+        let validated_artifact = LagunaArtifactValidator::new()
+            .validate(model_directory)
+            .unwrap_or_else(|validation_error| {
+                panic!("the installed Laguna variant {variant_model_id} must validate: {validation_error}")
+            });
+        assert_structurally_valid_laguna_artifact(&validated_artifact);
+        validated_model_ids.push(variant_model_id);
+        eprintln!(
+            "[laguna-variants] status=validated model={variant_model_id} elapsed_seconds={:.1}",
+            started_at.elapsed().as_secs_f32()
+        );
+    }
+
+    assert!(
+        validated_model_ids.contains(&laguna_xs_public_model_id()),
+        "the reference 6-bit variant must be installed and validated"
+    );
+    eprintln!(
+        "[laguna-variants] status=complete validated_models={} elapsed_seconds={:.1}",
+        validated_model_ids.len(),
+        started_at.elapsed().as_secs_f32()
+    );
+}

--- a/apps/inference-worker/tests/support/mod.rs
+++ b/apps/inference-worker/tests/support/mod.rs
@@ -21,8 +21,9 @@ mod e2e_test_model_names;
 #[allow(unused_imports)]
 pub(crate) use e2e_test_model_names::{
     dense_mtp_model_id, e2e_test_model_ids, flux2_klein_model_id, k2_horizon_mova_model_id,
-    laguna_xs_model_id, large_sparse_moe_model_id, required_e2e_test_model_ids,
-    resident_sparse_moe_model_id, small_dense_model_id,
+    laguna_xs_4bit_model_id, laguna_xs_5bit_model_id, laguna_xs_model_id,
+    large_sparse_moe_model_id, required_e2e_test_model_ids, resident_sparse_moe_model_id,
+    small_dense_model_id,
 };
 
 pub(crate) fn isolated_development_home_from_user_config() -> tempfile::TempDir {

--- a/apps/supervisor/tests/hermetic/download_catalog.rs
+++ b/apps/supervisor/tests/hermetic/download_catalog.rs
@@ -15,7 +15,6 @@ use astronomical_supervisor::{
 };
 
 const VALID_REVISION: &str = "0123456789abcdef0123456789abcdef01234567";
-
 #[test]
 fn should_package_flux_with_only_its_executable_diffusers_graph() {
     let download_catalog = DownloadCatalog::load_bundled()

--- a/apps/supervisor/tests/hermetic/download_catalog_laguna.rs
+++ b/apps/supervisor/tests/hermetic/download_catalog_laguna.rs
@@ -1,0 +1,98 @@
+//! Bundled-catalog contract for the Laguna XS 2.1 family offers.
+
+use astronomical_supervisor::{DownloadCatalog, DownloadCatalogFamily};
+
+#[test]
+fn should_offer_the_validated_laguna_variants_from_the_bundled_catalog() {
+    let download_catalog = DownloadCatalog::load_bundled()
+        .expect("the bundled production catalog should remain valid");
+    let laguna_entries = download_catalog
+        .entries()
+        .iter()
+        .filter(|entry| entry.family() == DownloadCatalogFamily::Laguna)
+        .collect::<Vec<_>>();
+
+    let expected_laguna_entries = [
+        (
+            "mlx-community/Laguna-XS-2.1-6bit",
+            "5f60b7511ea0be481a68be1500baf15b0bcccba6",
+            27_185_160_853,
+        ),
+        (
+            "mlx-community/Laguna-XS-2.1-5bit",
+            "f9990bed9f13df5089804c44a6ef9ea2589fe5df",
+            23_007_413_034,
+        ),
+        (
+            "mlx-community/Laguna-XS-2.1-4bit",
+            "c42e0a8f8d504ceacde015a535dcb286d65c8799",
+            18_829_665_100,
+        ),
+    ];
+    assert_eq!(
+        laguna_entries
+            .iter()
+            .map(|entry| (
+                entry.huggingface_id(),
+                entry.revision(),
+                entry.approximate_size_bytes()
+            ))
+            .collect::<Vec<_>>(),
+        expected_laguna_entries
+            .iter()
+            .map(|(huggingface_id, revision, approximate_size_bytes)| (
+                *huggingface_id,
+                *revision,
+                *approximate_size_bytes
+            ))
+            .collect::<Vec<_>>(),
+        "the bundled catalog must offer the validated Laguna variants pinned to immutable revisions"
+    );
+
+    for laguna_entry in &laguna_entries {
+        let capabilities = laguna_entry.capabilities();
+        assert!(
+            capabilities.supports_reasoning,
+            "{}",
+            laguna_entry.huggingface_id()
+        );
+        assert!(
+            capabilities.supports_tool_calls,
+            "{}",
+            laguna_entry.huggingface_id()
+        );
+        assert!(
+            !capabilities.supports_vision,
+            "Laguna XS 2.1 is text-only: {}",
+            laguna_entry.huggingface_id()
+        );
+        assert_eq!(
+            capabilities.context_window,
+            Some(262_144),
+            "{}",
+            laguna_entry.huggingface_id()
+        );
+        assert_eq!(
+            laguna_entry.upstream_license(),
+            Some("OpenMDW-1.1"),
+            "{}",
+            laguna_entry.huggingface_id()
+        );
+
+        let path_selection = laguna_entry.download_path_selection();
+        assert!(path_selection.includes("config.json"));
+        assert!(path_selection.includes("model.safetensors.index.json"));
+        assert!(path_selection.includes("tokenizer.json"));
+        assert!(path_selection.includes("chat_template.jinja"));
+        assert!(
+            !path_selection.includes("README.md"),
+            "the executable payload must not ship repository extras: {}",
+            laguna_entry.huggingface_id()
+        );
+        assert!(
+            !path_selection.includes(".eval_results/swe-bench_verified.yaml"),
+            "the executable payload must not ship evaluation metadata: {}",
+            laguna_entry.huggingface_id()
+        );
+    }
+}

--- a/apps/supervisor/tests/hermetic/mod.rs
+++ b/apps/supervisor/tests/hermetic/mod.rs
@@ -3,6 +3,7 @@ mod completion_attribution_log;
 mod config_reload;
 mod config_reload_resolver;
 mod download_catalog;
+mod download_catalog_laguna;
 mod download_disk_preflight;
 mod download_executable_preflight;
 mod download_job;

--- a/crates/model-serving/tests/common/e2e_test_model_names.rs
+++ b/crates/model-serving/tests/common/e2e_test_model_names.rs
@@ -13,14 +13,18 @@ const E2E_TEST_MODEL_NAMES_JSON: &str = include_str!(concat!(
 const LARGE_SPARSE_MOE_ROLE: &str = "large_sparse_moe";
 const RESIDENT_SPARSE_MOE_ROLE: &str = "resident_sparse_moe";
 const LAGUNA_XS_ROLE: &str = "laguna_xs";
+const LAGUNA_XS_5BIT_ROLE: &str = "laguna_xs_5bit";
+const LAGUNA_XS_4BIT_ROLE: &str = "laguna_xs_4bit";
 const DENSE_MTP_ROLE: &str = "dense_mtp";
 const SMALL_DENSE_ROLE: &str = "small_dense";
 const FLUX2_KLEIN_ROLE: &str = "flux2_klein";
 const K2_HORIZON_MOVA_ROLE: &str = "k2_horizon_mova";
-const E2E_TEST_MODEL_ROLES: [&str; 7] = [
+const E2E_TEST_MODEL_ROLES: [&str; 9] = [
     LARGE_SPARSE_MOE_ROLE,
     RESIDENT_SPARSE_MOE_ROLE,
     LAGUNA_XS_ROLE,
+    LAGUNA_XS_5BIT_ROLE,
+    LAGUNA_XS_4BIT_ROLE,
     DENSE_MTP_ROLE,
     SMALL_DENSE_ROLE,
     FLUX2_KLEIN_ROLE,
@@ -84,6 +88,17 @@ pub(crate) fn laguna_xs_model_id() -> &'static str {
     model_id_for_role(LAGUNA_XS_ROLE)
 }
 
+/// The smaller Laguna catalog variants validate the same family against lower
+/// memory ceilings; they stay out of the required on-disk set because only the
+/// 6-bit reference is pinned by the resident journeys.
+pub(crate) fn laguna_xs_5bit_model_id() -> &'static str {
+    model_id_for_role(LAGUNA_XS_5BIT_ROLE)
+}
+
+pub(crate) fn laguna_xs_4bit_model_id() -> &'static str {
+    model_id_for_role(LAGUNA_XS_4BIT_ROLE)
+}
+
 pub(crate) fn dense_mtp_model_id() -> &'static str {
     model_id_for_role(DENSE_MTP_ROLE)
 }
@@ -100,11 +115,13 @@ pub(crate) fn k2_horizon_mova_model_id() -> &'static str {
     model_id_for_role(K2_HORIZON_MOVA_ROLE)
 }
 
-pub(crate) fn e2e_test_model_ids() -> [&'static str; 7] {
+pub(crate) fn e2e_test_model_ids() -> [&'static str; 9] {
     [
         large_sparse_moe_model_id(),
         resident_sparse_moe_model_id(),
         laguna_xs_model_id(),
+        laguna_xs_5bit_model_id(),
+        laguna_xs_4bit_model_id(),
         dense_mtp_model_id(),
         small_dense_model_id(),
         flux2_klein_model_id(),

--- a/crates/model-serving/tests/common/mod.rs
+++ b/crates/model-serving/tests/common/mod.rs
@@ -3,8 +3,9 @@ mod e2e_test_model_names;
 #[allow(dead_code, unused_imports)]
 pub(crate) use e2e_test_model_names::{
     dense_mtp_model_id, e2e_test_model_ids, flux2_klein_model_id, k2_horizon_mova_model_id,
-    laguna_xs_model_id, large_sparse_moe_model_id, required_e2e_test_model_ids,
-    resident_sparse_moe_model_id, small_dense_model_id,
+    laguna_xs_4bit_model_id, laguna_xs_5bit_model_id, laguna_xs_model_id,
+    large_sparse_moe_model_id, required_e2e_test_model_ids, resident_sparse_moe_model_id,
+    small_dense_model_id,
 };
 
 #[cfg(feature = "direct-mlx")]

--- a/crates/model-serving/tests/hermetic/e2e_test_model_names.rs
+++ b/crates/model-serving/tests/hermetic/e2e_test_model_names.rs
@@ -4,6 +4,8 @@ fn should_load_a_discovered_leaf_model_id_for_every_e2e_test_role() {
         crate::common::large_sparse_moe_model_id(),
         crate::common::resident_sparse_moe_model_id(),
         crate::common::laguna_xs_model_id(),
+        crate::common::laguna_xs_5bit_model_id(),
+        crate::common::laguna_xs_4bit_model_id(),
         crate::common::dense_mtp_model_id(),
         crate::common::small_dense_model_id(),
         crate::common::flux2_klein_model_id(),

--- a/registry/download_catalog.json
+++ b/registry/download_catalog.json
@@ -128,6 +128,99 @@
             "quantization_label": "OptiQ static 5.5bpw (mixed-precision affine, group 64)",
             "architecture_summary": "Qwen3.5 MoE VLM, 35B total params, ~3B active (A3B), 40 layers, 256 experts, 8 routed per token. bf16 vision tower and int4 MTP head via OptiQ",
             "upstream_license": "MIT"
+        },
+        {
+            "huggingface_id": "mlx-community/Laguna-XS-2.1-6bit",
+            "revision": "5f60b7511ea0be481a68be1500baf15b0bcccba6",
+            "display_name": "Laguna XS 2.1 6-bit",
+            "family": "laguna",
+            "approximate_size_bytes": 27185160853,
+            "public": true,
+            "description": "A 33B-parameter sparse mixture-of-experts reasoning model for coding and agentic work, with about 3B active parameters per token. Takes text, reasons before answering, and calls tools natively. Under one memory ceiling, experts stream from SSD when they do not fit, without hidden quantization. Text-only, about 27.2 GB on disk.",
+            "capabilities": {
+                "supports_reasoning": true,
+                "supports_tool_calls": true,
+                "context_window": 262144
+            },
+            "quantization_label": "6-bit affine (group 64)",
+            "architecture_summary": "Laguna sparse MoE, 33B parameters, about 3B active per token, 40 layers (10 global attention, 30 sliding-window), 256 routed plus 1 shared expert, 8 routed per token, text-only",
+            "upstream_license": "OpenMDW-1.1",
+            "included_paths": [
+                "config.json",
+                "model.safetensors.index.json",
+                "model-00001-of-00006.safetensors",
+                "model-00002-of-00006.safetensors",
+                "model-00003-of-00006.safetensors",
+                "model-00004-of-00006.safetensors",
+                "model-00005-of-00006.safetensors",
+                "model-00006-of-00006.safetensors",
+                "tokenizer.json",
+                "tokenizer_config.json",
+                "generation_config.json",
+                "chat_template.jinja",
+                "special_tokens_map.json"
+            ]
+        },
+        {
+            "huggingface_id": "mlx-community/Laguna-XS-2.1-5bit",
+            "revision": "f9990bed9f13df5089804c44a6ef9ea2589fe5df",
+            "display_name": "Laguna XS 2.1 5-bit",
+            "family": "laguna",
+            "approximate_size_bytes": 23007413034,
+            "public": true,
+            "description": "A 33B-parameter sparse mixture-of-experts reasoning model for coding and agentic work, with about 3B active parameters per token. Takes text, reasons before answering, and calls tools natively. Under one memory ceiling, experts stream from SSD when they do not fit, without hidden quantization. Text-only, about 23.0 GB on disk.",
+            "capabilities": {
+                "supports_reasoning": true,
+                "supports_tool_calls": true,
+                "context_window": 262144
+            },
+            "quantization_label": "5-bit affine (group 64)",
+            "architecture_summary": "Laguna sparse MoE, 33B parameters, about 3B active per token, 40 layers (10 global attention, 30 sliding-window), 256 routed plus 1 shared expert, 8 routed per token, text-only",
+            "upstream_license": "OpenMDW-1.1",
+            "included_paths": [
+                "config.json",
+                "model.safetensors.index.json",
+                "model-00001-of-00005.safetensors",
+                "model-00002-of-00005.safetensors",
+                "model-00003-of-00005.safetensors",
+                "model-00004-of-00005.safetensors",
+                "model-00005-of-00005.safetensors",
+                "tokenizer.json",
+                "tokenizer_config.json",
+                "generation_config.json",
+                "chat_template.jinja",
+                "special_tokens_map.json"
+            ]
+        },
+        {
+            "huggingface_id": "mlx-community/Laguna-XS-2.1-4bit",
+            "revision": "c42e0a8f8d504ceacde015a535dcb286d65c8799",
+            "display_name": "Laguna XS 2.1 4-bit",
+            "family": "laguna",
+            "approximate_size_bytes": 18829665100,
+            "public": true,
+            "description": "A 33B-parameter sparse mixture-of-experts reasoning model for coding and agentic work, with about 3B active parameters per token. Takes text, reasons before answering, and calls tools natively. Under one memory ceiling, experts stream from SSD when they do not fit, without hidden quantization. Text-only, about 18.8 GB on disk.",
+            "capabilities": {
+                "supports_reasoning": true,
+                "supports_tool_calls": true,
+                "context_window": 262144
+            },
+            "quantization_label": "4-bit affine (group 64)",
+            "architecture_summary": "Laguna sparse MoE, 33B parameters, about 3B active per token, 40 layers (10 global attention, 30 sliding-window), 256 routed plus 1 shared expert, 8 routed per token, text-only",
+            "upstream_license": "OpenMDW-1.1",
+            "included_paths": [
+                "config.json",
+                "model.safetensors.index.json",
+                "model-00001-of-00004.safetensors",
+                "model-00002-of-00004.safetensors",
+                "model-00003-of-00004.safetensors",
+                "model-00004-of-00004.safetensors",
+                "tokenizer.json",
+                "tokenizer_config.json",
+                "generation_config.json",
+                "chat_template.jinja",
+                "special_tokens_map.json"
+            ]
         }
     ]
 }

--- a/registry/e2e_test_model_names.json
+++ b/registry/e2e_test_model_names.json
@@ -2,6 +2,8 @@
   "large_sparse_moe": "Ornith-1.5-35B-A3B-OptiQ-static-5.5bpw",
   "resident_sparse_moe": "Ornith-1.5-35B-A3B-OptiQ-4bit",
   "laguna_xs": "Laguna-XS-2.1-6bit",
+  "laguna_xs_5bit": "Laguna-XS-2.1-5bit",
+  "laguna_xs_4bit": "Laguna-XS-2.1-4bit",
   "dense_mtp": "Ornith-1.5-9B-vision-OptiQ-static-4.5bpw",
   "small_dense": "Qwen3.5-0.8B-MLX-4bit",
   "flux2_klein": "FLUX.2-klein-4B",


### PR DESCRIPTION
## Linked issue

Closes #463

## Summary

The Library now offers the validated Laguna XS 2.1 family — 6-bit, 5-bit, and 4-bit — so users with less RAM can opt for a smaller model under the same memory ceiling. The change is catalog data plus test evidence; the download pipeline already supported the Laguna family end to end.

## What changed

- **Bundled catalog**: three entries pinned to immutable 40-hex revisions, with measured payload sizes (27.19 GB, 23.01 GB, 18.83 GB decimal SI), reasoning and tool-call capabilities with a 262144-token context, and no vision because Laguna XS 2.1 is text-only. Each entry declares `included_paths` for the executable payload so evaluation metadata and unused source files are not shipped.
- **Bundled-catalog contract test**: a new hermetic test parses `DownloadCatalog::load_bundled()` and asserts all three Laguna entries, their revisions, capabilities, license, and payload selection — closing the gap where no test parsed the bundled catalog.
- **End-to-end registry**: the 5-bit and 4-bit leaf ids join the registry as optional roles (the resident 6-bit reference stays in the required on-disk set), and a new ignored journey validates every installed Laguna catalog variant against its own pinned revision.
- **Recorded validation**: all three variants passed the artifact validation journey against their pinned revisions.

## Evidence

- `should_validate_installed_laguna_catalog_variants`: validated 6-bit (0.6 s), 5-bit (1.2 s), and 4-bit (1.8 s) against their pinned revisions, including the structural checks on shard indexes, affine profiles, end tokens, and parser identities.
- Full local commit gate: 18/18 steps green, including the direct-MLX lane.
- The 6-bit restore journey measurement (cold 5.22 s, warm 0.43 s with 1024 tokens restored) is recorded on #105.
