### PR TITLE
Cut first-launch cost in native compatibility identity (#477)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,27 @@ jobs:
           set -euo pipefail
           started_at_seconds="$(date +%s)"
           printf '[native-build-identity] status=start\n'
-          native_build_identity="$(scripts/native-build-cache-fingerprint.sh --profile core)"
+          native_identity_file="$RUNNER_TEMP/astronomical-native-identity"
+          swift_toolchain_manifest="$RUNNER_TEMP/astronomical-swift-toolchain"
+          scripts/native-build-cache-fingerprint.sh --profile core > "$native_identity_file" &
+          fingerprint_process_id=$!
+          {
+            xcodebuild -version
+            swift --version
+            xcrun --sdk macosx --show-sdk-version
+            xcrun --sdk macosx --show-sdk-build-version
+          } > "$swift_toolchain_manifest" &
+          swift_toolchain_process_id=$!
+          wait "$fingerprint_process_id"
+          wait "$swift_toolchain_process_id"
+          native_build_identity="$(tr -d '[:space:]' < "$native_identity_file")"
+          case "$native_build_identity" in
+            ''|*[!0-9a-f]*) printf '%s\n' 'Error: native build identity is invalid' >&2; exit 1 ;;
+          esac
+          [ "${#native_build_identity}" -eq 64 ] || {
+            printf '%s\n' 'Error: native build identity length is invalid' >&2
+            exit 1
+          }
           native_build_store_directory="$HOME/Library/Caches/Astronomical/native-builds"
           native_store_schema_version="$(tr -d '[:space:]' < crates/runtime-integration/native-build-store-schema-version)"
           case "$native_store_schema_version" in
@@ -85,13 +105,6 @@ jobs:
           esac
           native_build_entry_directory="$native_build_store_directory/v$native_store_schema_version/entries/$native_build_identity"
           native_build_status_file="$RUNNER_TEMP/astronomical-native-build-status"
-          swift_toolchain_manifest="$RUNNER_TEMP/astronomical-swift-toolchain"
-          {
-            xcodebuild -version
-            swift --version
-            xcrun --sdk macosx --show-sdk-version
-            xcrun --sdk macosx --show-sdk-build-version
-          } > "$swift_toolchain_manifest"
           swift_toolchain_digest_output="$(shasum -a 256 "$swift_toolchain_manifest")"
           swift_toolchain_identity="${swift_toolchain_digest_output%% *}"
           {

--- a/scripts/native-build-cache-fingerprint.sh
+++ b/scripts/native-build-cache-fingerprint.sh
@@ -204,11 +204,16 @@ append_compatibility_identity() {
     }
     printf 'compatibility\ttarget\t%s\n' "$target_identity" >> "$identity_manifest"
     printf 'compatibility\tbuild-type\t%s\n' "$build_type" >> "$identity_manifest"
-    capture_compatibility_input xcode ASTRONOMICAL_NATIVE_IDENTITY_XCODE capture_xcode_identity
-    capture_compatibility_input sdk ASTRONOMICAL_NATIVE_IDENTITY_SDK capture_sdk_identity
-    capture_compatibility_input clang ASTRONOMICAL_NATIVE_IDENTITY_CLANG capture_clang_identity
-    capture_compatibility_input cmake ASTRONOMICAL_NATIVE_IDENTITY_CMAKE capture_cmake_identity
-    capture_compatibility_input rustc ASTRONOMICAL_NATIVE_IDENTITY_RUSTC capture_rustc_identity
+    for compatibility_probe in xcode,ASTRONOMICAL_NATIVE_IDENTITY_XCODE,capture_xcode_identity sdk,ASTRONOMICAL_NATIVE_IDENTITY_SDK,capture_sdk_identity clang,ASTRONOMICAL_NATIVE_IDENTITY_CLANG,capture_clang_identity cmake,ASTRONOMICAL_NATIVE_IDENTITY_CMAKE,capture_cmake_identity rustc,ASTRONOMICAL_NATIVE_IDENTITY_RUSTC,capture_rustc_identity; do
+        probe_name="${compatibility_probe%%,*}"
+        probe_rest="${compatibility_probe#*,}"
+        probe_override="${probe_rest%%,*}"
+        probe_command="${probe_rest#*,}"
+        probe_started_at_seconds="$(date +%s)"
+        capture_compatibility_input "$probe_name" "$probe_override" "$probe_command"
+        printf '[native-build-cache-fingerprint] probe=%s elapsed_seconds=%s\n' \
+            "$probe_name" "$(( $(date +%s) - probe_started_at_seconds ))" >&2
+    done
 }
 
 main() {


### PR DESCRIPTION
## Linked issue

Closes #477

## Problem

"Resolve native compatibility identity" took 16 seconds on a recent hermetic job. The step ran the native fingerprint (xcodebuild, sdk, clang, cmake, rustc) and then captured the Swift toolchain manifest with another xcodebuild/swift/xcrun sequence.

## Change

- Run the fingerprint script and the Swift toolchain capture in parallel, then wait for both.
- Log each fingerprint probe's elapsed seconds so the dominant cold-start command is visible in the job log.

Identity bytes and cache keys are unchanged.

## Verification

- `scripts/test-ci-native-cache-coordination.sh`
- `scripts/verify-before-commit.sh` (18/18)
- Hosted CI identity step log includes per-probe elapsed times.

## Safety

- [x] No credentials, personal paths, prompts, model inventories, proprietary artifacts, or machine logs are included.
- [x] Model precision and output semantics are preserved or explicitly justified.
- [x] Performance and memory effects are measured when the critical path changes.
- [x] Source reuse and third-party licensing are accurately attributed.
