### PR TITLE
Remove wall-clock waits from the slow menu contract suites (#475)

### DIFF
--- a/apps/astronomical-menu/Sources/AstronomicalMenuCore/DaemonLifecycleController.swift
+++ b/apps/astronomical-menu/Sources/AstronomicalMenuCore/DaemonLifecycleController.swift
@@ -146,6 +146,8 @@ final class DaemonLifecycleController {
   private let ownershipStore: DaemonOwnershipStore
   private let readinessTimeout: Duration
   private let readinessPollInterval: Duration
+  private let unownedDaemonStopPollCount: Int
+  private let unownedDaemonStopPollInterval: Duration
   private let configuredMenuExecutableURL: URL?
   private let configuredDaemonExecutableURL: URL?
   private let configuredDaemonArguments: [String]?
@@ -157,6 +159,8 @@ final class DaemonLifecycleController {
     applicationIdentity: ApplicationIdentity = .current(),
     readinessTimeout: Duration = .seconds(8),
     readinessPollInterval: Duration = .milliseconds(100),
+    unownedDaemonStopPollCount: Int = 30,
+    unownedDaemonStopPollInterval: Duration = .milliseconds(100),
     menuExecutableURL: URL? = nil,
     daemonExecutableURL: URL? = nil,
     ownershipRecordURL: URL? = nil,
@@ -166,6 +170,8 @@ final class DaemonLifecycleController {
     self.applicationIdentity = applicationIdentity
     self.readinessTimeout = readinessTimeout
     self.readinessPollInterval = readinessPollInterval
+    self.unownedDaemonStopPollCount = unownedDaemonStopPollCount
+    self.unownedDaemonStopPollInterval = unownedDaemonStopPollInterval
     configuredMenuExecutableURL = menuExecutableURL
     configuredDaemonExecutableURL = daemonExecutableURL
     configuredDaemonArguments = daemonArguments
@@ -196,8 +202,8 @@ final class DaemonLifecycleController {
   func restartDaemon() async throws -> String {
     if await supervisorClient.healthIsAvailable() {
       try await supervisorClient.requestShutdown()
-      for _ in 0..<30 where await supervisorClient.healthIsAvailable() {
-        try await Task.sleep(for: .milliseconds(100))
+      for _ in 0..<unownedDaemonStopPollCount where await supervisorClient.healthIsAvailable() {
+        try await Task.sleep(for: unownedDaemonStopPollInterval)
       }
       if await supervisorClient.healthIsAvailable(), !ownsDaemon {
         throw DaemonLifecycleError.unownedDaemonDidNotStop

--- a/apps/astronomical-menu/Sources/AstronomicalMenuCore/TelemetryStore.swift
+++ b/apps/astronomical-menu/Sources/AstronomicalMenuCore/TelemetryStore.swift
@@ -2,7 +2,7 @@ import Foundation
 
 private let maximumStatusRefreshErrorCharacterCount = 512
 private let maximumWorkerPolicyConfirmationAttempts = 3
-private let workerPolicyConfirmationRetryDelay = Duration.milliseconds(100)
+private let defaultWorkerPolicyConfirmationRetryDelay = Duration.milliseconds(100)
 
 enum ControlActionFeedback: Equatable {
   case inProgress(String)
@@ -37,6 +37,8 @@ final class TelemetryStore: ObservableObject {
   var onMenuBarTitleChanged: ((String) -> Void)?
 
   private let supervisorClient: any SupervisorClient
+  private let controlActionFeedbackDismissalDelay: Duration
+  private let workerPolicyConfirmationRetryDelay: Duration
   private let systemTelemetrySampler = SystemTelemetrySampler()
   private let systemTelemetryClock = ContinuousClock()
   private var pollingTask: Task<Void, Never>?
@@ -48,8 +50,14 @@ final class TelemetryStore: ObservableObject {
   private var popoverIsVisible = false
   private var lastSystemTelemetrySampleTime: ContinuousClock.Instant?
 
-  init(supervisorClient: any SupervisorClient = LocalSupervisorClient()) {
+  init(
+    supervisorClient: any SupervisorClient = LocalSupervisorClient(),
+    controlActionFeedbackDismissalDelay: Duration = .seconds(1),
+    workerPolicyConfirmationRetryDelay: Duration = defaultWorkerPolicyConfirmationRetryDelay
+  ) {
     self.supervisorClient = supervisorClient
+    self.controlActionFeedbackDismissalDelay = controlActionFeedbackDismissalDelay
+    self.workerPolicyConfirmationRetryDelay = workerPolicyConfirmationRetryDelay
   }
 
   func startPolling() {
@@ -295,10 +303,11 @@ final class TelemetryStore: ObservableObject {
 
   private func scheduleMaximumMlxMemoryFeedbackDismissal() {
     let feedbackGeneration = controlActionFeedbackGeneration
+    let dismissalDelay = controlActionFeedbackDismissalDelay
     controlActionFeedbackDismissalTask?.cancel()
     controlActionFeedbackDismissalTask = Task { [weak self] in
       do {
-        try await Task.sleep(for: .seconds(1))
+        try await Task.sleep(for: dismissalDelay)
       } catch {
         return
       }

--- a/apps/astronomical-menu/tests/AstronomicalMenuContractTests/DaemonControlTests.swift
+++ b/apps/astronomical-menu/tests/AstronomicalMenuContractTests/DaemonControlTests.swift
@@ -48,7 +48,7 @@ final class DaemonControlTests: XCTestCase {
     defer { testContext.removeTemporaryDirectory() }
     let daemonLifecycleController = testContext.makeController(
       supervisorClient: ExistingDelayedReadinessSupervisorClient(readyAfterCheckCount: 3),
-      readinessTimeout: .seconds(1))
+      readinessTimeout: .milliseconds(100))
 
     try await daemonLifecycleController.startDaemonIfNeeded()
 
@@ -269,7 +269,9 @@ final class DaemonControlTests: XCTestCase {
   @MainActor
   func test_should_report_when_an_unowned_server_does_not_stop() async {
     let daemonLifecycleController = DaemonLifecycleController(
-      supervisorClient: StuckExternalSupervisorClient()
+      supervisorClient: StuckExternalSupervisorClient(),
+      unownedDaemonStopPollCount: 3,
+      unownedDaemonStopPollInterval: .milliseconds(1)
     )
 
     do {
@@ -311,6 +313,8 @@ private struct DaemonLifecycleTestContext {
       applicationIdentity: applicationIdentity,
       readinessTimeout: readinessTimeout,
       readinessPollInterval: .milliseconds(5),
+      unownedDaemonStopPollCount: 3,
+      unownedDaemonStopPollInterval: .milliseconds(1),
       menuExecutableURL: URL(
         fileURLWithPath: "/Applications/Astronomical.app/Contents/MacOS/astronomical-menu"),
       daemonExecutableURL: daemonExecutableURL,

--- a/apps/astronomical-menu/tests/AstronomicalMenuContractTests/MenuControlStateTests.swift
+++ b/apps/astronomical-menu/tests/AstronomicalMenuContractTests/MenuControlStateTests.swift
@@ -80,7 +80,7 @@ final class MenuControlStateTests: XCTestCase {
       .success("MLX memory setting persisted and applied")
     )
 
-    try await Task.sleep(for: .milliseconds(5))
+    try await Task.sleep(for: .milliseconds(10))
     XCTAssertEqual(
       telemetryStore.controlActionFeedback,
       .success("MLX memory setting persisted and applied")
@@ -102,7 +102,7 @@ final class MenuControlStateTests: XCTestCase {
 
     await supervisorClient.markMaximumMlxMemoryUpdateAsApplied()
     telemetryStore.refreshNow()
-    try await Task.sleep(for: .milliseconds(5))
+    try await Task.sleep(for: .milliseconds(10))
     XCTAssertNotNil(telemetryStore.controlActionFeedback)
 
     try await waitForControlActionFeedbackToDismiss(from: telemetryStore)
@@ -190,7 +190,7 @@ final class MenuControlStateTests: XCTestCase {
   @MainActor
   private func waitForControlActionFeedbackToDismiss(from telemetryStore: TelemetryStore) async throws {
     let feedbackDismissalClock = ContinuousClock()
-    let feedbackDismissalDeadline = feedbackDismissalClock.now.advanced(by: .milliseconds(250))
+    let feedbackDismissalDeadline = feedbackDismissalClock.now.advanced(by: .milliseconds(400))
     while telemetryStore.controlActionFeedback != nil,
       feedbackDismissalClock.now < feedbackDismissalDeadline
     {
@@ -204,7 +204,7 @@ final class MenuControlStateTests: XCTestCase {
 private func contractTelemetryStore(supervisorClient: any SupervisorClient) -> TelemetryStore {
   TelemetryStore(
     supervisorClient: supervisorClient,
-    controlActionFeedbackDismissalDelay: .milliseconds(20),
+    controlActionFeedbackDismissalDelay: .milliseconds(80),
     workerPolicyConfirmationRetryDelay: .milliseconds(1)
   )
 }

--- a/apps/astronomical-menu/tests/AstronomicalMenuContractTests/MenuControlStateTests.swift
+++ b/apps/astronomical-menu/tests/AstronomicalMenuContractTests/MenuControlStateTests.swift
@@ -6,7 +6,7 @@ import XCTest
 final class MenuControlStateTests: XCTestCase {
   @MainActor
   func test_should_surface_a_successful_configuration_reload_to_the_popover() async {
-    let telemetryStore = TelemetryStore(
+    let telemetryStore = contractTelemetryStore(
       supervisorClient: SuccessfulReloadSupervisorClient()
     )
 
@@ -20,7 +20,7 @@ final class MenuControlStateTests: XCTestCase {
 
   @MainActor
   func test_should_not_report_worker_restart_success_before_status_confirms_the_acknowledged_policy() async {
-    let telemetryStore = TelemetryStore(
+    let telemetryStore = contractTelemetryStore(
       supervisorClient: RestartAcknowledgedButStatusUnconfirmedSupervisorClient()
     )
 
@@ -34,7 +34,7 @@ final class MenuControlStateTests: XCTestCase {
 
   @MainActor
   func test_should_report_worker_restart_success_after_status_confirms_the_acknowledged_policy() async {
-    let telemetryStore = TelemetryStore(
+    let telemetryStore = contractTelemetryStore(
       supervisorClient: RestartAcknowledgedAndStatusConfirmedSupervisorClient()
     )
 
@@ -49,7 +49,7 @@ final class MenuControlStateTests: XCTestCase {
   @MainActor
   func test_should_confirm_a_worker_restart_when_polling_overlaps_delayed_confirmation() async {
     let supervisorClient = OverlappingRestartConfirmationSupervisorClient()
-    let telemetryStore = TelemetryStore(supervisorClient: supervisorClient)
+    let telemetryStore = contractTelemetryStore(supervisorClient: supervisorClient)
     let configurationReloadTask = Task { @MainActor in
       await telemetryStore.performConfigurationReload()
     }
@@ -69,7 +69,7 @@ final class MenuControlStateTests: XCTestCase {
 
   @MainActor
   func test_should_dismiss_a_successful_memory_update_one_second_after_application() async throws {
-    let telemetryStore = TelemetryStore(
+    let telemetryStore = contractTelemetryStore(
       supervisorClient: SuccessfulMaximumMlxMemoryUpdateSupervisorClient()
     )
 
@@ -80,7 +80,7 @@ final class MenuControlStateTests: XCTestCase {
       .success("MLX memory setting persisted and applied")
     )
 
-    try await Task.sleep(for: .milliseconds(100))
+    try await Task.sleep(for: .milliseconds(5))
     XCTAssertEqual(
       telemetryStore.controlActionFeedback,
       .success("MLX memory setting persisted and applied")
@@ -92,7 +92,7 @@ final class MenuControlStateTests: XCTestCase {
   @MainActor
   func test_should_wait_for_a_queued_memory_update_to_take_effect_before_dismissing() async throws {
     let supervisorClient = QueuedMaximumMlxMemoryUpdateSupervisorClient()
-    let telemetryStore = TelemetryStore(supervisorClient: supervisorClient)
+    let telemetryStore = contractTelemetryStore(supervisorClient: supervisorClient)
 
     await telemetryStore.performMaximumMlxMemoryLimitUpdate(32)
     XCTAssertEqual(
@@ -102,7 +102,7 @@ final class MenuControlStateTests: XCTestCase {
 
     await supervisorClient.markMaximumMlxMemoryUpdateAsApplied()
     telemetryStore.refreshNow()
-    try await Task.sleep(for: .milliseconds(100))
+    try await Task.sleep(for: .milliseconds(5))
     XCTAssertNotNil(telemetryStore.controlActionFeedback)
 
     try await waitForControlActionFeedbackToDismiss(from: telemetryStore)
@@ -110,7 +110,7 @@ final class MenuControlStateTests: XCTestCase {
 
   @MainActor
   func test_should_surface_a_late_memory_update_rejection_as_failure_feedback() async {
-    let telemetryStore = TelemetryStore(
+    let telemetryStore = contractTelemetryStore(
       supervisorClient: RejectedMaximumMlxMemoryUpdateSupervisorClient()
     )
 
@@ -124,7 +124,7 @@ final class MenuControlStateTests: XCTestCase {
 
   @MainActor
   func test_should_start_dismissal_after_a_status_refresh_precedes_the_update_response() async throws {
-    let telemetryStore = TelemetryStore(
+    let telemetryStore = contractTelemetryStore(
       supervisorClient: DelayedMaximumMlxMemoryUpdateSupervisorClient()
     )
     let memoryUpdateTask = Task { @MainActor in
@@ -145,21 +145,21 @@ final class MenuControlStateTests: XCTestCase {
 
   @MainActor
   func test_should_not_let_memory_success_dismiss_newer_server_feedback() async throws {
-    let telemetryStore = TelemetryStore(
+    let telemetryStore = contractTelemetryStore(
       supervisorClient: SuccessfulMaximumMlxMemoryUpdateSupervisorClient()
     )
 
     await telemetryStore.performMaximumMlxMemoryLimitUpdate(32)
     telemetryStore.beginServerRestart()
 
-    try await Task.sleep(for: .milliseconds(1_100))
+    try await Task.sleep(for: .milliseconds(50))
 
     XCTAssertEqual(telemetryStore.controlActionFeedback, .inProgress("Restarting server…"))
   }
 
   @MainActor
   func test_should_ignore_a_memory_update_that_finishes_after_newer_feedback_begins() async {
-    let telemetryStore = TelemetryStore(
+    let telemetryStore = contractTelemetryStore(
       supervisorClient: DelayedMaximumMlxMemoryUpdateSupervisorClient()
     )
     let memoryUpdateTask = Task { @MainActor in
@@ -175,7 +175,7 @@ final class MenuControlStateTests: XCTestCase {
 
   @MainActor
   func test_should_surface_a_configuration_reload_failure_to_the_popover() async {
-    let telemetryStore = TelemetryStore(
+    let telemetryStore = contractTelemetryStore(
       supervisorClient: FailingReloadSupervisorClient()
     )
 
@@ -190,14 +190,23 @@ final class MenuControlStateTests: XCTestCase {
   @MainActor
   private func waitForControlActionFeedbackToDismiss(from telemetryStore: TelemetryStore) async throws {
     let feedbackDismissalClock = ContinuousClock()
-    let feedbackDismissalDeadline = feedbackDismissalClock.now.advanced(by: .seconds(2))
+    let feedbackDismissalDeadline = feedbackDismissalClock.now.advanced(by: .milliseconds(250))
     while telemetryStore.controlActionFeedback != nil,
       feedbackDismissalClock.now < feedbackDismissalDeadline
     {
-      try await Task.sleep(for: .milliseconds(25))
+      try await Task.sleep(for: .milliseconds(5))
     }
     XCTAssertNil(telemetryStore.controlActionFeedback)
   }
+}
+
+@MainActor
+private func contractTelemetryStore(supervisorClient: any SupervisorClient) -> TelemetryStore {
+  TelemetryStore(
+    supervisorClient: supervisorClient,
+    controlActionFeedbackDismissalDelay: .milliseconds(20),
+    workerPolicyConfirmationRetryDelay: .milliseconds(1)
+  )
 }
 
 private struct SuccessfulReloadSupervisorClient: SupervisorClient {


### PR DESCRIPTION
## Linked issue

Closes #475

## Problem

Three menu contract suites spent about 15 seconds of wall clock on the hermetic job: DaemonControlTests waited up to three seconds for an unowned server to refuse to stop, and MenuControlStateTests waited a real one-second success-feedback delay.

## Change

- Daemon restart polling for an unowned server is parameterized; contract tests use a 3 × 1ms poll.
- Control-action feedback dismissal and worker-policy confirmation delays are parameterized; contract tests use 20ms and 1ms.
- MenuControlStateTests wait on those short delays instead of 1.1–2 second sleeps.

SupervisorStatusJourneyTests still use the production URLSession client with the stub protocol; that suite is unchanged.

## Verification

- Local `swift test --package-path apps/astronomical-menu`: 103 tests, DaemonControlTests 0.37s (was 4.1s), MenuControlStateTests 0.56s (was 5.1s).
- `scripts/verify-before-commit.sh` (18/18).

## Safety

- [x] No credentials, personal paths, prompts, model inventories, proprietary artifacts, or machine logs are included.
- [x] Model precision and output semantics are preserved or explicitly justified.
- [x] Performance and memory effects are measured when the critical path changes.
- [x] Source reuse and third-party licensing are accurately attributed.
