### PR TITLE
fix: apply InitializeWorker runtime ack before SwapModel

### DIFF
--- a/apps/supervisor/src/lib.rs
+++ b/apps/supervisor/src/lib.rs
@@ -71,6 +71,7 @@ mod worker_model_swap;
 mod worker_prefill_progress;
 mod worker_process;
 mod worker_replacement;
+mod worker_startup_runtime;
 mod worker_stderr_tail;
 
 pub use application::{

--- a/apps/supervisor/src/worker_embeddings_request.rs
+++ b/apps/supervisor/src/worker_embeddings_request.rs
@@ -14,6 +14,7 @@ use crate::{
     worker_health::{clear_active_request_progress, publish_activity},
     worker_loop_types::{ActiveEmbeddingsGeneration, ActiveWorkerRequest},
     worker_model_swap::{ModelSwapWaitOutcome, wait_for_model_swap},
+    worker_startup_runtime::wait_for_startup_runtime_configuration,
 };
 
 /// Bounded embeddings execution deadline; the single forward pass has no
@@ -46,6 +47,17 @@ pub(super) async fn handle_generate_embeddings_command(
         tracing::error!("received GenerateEmbeddings while another request is active");
         return Ok(());
     }
+    wait_for_startup_runtime_configuration(
+        worker_process,
+        health_snapshot,
+        is_ready,
+        model_load_deadline,
+        active_request,
+        performance_log,
+        completion_log,
+        model_load_timeout,
+    )
+    .await?;
     let loaded_model_id = health_snapshot
         .read()
         .ok()

--- a/apps/supervisor/src/worker_generate.rs
+++ b/apps/supervisor/src/worker_generate.rs
@@ -17,6 +17,7 @@ use crate::{
     worker_health::{clear_active_request_progress, publish_activity},
     worker_loop_types::{ActiveGeneration, ActiveWorkerRequest},
     worker_model_swap::{ModelSwapWaitOutcome, wait_for_model_swap},
+    worker_startup_runtime::wait_for_startup_runtime_configuration,
 };
 
 pub(super) async fn handle_generate_command(
@@ -44,6 +45,17 @@ pub(super) async fn handle_generate_command(
         );
         return Ok(());
     }
+    wait_for_startup_runtime_configuration(
+        worker_process,
+        health_snapshot,
+        is_ready,
+        model_load_deadline,
+        active_request,
+        performance_log,
+        completion_log,
+        model_load_timeout,
+    )
+    .await?;
     // REST validates model IDs, but direct WorkerHandle callers share this
     // boundary and therefore still need the empty-worker guard.
     let loaded_model_id = health_snapshot

--- a/apps/supervisor/src/worker_image_request.rs
+++ b/apps/supervisor/src/worker_image_request.rs
@@ -17,6 +17,7 @@ use crate::{
     worker_health::{clear_active_request_progress, publish_activity},
     worker_loop_types::{ActiveImageGeneration, ActiveWorkerRequest},
     worker_model_swap::{ModelSwapWaitOutcome, wait_for_model_swap},
+    worker_startup_runtime::wait_for_startup_runtime_configuration,
 };
 
 #[allow(clippy::too_many_arguments)]
@@ -46,6 +47,17 @@ pub(super) async fn handle_generate_image_command(
         tracing::error!("received GenerateImage while another request is active");
         return Ok(());
     }
+    wait_for_startup_runtime_configuration(
+        worker_process,
+        health_snapshot,
+        is_ready,
+        model_load_deadline,
+        active_request,
+        performance_log,
+        completion_log,
+        model_load_timeout,
+    )
+    .await?;
     let loaded_model_id = health_snapshot
         .read()
         .ok()

--- a/apps/supervisor/src/worker_process.rs
+++ b/apps/supervisor/src/worker_process.rs
@@ -66,6 +66,7 @@ pub struct WorkerProcess {
     command_write_timeout: Duration,
     launch_executable_path: PathBuf,
     launch_startup_configuration: Option<WorkerStartupConfiguration>,
+    startup_runtime_configuration_applied: bool,
     shutdown_timeout: Duration,
     stderr_drain_task: Option<JoinHandle<()>>,
     worker_stderr_tail: WorkerStderrTail,
@@ -204,6 +205,7 @@ impl WorkerProcess {
             command_write_timeout,
             launch_executable_path,
             launch_startup_configuration,
+            startup_runtime_configuration_applied: false,
             shutdown_timeout,
             stderr_drain_task: Some(stderr_drain_task),
             worker_stderr_tail,
@@ -229,6 +231,14 @@ impl WorkerProcess {
         self.launch_startup_configuration
             .as_ref()
             .map(|configuration| configuration.configuration_generation.as_str())
+    }
+
+    pub(crate) fn startup_runtime_configuration_applied(&self) -> bool {
+        self.startup_runtime_configuration_applied
+    }
+
+    pub(crate) fn mark_startup_runtime_configuration_applied(&mut self) {
+        self.startup_runtime_configuration_applied = true;
     }
 
     pub async fn start_generation(

--- a/apps/supervisor/src/worker_startup_runtime.rs
+++ b/apps/supervisor/src/worker_startup_runtime.rs
@@ -1,0 +1,100 @@
+//! Applies InitializeWorker runtime-policy acknowledgement before SwapModel.
+//!
+//! Launch writes InitializeWorker and returns as soon as the process is
+//! spawned. Idle can mark the worker ready while that acknowledgement is
+//! still in the pipe. A SwapModel in that window treats a missing health
+//! generation as "policy already ready", then the later
+//! RuntimeFeatureConfigurationApplied looks like an illegal loaded-model
+//! change and the supervisor contains the worker.
+//!
+//! The wait is once per worker process. Live memory updates may change the
+//! configuration generation, and a rejected swap may clear it from health;
+//! neither should wait for InitializeWorker again.
+
+use std::sync::{Arc, RwLock};
+use std::time::Duration;
+
+use tokio::time::{Instant, timeout};
+
+use crate::{
+    CompletionAttributionLog, GenerationPerformanceLog, WorkerControlError, WorkerHealthSnapshot,
+    WorkerProcess, worker_event_handler::handle_worker_event,
+    worker_loop_types::ActiveWorkerRequest,
+};
+
+#[allow(clippy::too_many_arguments)]
+pub(super) async fn wait_for_startup_runtime_configuration(
+    worker_process: &mut WorkerProcess,
+    health_snapshot: &Arc<RwLock<WorkerHealthSnapshot>>,
+    is_ready: &mut bool,
+    model_load_deadline: &mut Option<Instant>,
+    active_request: &mut Option<ActiveWorkerRequest>,
+    performance_log: &mut GenerationPerformanceLog,
+    completion_log: &mut CompletionAttributionLog,
+    model_load_timeout: Duration,
+) -> Result<(), WorkerControlError> {
+    if worker_process.expected_configuration_generation().is_none() {
+        return Ok(());
+    }
+    if worker_process.startup_runtime_configuration_applied() {
+        return Ok(());
+    }
+    if health_has_runtime_configuration(health_snapshot) {
+        worker_process.mark_startup_runtime_configuration_applied();
+        return Ok(());
+    }
+    timeout(
+        model_load_timeout,
+        drain_until_startup_runtime_configuration(
+            worker_process,
+            health_snapshot,
+            is_ready,
+            model_load_deadline,
+            active_request,
+            performance_log,
+            completion_log,
+        ),
+    )
+    .await
+    .map_err(|_| WorkerControlError::ModelLoadTimeout {
+        model_load_timeout_millis: model_load_timeout.as_millis(),
+    })?
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn drain_until_startup_runtime_configuration(
+    worker_process: &mut WorkerProcess,
+    health_snapshot: &Arc<RwLock<WorkerHealthSnapshot>>,
+    is_ready: &mut bool,
+    model_load_deadline: &mut Option<Instant>,
+    active_request: &mut Option<ActiveWorkerRequest>,
+    performance_log: &mut GenerationPerformanceLog,
+    completion_log: &mut CompletionAttributionLog,
+) -> Result<(), WorkerControlError> {
+    loop {
+        if health_has_runtime_configuration(health_snapshot) {
+            worker_process.mark_startup_runtime_configuration_applied();
+            return Ok(());
+        }
+        let worker_event = worker_process
+            .next_event()
+            .await?
+            .ok_or(WorkerControlError::WorkerEventStreamClosed)?;
+        handle_worker_event(
+            worker_event,
+            health_snapshot,
+            is_ready,
+            model_load_deadline,
+            active_request,
+            performance_log,
+            completion_log,
+        )?;
+    }
+}
+
+fn health_has_runtime_configuration(health_snapshot: &Arc<RwLock<WorkerHealthSnapshot>>) -> bool {
+    health_snapshot
+        .read()
+        .ok()
+        .is_some_and(|snapshot| snapshot.worker_runtime_feature_configuration.is_some())
+}

--- a/apps/supervisor/tests/fixtures/idle_worker.rs
+++ b/apps/supervisor/tests/fixtures/idle_worker.rs
@@ -23,6 +23,8 @@ const GENERATION_EVENT_BEFORE_SWAP_MODEL_ID: &str =
 const TELEMETRY_BEFORE_SWAP_MODEL_ID: &str = "astronomical/telemetry-before-swap-model";
 const DELAYED_POLICY_ACK_MODEL_ID: &str = "astronomical/delayed-policy-ack-model";
 const DELAYED_IMAGE_POLICY_ACK_MODEL_ID: &str = "astronomical/delayed-image-policy-ack-model";
+const DELAYED_STARTUP_RUNTIME_CONFIGURATION_GENERATION: &str =
+    "delayed-startup-runtime-configuration";
 
 #[tokio::main]
 async fn main() -> ExitCode {
@@ -51,6 +53,11 @@ async fn run_fixture() -> Result<(), Box<dyn Error + Send + Sync>> {
     while let Some(worker_command) = command_reader.next_command().await? {
         match worker_command {
             WorkerCommand::InitializeWorker(worker_startup_configuration) => {
+                if worker_startup_configuration.configuration_generation
+                    == DELAYED_STARTUP_RUNTIME_CONFIGURATION_GENERATION
+                {
+                    tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+                }
                 let runtime_configuration = WorkerRuntimeFeatureConfiguration {
                     configuration_generation: worker_startup_configuration.configuration_generation,
                     persistent_prompt_cache_enabled: worker_startup_configuration

--- a/apps/supervisor/tests/hermetic/mod.rs
+++ b/apps/supervisor/tests/hermetic/mod.rs
@@ -28,3 +28,4 @@ mod worker_launch;
 mod worker_memory_limit_model_swap;
 mod worker_model_swap;
 mod worker_replacement;
+mod worker_startup_runtime;

--- a/apps/supervisor/tests/hermetic/worker_memory_limit_model_swap.rs
+++ b/apps/supervisor/tests/hermetic/worker_memory_limit_model_swap.rs
@@ -30,7 +30,7 @@ async fn should_load_a_model_after_a_live_memory_update_changes_the_configuratio
         .await
         .expect("the model should load after the live configuration update");
 
-    assert_generation_completed(&mut generation_events).await;
+    assert_generation_completed(&mut generation_events, "after live memory update").await;
     assert_eq!(
         worker_handle.worker_health_snapshot().status,
         WorkerHealthStatus::Ready

--- a/apps/supervisor/tests/hermetic/worker_model_swap.rs
+++ b/apps/supervisor/tests/hermetic/worker_model_swap.rs
@@ -44,13 +44,17 @@ async fn should_complete_a_queued_model_swap_when_idle_telemetry_arrives_before_
             .await
     });
 
-    assert_generation_completed(&mut first_generation_events).await;
+    assert_generation_completed(&mut first_generation_events, "first delayed completion").await;
     let mut queued_generation_events = timeout(Duration::from_secs(2), queued_generation_task)
         .await
         .expect("the queued model swap should finish before the timeout")
         .expect("the queued generation task should not panic")
         .expect("idle telemetry must not make the queued model swap unavailable");
-    assert_generation_completed(&mut queued_generation_events).await;
+    assert_generation_completed(
+        &mut queued_generation_events,
+        "queued telemetry-before-swap",
+    )
+    .await;
 
     let worker_health_snapshot = worker_handle.worker_health_snapshot();
     assert_eq!(worker_health_snapshot.status, WorkerHealthStatus::Ready);
@@ -115,7 +119,7 @@ async fn should_swap_chat_to_image_to_chat_with_exact_runtime_policy() {
         .start_chat_generation(chat_command(TELEMETRY_BEFORE_SWAP_MODEL_ID, 10))
         .await
         .expect("the chat model should load");
-    assert_generation_completed(&mut first_chat).await;
+    assert_generation_completed(&mut first_chat, "chat before image swap").await;
 
     let mut image_result = worker_handle
         .start_image_generation(ImageGenerationCommand {
@@ -153,7 +157,7 @@ async fn should_swap_chat_to_image_to_chat_with_exact_runtime_policy() {
         .start_chat_generation(chat_command(TELEMETRY_BEFORE_SWAP_MODEL_ID, 12))
         .await
         .expect("the chat model should reload");
-    assert_generation_completed(&mut final_chat).await;
+    assert_generation_completed(&mut final_chat, "chat after image swap").await;
     worker_handle
         .shutdown()
         .await
@@ -195,7 +199,11 @@ async fn should_publish_model_identity_and_runtime_policy_as_one_health_snapshot
         .start_chat_generation(chat_command(TELEMETRY_BEFORE_SWAP_MODEL_ID, 15))
         .await
         .expect("the initial model should load");
-    assert_generation_completed(&mut first_generation).await;
+    assert_generation_completed(
+        &mut first_generation,
+        "health snapshot before delayed policy",
+    )
+    .await;
 
     let swapping_worker_handle = worker_handle.clone();
     let swap_task = tokio::spawn(async move {
@@ -223,7 +231,11 @@ async fn should_publish_model_identity_and_runtime_policy_as_one_health_snapshot
         .expect("the exact swap acknowledgements should arrive")
         .expect("the swap task should not panic")
         .expect("the swapped generation should start");
-    assert_generation_completed(&mut swapped_generation).await;
+    assert_generation_completed(
+        &mut swapped_generation,
+        "health snapshot after delayed policy",
+    )
+    .await;
     let committed_health_snapshot = worker_handle.worker_health_snapshot();
     assert_eq!(
         committed_health_snapshot.ready_model_id.as_deref(),
@@ -408,7 +420,7 @@ fn image_generation_command(model_id: &str, request_id: u64) -> ImageGenerationC
     }
 }
 
-fn runtime_model_policy(
+pub(super) fn runtime_model_policy(
     model_id: &str,
     model_directory: &str,
     maximum_output_tokens: u32,
@@ -452,7 +464,7 @@ fn runtime_model_policy(
     }
 }
 
-async fn wait_for_ready_worker(worker_handle: &WorkerHandle) {
+pub(super) async fn wait_for_ready_worker(worker_handle: &WorkerHandle) {
     let readiness_deadline = Instant::now() + Duration::from_secs(1);
     loop {
         let worker_health_status = worker_handle.worker_health_snapshot().status;
@@ -469,18 +481,22 @@ async fn wait_for_ready_worker(worker_handle: &WorkerHandle) {
 
 pub(super) async fn assert_generation_completed(
     generation_events: &mut tokio::sync::mpsc::Receiver<ChatGenerationStreamEvent>,
+    generation_label: &str,
 ) {
     let generation_event = timeout(Duration::from_secs(2), generation_events.recv())
         .await
         .expect("the generation should complete before the timeout")
         .expect("the generation stream should contain a completion event");
-    assert!(matches!(
-        generation_event,
-        ChatGenerationStreamEvent::Completed {
-            reason: ChatGenerationCompletionReason::EndOfSequence,
-            ..
-        }
-    ));
+    assert!(
+        matches!(
+            generation_event,
+            ChatGenerationStreamEvent::Completed {
+                reason: ChatGenerationCompletionReason::EndOfSequence,
+                ..
+            }
+        ),
+        "{generation_label}: expected EndOfSequence completion, received {generation_event:?}"
+    );
 }
 
 pub(super) fn chat_command(model_id: &str, request_id: u64) -> ChatGenerationCommand {

--- a/apps/supervisor/tests/hermetic/worker_startup_runtime.rs
+++ b/apps/supervisor/tests/hermetic/worker_startup_runtime.rs
@@ -1,0 +1,72 @@
+//! Proves the first generation still completes when InitializeWorker
+//! acknowledgement is still in flight after Idle has made the worker ready.
+
+use std::{collections::HashMap, path::PathBuf, sync::Arc, time::Duration};
+
+use astronomical_ipc_protocol::{WorkerLogLevel, WorkerStartupConfiguration};
+use astronomical_supervisor::{ChatGenerationExecutor, GenerationPerformanceLog, WorkerHandle};
+use tokio::time::timeout;
+
+use super::worker_model_swap::{
+    TELEMETRY_BEFORE_SWAP_MODEL_ID, assert_generation_completed, chat_command,
+    runtime_model_policy, wait_for_ready_worker,
+};
+
+const DELAYED_STARTUP_RUNTIME_CONFIGURATION_GENERATION: &str =
+    "delayed-startup-runtime-configuration";
+
+#[tokio::test]
+async fn should_complete_generation_when_startup_runtime_acknowledgement_is_still_in_flight() {
+    let worker_executable_path = PathBuf::from(
+        std::env::var("CARGO_BIN_EXE_astronomical-supervisor-idle-worker")
+            .expect("Cargo should provide the idle worker fixture path"),
+    );
+    let temporary_log_directory =
+        tempfile::tempdir().expect("test performance log directory should be created");
+    let worker_handle = WorkerHandle::launch_with_startup_configuration(
+        worker_executable_path,
+        Duration::from_secs(1),
+        GenerationPerformanceLog::open(temporary_log_directory.path())
+            .expect("test performance log should be created"),
+        Arc::new(HashMap::from([(
+            TELEMETRY_BEFORE_SWAP_MODEL_ID.to_owned(),
+            runtime_model_policy(
+                TELEMETRY_BEFORE_SWAP_MODEL_ID,
+                "/models/telemetry-before-swap-model",
+                64,
+            ),
+        )])),
+        WorkerStartupConfiguration {
+            configuration_generation: DELAYED_STARTUP_RUNTIME_CONFIGURATION_GENERATION.to_owned(),
+            global_prompt_cache_root_directory: temporary_log_directory.path().join("prompt-cache"),
+            global_prompt_cache_maximum_size_bytes: 50_000_000_000,
+            persistent_prompt_cache_enabled: true,
+            configured_maximum_mlx_memory_bytes: None,
+            performance_attribution_enabled: false,
+            logging_directory: temporary_log_directory.path().to_path_buf(),
+            logging_level: WorkerLogLevel::Warn,
+            retained_log_file_count: 7,
+        },
+    )
+    .await
+    .expect("the idle worker should launch");
+    wait_for_ready_worker(&worker_handle).await;
+
+    let mut generation_events = timeout(
+        Duration::from_secs(2),
+        worker_handle.start_chat_generation(chat_command(TELEMETRY_BEFORE_SWAP_MODEL_ID, 1)),
+    )
+    .await
+    .expect("startup runtime acknowledgement should not block generation admission")
+    .expect("the first model should load after delayed startup runtime acknowledgement");
+    assert_generation_completed(
+        &mut generation_events,
+        "delayed startup runtime acknowledgement",
+    )
+    .await;
+
+    worker_handle
+        .shutdown()
+        .await
+        .expect("the worker should remain available for graceful shutdown");
+}


### PR DESCRIPTION
## Linked issue

Closes #443

## Summary

The first generation after launch could contain the worker with `Error(WorkerUnavailable)` when `InitializeWorker` acknowledgement was still in the pipe after Idle. `wait_for_model_swap` then treated a missing health generation as policy-ready, and the later `RuntimeFeatureConfigurationApplied` looked like an illegal loaded-model change.

Drain that acknowledgement once per worker process before chat, image, or embeddings SwapModel. Do not wait again after a live memory-generation change or a rejected swap that clears health.

## Evidence

- Hermetic journey `should_complete_generation_when_startup_runtime_acknowledgement_is_still_in_flight` delays InitializeWorker 150 ms after Idle.
- `worker_model_swap` module: 15/15 parallel runs green (was failing on the first parallel iteration before the fix).
- Assertion now prints the stream event so a future failure names `Error(WorkerUnavailable)` instead of a bare `matches!`.
