### PR TITLE
Compile rest_api_tests during the hermetic --no-run step (#474)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -284,7 +284,9 @@ jobs:
       - name: Set maximum parallel build jobs
         run: printf 'CARGO_BUILD_JOBS=%s\n' "$(sysctl -n hw.logicalcpu)" >> "$GITHUB_ENV"
       - name: Compile hermetic tests
-        run: cargo test --timings --no-fail-fast --no-run -p astronomical-config -p astronomical-ipc-protocol -p astronomical-runtime-integration -p astronomical-model-serving -p astronomical-inference-worker -p astronomical-supervisor --test hermetic_tests
+        run: |
+          cargo test --timings --no-fail-fast --no-run -p astronomical-config -p astronomical-ipc-protocol -p astronomical-runtime-integration -p astronomical-model-serving -p astronomical-inference-worker -p astronomical-supervisor --test hermetic_tests
+          cargo test --timings --no-fail-fast --no-run -p astronomical-supervisor --test rest_api_tests
         timeout-minutes: 12
       - name: Classify native build result
         id: native-build-result

--- a/scripts/test-ci-native-cache-coordination.sh
+++ b/scripts/test-ci-native-cache-coordination.sh
@@ -269,6 +269,12 @@ assert_workflow_contract() {
         ]
         raise "Library REST required-CI command changed" unless Shellwords.split(library_rest_step.fetch("run")) == expected_library_rest_command
         raise "Library REST contracts exceeded their bounded timeout" unless library_rest_step.fetch("timeout-minutes") <= 2
+        compile_step = steps.find { |step| step["name"] == "Compile hermetic tests" }
+        raise "hermetic compile step is missing from required CI" unless compile_step
+        compile_command = compile_step.fetch("run")
+        raise "hermetic compile does not use --no-run" unless compile_command.include?("--no-run")
+        raise "hermetic compile omits hermetic_tests" unless compile_command.include?("--test hermetic_tests")
+        raise "hermetic compile omits rest_api_tests" unless compile_command.include?("--test rest_api_tests")
         cache_owners = {
           "cargo-downloads-cache" => ["~/.cargo/registry", "~/.cargo/git"],
           "native-archives-cache" => ["~/Library/Caches/Astronomical/native-dependencies"],


### PR DESCRIPTION
## Linked issue

Closes #474

## Problem

The hermetic job compiled `--test hermetic_tests` with `--no-run`, then compiled `rest_api_tests` during "Run Library REST contracts". That run step was 23 seconds; the following image-status step on the same binary was 1 second.

## Change

- Compile `rest_api_tests` with `--no-run` in the hermetic compile step, after the hermetic test binaries.
- Keep the Library REST and image-status steps as filtered runs.
- The native-cache contract now requires the compile step to `--no-run` both `hermetic_tests` and `rest_api_tests`.

## Verification

- `scripts/test-ci-native-cache-coordination.sh`
- `scripts/verify-before-commit.sh` (18/18)

## Safety

- [x] No credentials, personal paths, prompts, model inventories, proprietary artifacts, or machine logs are included.
- [x] Model precision and output semantics are preserved or explicitly justified.
- [x] Performance and memory effects are measured when the critical path changes.
- [x] Source reuse and third-party licensing are accurately attributed.
