### PR TITLE
fix: apply a queued memory-ceiling raise before the next chat starts

### DIFF
--- a/apps/supervisor/src/worker.rs
+++ b/apps/supervisor/src/worker.rs
@@ -20,7 +20,9 @@ use crate::worker_embeddings_request::handle_generate_embeddings_command;
 use crate::worker_generate::handle_generate_command;
 use crate::worker_image_request::handle_generate_image_command;
 use crate::worker_memory_limit::{
-    MlxMemoryLimitUpdateOutcome, apply_mlx_memory_limit, contain_mlx_memory_limit_failure,
+    MlxMemoryLimitUpdateOutcome, PendingMlxMemoryLimitUpdate, apply_mlx_memory_limit,
+    apply_pending_mlx_memory_limit_if_idle, contain_mlx_memory_limit_failure,
+    take_generation_start_after_pending_memory_limit,
 };
 use crate::{
     ChatGenerationStreamErrorCode, CompletionAttributionLog, GenerationPerformanceLog,
@@ -40,11 +42,6 @@ use crate::{
     worker_loop_types::{ActiveWorkerRequest, WorkerLoopCommand},
     worker_replacement::WorkerReplacement,
 };
-
-struct PendingMlxMemoryLimitUpdate {
-    effective_mlx_memory_ceiling_bytes: u64,
-    configuration_generation: String,
-}
 
 // Keeping process-loop dependencies explicit is clearer than hiding them in a context object.
 #[allow(clippy::too_many_arguments)]
@@ -75,12 +72,9 @@ pub(crate) async fn run_worker(
 
     loop {
         if active_generation.is_none()
-            && let Some(pending_memory_limit_update) = pending_mlx_memory_limit_update.take()
-        {
-            if let Err(memory_limit_error) = apply_mlx_memory_limit(
+            && let Err(memory_limit_error) = apply_pending_mlx_memory_limit_if_idle(
+                &mut pending_mlx_memory_limit_update,
                 &mut worker_process,
-                pending_memory_limit_update.effective_mlx_memory_ceiling_bytes,
-                pending_memory_limit_update.configuration_generation,
                 model_load_timeout,
                 &health_snapshot,
                 &mut is_ready,
@@ -90,16 +84,15 @@ pub(crate) async fn run_worker(
                 &mut completion_log,
             )
             .await
-            {
-                contain_mlx_memory_limit_failure(
-                    &mut worker_process,
-                    &health_snapshot,
-                    &mut active_generation,
-                    &mut is_ready,
-                    memory_limit_error,
-                )
-                .await;
-            }
+        {
+            contain_mlx_memory_limit_failure(
+                &mut worker_process,
+                &health_snapshot,
+                &mut active_generation,
+                &mut is_ready,
+                memory_limit_error,
+            )
+            .await;
         }
         apply_pending_prompt_cache_clear_if_idle(
             &mut pending_prompt_cache_clear,
@@ -159,6 +152,22 @@ pub(crate) async fn run_worker(
                             let _send_outcome = start_sender.send(Err(GenerationStartError::WorkerUnavailable));
                             continue;
                         }
+                        let Some(start_sender) = take_generation_start_after_pending_memory_limit(
+                            &mut pending_mlx_memory_limit_update,
+                            &mut worker_process,
+                            model_load_timeout,
+                            &health_snapshot,
+                            &mut is_ready,
+                            &mut model_load_deadline,
+                            &mut active_generation,
+                            &mut performance_log,
+                            &mut completion_log,
+                            start_sender,
+                        )
+                        .await
+                        else {
+                            continue;
+                        };
                         if let Err(control_error) = handle_generate_command(
                             &mut worker_process,
                             active_generation_permit,
@@ -199,6 +208,22 @@ pub(crate) async fn run_worker(
                             let _send_outcome = start_sender.send(Err(GenerationStartError::WorkerUnavailable));
                             continue;
                         }
+                        let Some(start_sender) = take_generation_start_after_pending_memory_limit(
+                            &mut pending_mlx_memory_limit_update,
+                            &mut worker_process,
+                            model_load_timeout,
+                            &health_snapshot,
+                            &mut is_ready,
+                            &mut model_load_deadline,
+                            &mut active_generation,
+                            &mut performance_log,
+                            &mut completion_log,
+                            start_sender,
+                        )
+                        .await
+                        else {
+                            continue;
+                        };
                         if let Err(control_error) = handle_generate_image_command(
                             &mut worker_process,
                             active_generation_permit,
@@ -239,6 +264,22 @@ pub(crate) async fn run_worker(
                             let _send_outcome = start_sender.send(Err(GenerationStartError::WorkerUnavailable));
                             continue;
                         }
+                        let Some(start_sender) = take_generation_start_after_pending_memory_limit(
+                            &mut pending_mlx_memory_limit_update,
+                            &mut worker_process,
+                            model_load_timeout,
+                            &health_snapshot,
+                            &mut is_ready,
+                            &mut model_load_deadline,
+                            &mut active_generation,
+                            &mut performance_log,
+                            &mut completion_log,
+                            start_sender,
+                        )
+                        .await
+                        else {
+                            continue;
+                        };
                         if let Err(control_error) = handle_generate_embeddings_command(
                             &mut worker_process,
                             active_generation_permit,

--- a/apps/supervisor/src/worker_memory_limit.rs
+++ b/apps/supervisor/src/worker_memory_limit.rs
@@ -10,9 +10,10 @@ use crate::worker_containment::contain_worker_failure;
 use crate::worker_event_handler::handle_worker_event;
 use crate::worker_loop_types::ActiveWorkerRequest;
 use crate::{
-    CompletionAttributionLog, GenerationPerformanceLog, WorkerControlError, WorkerHealthSnapshot,
-    WorkerProcess,
+    CompletionAttributionLog, GenerationPerformanceLog, GenerationStartError, WorkerControlError,
+    WorkerHealthSnapshot, WorkerProcess,
 };
+use tokio::sync::oneshot;
 
 /// Completion state returned by a live MLX memory-limit request.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -20,6 +21,12 @@ pub enum MlxMemoryLimitUpdateOutcome {
     Applied,
     Queued,
     Rejected,
+}
+
+/// A live ceiling raise that waited because a generation was already running.
+pub(super) struct PendingMlxMemoryLimitUpdate {
+    pub effective_mlx_memory_ceiling_bytes: u64,
+    pub configuration_generation: String,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -109,4 +116,95 @@ pub(super) async fn contain_mlx_memory_limit_failure(
         .await;
     }
     *is_ready = false;
+}
+
+/// Applies a queued live ceiling raise now that the worker is idle.
+///
+/// Issue #515: the next Generate must not be admitted against the old
+/// ceiling after the user has already asked for more RAM. Call this both
+/// at the idle loop head and immediately before starting chat, image, or
+/// embeddings work, because `select` can deliver a Generate that was
+/// sitting in the channel beside the raise.
+#[allow(clippy::too_many_arguments)]
+pub(super) async fn apply_pending_mlx_memory_limit_if_idle(
+    pending_mlx_memory_limit_update: &mut Option<PendingMlxMemoryLimitUpdate>,
+    worker_process: &mut WorkerProcess,
+    model_load_timeout: Duration,
+    health_snapshot: &Arc<RwLock<WorkerHealthSnapshot>>,
+    is_ready: &mut bool,
+    model_load_deadline: &mut Option<Instant>,
+    active_generation: &mut Option<ActiveWorkerRequest>,
+    performance_log: &mut GenerationPerformanceLog,
+    completion_log: &mut CompletionAttributionLog,
+) -> Result<Option<MlxMemoryLimitUpdateOutcome>, WorkerControlError> {
+    let Some(pending_memory_limit_update) = pending_mlx_memory_limit_update.take() else {
+        return Ok(None);
+    };
+    let update_outcome = apply_mlx_memory_limit(
+        worker_process,
+        pending_memory_limit_update.effective_mlx_memory_ceiling_bytes,
+        pending_memory_limit_update.configuration_generation,
+        model_load_timeout,
+        health_snapshot,
+        is_ready,
+        model_load_deadline,
+        active_generation,
+        performance_log,
+        completion_log,
+    )
+    .await?;
+    Ok(Some(update_outcome))
+}
+
+/// Applies a queued ceiling raise, then reports whether generation may start.
+///
+/// Returns `Some(start_sender)` when the request may proceed. Returns `None`
+/// after refusing the start (rejected raise or control failure). The caller
+/// must `continue` the worker loop when this returns `None`.
+#[allow(clippy::too_many_arguments)]
+pub(super) async fn take_generation_start_after_pending_memory_limit(
+    pending_mlx_memory_limit_update: &mut Option<PendingMlxMemoryLimitUpdate>,
+    worker_process: &mut WorkerProcess,
+    model_load_timeout: Duration,
+    health_snapshot: &Arc<RwLock<WorkerHealthSnapshot>>,
+    is_ready: &mut bool,
+    model_load_deadline: &mut Option<Instant>,
+    active_generation: &mut Option<ActiveWorkerRequest>,
+    performance_log: &mut GenerationPerformanceLog,
+    completion_log: &mut CompletionAttributionLog,
+    start_sender: oneshot::Sender<Result<(), GenerationStartError>>,
+) -> Option<oneshot::Sender<Result<(), GenerationStartError>>> {
+    match apply_pending_mlx_memory_limit_if_idle(
+        pending_mlx_memory_limit_update,
+        worker_process,
+        model_load_timeout,
+        health_snapshot,
+        is_ready,
+        model_load_deadline,
+        active_generation,
+        performance_log,
+        completion_log,
+    )
+    .await
+    {
+        Ok(None)
+        | Ok(Some(MlxMemoryLimitUpdateOutcome::Applied))
+        | Ok(Some(MlxMemoryLimitUpdateOutcome::Queued)) => Some(start_sender),
+        Ok(Some(MlxMemoryLimitUpdateOutcome::Rejected)) => {
+            let _send_outcome = start_sender.send(Err(GenerationStartError::WorkerUnavailable));
+            None
+        }
+        Err(memory_limit_error) => {
+            let _send_outcome = start_sender.send(Err(GenerationStartError::WorkerUnavailable));
+            contain_mlx_memory_limit_failure(
+                worker_process,
+                health_snapshot,
+                active_generation,
+                is_ready,
+                memory_limit_error,
+            )
+            .await;
+            None
+        }
+    }
 }

--- a/apps/supervisor/tests/hermetic/request_queue.rs
+++ b/apps/supervisor/tests/hermetic/request_queue.rs
@@ -133,6 +133,66 @@ async fn should_queue_a_memory_limit_while_generation_is_active() {
         .expect("the worker should shut down");
 }
 
+#[tokio::test]
+async fn should_apply_a_queued_memory_limit_before_the_next_chat_starts() {
+    let worker_executor = launch_fixture().await;
+    let active_stream = worker_executor
+        .start_chat_generation(command_with_request_id(
+            "astronomical/delayed-fragment-chat-fixture",
+            1,
+        ))
+        .await
+        .expect("the delayed request should start");
+
+    assert_eq!(
+        worker_executor
+            .update_mlx_memory_limit(32_000_000_000, "raise-before-next-chat".to_owned())
+            .await
+            .expect("the active request should accept a queued limit"),
+        MlxMemoryLimitUpdateOutcome::Queued
+    );
+
+    let executor_for_next_chat = worker_executor.clone();
+    let next_chat_task = tokio::spawn(async move {
+        executor_for_next_chat
+            .start_chat_generation(command_with_request_id("astronomical/test-worker", 2))
+            .await
+    });
+
+    sleep(Duration::from_millis(50)).await;
+    drop(active_stream);
+
+    let mut next_stream = timeout(Duration::from_secs(5), next_chat_task)
+        .await
+        .expect("the next chat should start after the raise")
+        .expect("the next chat task should not panic")
+        .expect("the next chat should be admitted");
+
+    let worker_health_snapshot = worker_executor.worker_health_snapshot();
+    assert_eq!(
+        worker_health_snapshot.mlx_memory_ceiling_bytes, 32_000_000_000,
+        "the next chat must be admitted against the raised ceiling, not the old one: {worker_health_snapshot:?}"
+    );
+    assert!(
+        worker_health_snapshot
+            .pending_mlx_memory_ceiling_bytes
+            .is_none(),
+        "the pending flag must clear once the worker has applied the raise: {worker_health_snapshot:?}"
+    );
+
+    let completed_event =
+        receive_event_with_timeout(&mut next_stream, Duration::from_secs(2)).await;
+    assert!(
+        matches!(completed_event, ChatGenerationStreamEvent::Completed { .. }),
+        "the next chat should complete, got {completed_event:?}"
+    );
+
+    worker_executor
+        .shutdown()
+        .await
+        .expect("the worker should shut down");
+}
+
 /// The existing behavior of rejecting a request when capacity is full
 /// should still work: when the active slot AND all queue slots are taken,
 /// new requests get CapacityUnavailable immediately.


### PR DESCRIPTION
## Linked issue

Closes #515

## Summary

A live raise of the MLX memory ceiling could lose a race with the next prompt. Apply and Generate both sit in the supervisor command channel; if Generate is selected first, the request is admitted against the old ceiling.

## Evidence

A working Ornith session at 23 GB was raised to 40 GB. The next chat was rejected with `P=23230000000` — the old 23 GB peak allowance — while the raise finished 1.4 seconds later and promoted the model to fully resident. Worker logs:

- 19:53:28.723 generation `request_id=2` failed against 23 GB
- 19:53:30.126 the 40 GB raise completed (`Promoted`, fully resident)

## Fix

Before starting chat, image, or embeddings generation, apply any pending live MLX memory-limit update and wait for the worker's acknowledgement. A rejected raise refuses the start instead of silently serving the old ceiling. The existing "queue the raise while a generation is already running" behavior is unchanged.

## Test

A supervisor hermetic journey enqueues a raise beside an in-flight chat, starts the next chat as the first one ends, and asserts that chat is admitted against the new ceiling with the pending flag cleared.
