### PR TITLE
feat: paint unused MLX headroom as named owners in the menu

### DIFF
--- a/apps/astronomical-menu/Sources/AstronomicalMenuCore/MlxMemoryBreakdownBar.swift
+++ b/apps/astronomical-menu/Sources/AstronomicalMenuCore/MlxMemoryBreakdownBar.swift
@@ -8,8 +8,8 @@ enum MlxMemoryPalette {
   static let contextState = Color(.sRGB, red: 240 / 255, green: 228 / 255, blue: 66 / 255, opacity: 1)
   static let runtimeWork = Color(.sRGB, red: 167 / 255, green: 139 / 255, blue: 250 / 255, opacity: 1)
   static let available = Color.secondary.opacity(0.18)
-  /// Recoverable expert entitlement — Okabe-Ito bluish green, unused in occupancy.
-  static let recoverableExperts = Color(
+  /// Unused expert budget — Okabe-Ito bluish green, not occupancy.
+  static let unusedBudget = Color(
     .sRGB, red: 0 / 255, green: 158 / 255, blue: 115 / 255, opacity: 1)
   /// Context-growth reserve — Okabe-Ito reddish purple, distinct from live context yellow.
   static let reservedContextGrowth = Color(
@@ -29,7 +29,7 @@ enum MlxMemoryLegendItem: Equatable {
   case contextState
   case runtimeWork
   case available
-  case recoverableExperts
+  case unusedBudget
   case reservedContextGrowth
   case reservedActivations
   case reservedModelCoreSlack
@@ -44,7 +44,7 @@ enum MlxMemoryLegendItem: Equatable {
     case .contextState: return "Live context state"
     case .runtimeWork: return "Runtime work"
     case .available: return "Nominal MLX headroom"
-    case .recoverableExperts: return "Recoverable experts"
+    case .unusedBudget: return "Unused"
     case .reservedContextGrowth: return "Held for context"
     case .reservedActivations: return "Held for activations"
     case .reservedModelCoreSlack: return "Core slack"
@@ -67,8 +67,8 @@ enum MlxMemoryLegendItem: Equatable {
       return "Temporary computation work and other active MLX memory not attributed above."
     case .available:
       return "Calculated capacity below this Mac's MLX ceiling. It is not free RAM; macOS memory pressure and temporary work can reduce what is safely usable."
-    case .recoverableExperts:
-      return "Expert budget the ceiling already granted that warming has not filled. This is the only unused slice a residency change can still spend."
+    case .unusedBudget:
+      return "Unused budget the ceiling already granted for expert weights that are not in RAM. Distinct from Experts, which are weights already resident."
     case .reservedContextGrowth:
       return "Held so conversation state can grow. Spending it on expert weights invites eviction mid-request."
     case .reservedActivations:
@@ -126,8 +126,8 @@ struct MlxMemoryBreakdownBar: View {
           )
           if headroomSplit.enginePublishedTheSplit {
             memorySegment(
-              MlxMemoryPalette.recoverableExperts,
-              headroomSplit.recoverableExpertBudgetByteCount,
+              MlxMemoryPalette.unusedBudget,
+              headroomSplit.unusedBudgetByteCount,
               geometry.size.width
             )
             memorySegment(
@@ -173,9 +173,9 @@ struct MlxMemoryBreakdownBar: View {
       memoryLegendRow(.contextState, MlxMemoryPalette.contextState, breakdown.contextStatePayloadByteCount)
       if headroomSplit.enginePublishedTheSplit {
         memoryLegendRow(
-          .recoverableExperts,
-          MlxMemoryPalette.recoverableExperts,
-          headroomSplit.recoverableExpertBudgetByteCount
+          .unusedBudget,
+          MlxMemoryPalette.unusedBudget,
+          headroomSplit.unusedBudgetByteCount
         )
         memoryLegendRow(
           .reservedContextGrowth,

--- a/apps/astronomical-menu/Sources/AstronomicalMenuCore/MlxMemoryBreakdownBar.swift
+++ b/apps/astronomical-menu/Sources/AstronomicalMenuCore/MlxMemoryBreakdownBar.swift
@@ -8,9 +8,8 @@ enum MlxMemoryPalette {
   static let contextState = Color(.sRGB, red: 240 / 255, green: 228 / 255, blue: 66 / 255, opacity: 1)
   static let runtimeWork = Color(.sRGB, red: 167 / 255, green: 139 / 255, blue: 250 / 255, opacity: 1)
   static let available = Color.secondary.opacity(0.18)
-  /// Unused expert budget — Okabe-Ito bluish green, not occupancy.
-  static let unusedBudget = Color(
-    .sRGB, red: 0 / 255, green: 158 / 255, blue: 115 / 255, opacity: 1)
+  /// Unused budget — same grey capsule as the empty Cache efficacy track.
+  static let unusedBudget = Color.secondary.opacity(0.18)
   /// Context-growth reserve — Okabe-Ito reddish purple, distinct from live context yellow.
   static let reservedContextGrowth = Color(
     .sRGB, red: 204 / 255, green: 121 / 255, blue: 167 / 255, opacity: 1)

--- a/apps/astronomical-menu/Sources/AstronomicalMenuCore/MlxMemoryBreakdownBar.swift
+++ b/apps/astronomical-menu/Sources/AstronomicalMenuCore/MlxMemoryBreakdownBar.swift
@@ -125,11 +125,6 @@ struct MlxMemoryBreakdownBar: View {
           )
           if headroomSplit.enginePublishedTheSplit {
             memorySegment(
-              MlxMemoryPalette.unusedBudget,
-              headroomSplit.unusedBudgetByteCount,
-              geometry.size.width
-            )
-            memorySegment(
               MlxMemoryPalette.reservedContextGrowth,
               headroomSplit.reservedContextGrowthByteCount,
               geometry.size.width
@@ -150,8 +145,8 @@ struct MlxMemoryBreakdownBar: View {
               geometry.size.width
             )
             memorySegment(
-              MlxMemoryPalette.available,
-              headroomSplit.remainderByteCount,
+              MlxMemoryPalette.unusedBudget,
+              headroomSplit.unusedBudgetByteCount + headroomSplit.remainderByteCount,
               geometry.size.width
             )
           } else {
@@ -171,11 +166,6 @@ struct MlxMemoryBreakdownBar: View {
       memoryLegendRow(.runtimeWork, MlxMemoryPalette.runtimeWork, breakdown.runtimeWorkByteCount)
       memoryLegendRow(.contextState, MlxMemoryPalette.contextState, breakdown.contextStatePayloadByteCount)
       if headroomSplit.enginePublishedTheSplit {
-        memoryLegendRow(
-          .unusedBudget,
-          MlxMemoryPalette.unusedBudget,
-          headroomSplit.unusedBudgetByteCount
-        )
         memoryLegendRow(
           .reservedContextGrowth,
           MlxMemoryPalette.reservedContextGrowth,
@@ -200,6 +190,11 @@ struct MlxMemoryBreakdownBar: View {
             headroomSplit.unexplainedHeadroomByteCount
           )
         }
+        memoryLegendRow(
+          .unusedBudget,
+          MlxMemoryPalette.unusedBudget,
+          headroomSplit.unusedBudgetByteCount
+        )
         if headroomSplit.ownerOverrunByteCount > 0 {
           memoryLegendRow(
             .ownerOverrun,

--- a/apps/astronomical-menu/Sources/AstronomicalMenuCore/MlxMemoryBreakdownBar.swift
+++ b/apps/astronomical-menu/Sources/AstronomicalMenuCore/MlxMemoryBreakdownBar.swift
@@ -1,0 +1,284 @@
+import AppKit
+import SwiftUI
+
+enum MlxMemoryPalette {
+  static let experts = Color(.sRGB, red: 10 / 255, green: 132 / 255, blue: 255 / 255, opacity: 1)
+  static let modelCore = Color(.sRGB, red: 86 / 255, green: 180 / 255, blue: 233 / 255, opacity: 1)
+  static let drafter = Color(.sRGB, red: 230 / 255, green: 159 / 255, blue: 0, opacity: 1)
+  static let contextState = Color(.sRGB, red: 240 / 255, green: 228 / 255, blue: 66 / 255, opacity: 1)
+  static let runtimeWork = Color(.sRGB, red: 167 / 255, green: 139 / 255, blue: 250 / 255, opacity: 1)
+  static let available = Color.secondary.opacity(0.18)
+  /// Recoverable expert entitlement — Okabe-Ito bluish green, unused in occupancy.
+  static let recoverableExperts = Color(
+    .sRGB, red: 0 / 255, green: 158 / 255, blue: 115 / 255, opacity: 1)
+  /// Context-growth reserve — Okabe-Ito reddish purple, distinct from live context yellow.
+  static let reservedContextGrowth = Color(
+    .sRGB, red: 204 / 255, green: 121 / 255, blue: 167 / 255, opacity: 1)
+  /// Activation and stream-slot reserve — Okabe-Ito vermillion, not the drafter orange.
+  static let reservedActivations = Color(
+    .sRGB, red: 213 / 255, green: 94 / 255, blue: 0 / 255, opacity: 1)
+  static let unexplainedHeadroom = Color.primary.opacity(0.28)
+  static let ownerOverrun = Color.red
+  static let segmentDivider = Color(.sRGB, red: 24 / 255, green: 25 / 255, blue: 25 / 255, opacity: 1)
+}
+
+enum MlxMemoryLegendItem: Equatable {
+  case experts
+  case modelCore
+  case drafter
+  case contextState
+  case runtimeWork
+  case available
+  case recoverableExperts
+  case reservedContextGrowth
+  case reservedActivations
+  case reservedModelCoreSlack
+  case unexplainedHeadroom
+  case ownerOverrun
+
+  var title: String {
+    switch self {
+    case .experts: return "Experts"
+    case .modelCore: return "Model core"
+    case .drafter: return "Drafter"
+    case .contextState: return "Live context state"
+    case .runtimeWork: return "Runtime work"
+    case .available: return "Nominal MLX headroom"
+    case .recoverableExperts: return "Recoverable experts"
+    case .reservedContextGrowth: return "Held for context"
+    case .reservedActivations: return "Held for activations"
+    case .reservedModelCoreSlack: return "Core slack"
+    case .unexplainedHeadroom: return "Unexplained headroom"
+    case .ownerOverrun: return "Owner overrun"
+    }
+  }
+
+  var explanationText: String {
+    switch self {
+    case .experts:
+      return "Sparse MoE weights currently resident in MLX, including loaded expert pages."
+    case .modelCore:
+      return "Always-resident non-expert weights, including embeddings, attention, and vision weights."
+    case .drafter:
+      return "All active MLX memory attributed to live request-scoped drafter scoring, including draft weights, resident draft expert pages, temporary decoder context, visual inputs, scoring tensors, and draft-phase work. It returns to zero after the drafter is released and is separate from the client conversation window."
+    case .contextState:
+      return "Decoder state for the active request, including conversation key-value state. It is released after completion and is separate from the client conversation window."
+    case .runtimeWork:
+      return "Temporary computation work and other active MLX memory not attributed above."
+    case .available:
+      return "Calculated capacity below this Mac's MLX ceiling. It is not free RAM; macOS memory pressure and temporary work can reduce what is safely usable."
+    case .recoverableExperts:
+      return "Expert budget the ceiling already granted that warming has not filled. This is the only unused slice a residency change can still spend."
+    case .reservedContextGrowth:
+      return "Held so conversation state can grow. Spending it on expert weights invites eviction mid-request."
+    case .reservedActivations:
+      return "Held for temporary decode and prefill workspace, including one expert page. It is a promise, not idle RAM."
+    case .reservedModelCoreSlack:
+      return "Model-core reserve the loaded core does not occupy."
+    case .unexplainedHeadroom:
+      return "Unused capacity with no named owner yet. The engine reports this instead of folding it into a reserved bucket."
+    case .ownerOverrun:
+      return "A named owner consumed more than its reserve. This is not unused capacity."
+    }
+  }
+
+  var infoButtonAccessibilityLabel: String { "Explain \(title)" }
+}
+
+struct MlxMemoryBreakdownBar: View {
+  let activeByteCount: UInt64
+  let limitByteCount: UInt64
+  let breakdown: SupervisorStatusDocument.MlxMemoryBreakdown
+  let headroomSplit: MlxHeadroomSplit
+  let sourceTitle: String
+  @State private var selectedMemoryLegendItem: MlxMemoryLegendItem?
+
+  var body: some View {
+    VStack(spacing: 6) {
+      HStack {
+        Text("MLX memory").foregroundStyle(.secondary)
+        Spacer()
+        Text(
+          "\(decimalGigabyteText(byteCount: activeByteCount)) / \(decimalGigabyteText(byteCount: limitByteCount))"
+        ).font(PopoverTypography.monospacedBody)
+      }
+      Text(sourceTitle).font(.caption).foregroundStyle(.secondary)
+      GeometryReader { geometry in
+        HStack(spacing: 0) {
+          memorySegment(MlxMemoryPalette.experts, breakdown.expertPayloadByteCount, geometry.size.width)
+          memorySegment(MlxMemoryPalette.modelCore, breakdown.modelCorePayloadByteCount, geometry.size.width)
+          memorySegment(
+            MlxMemoryPalette.drafter,
+            breakdown.speculativePrefillDraftMemoryByteCount,
+            geometry.size.width
+          )
+          memorySegment(
+            MlxMemoryPalette.runtimeWork,
+            breakdown.runtimeWorkByteCount,
+            geometry.size.width
+          )
+          memorySegment(
+            MlxMemoryPalette.contextState,
+            breakdown.contextStatePayloadByteCount,
+            geometry.size.width,
+            showsTrailingDivider: breakdown.contextStatePayloadByteCount > 0
+              && breakdown.availableByteCount > 0
+          )
+          if headroomSplit.enginePublishedTheSplit {
+            memorySegment(
+              MlxMemoryPalette.recoverableExperts,
+              headroomSplit.recoverableExpertBudgetByteCount,
+              geometry.size.width
+            )
+            memorySegment(
+              MlxMemoryPalette.reservedContextGrowth,
+              headroomSplit.reservedContextGrowthByteCount,
+              geometry.size.width
+            )
+            memorySegment(
+              MlxMemoryPalette.reservedActivations,
+              headroomSplit.reservedActivationByteCount,
+              geometry.size.width
+            )
+            memorySegment(
+              MlxMemoryPalette.modelCore.opacity(0.45),
+              headroomSplit.reservedModelCoreSlackByteCount,
+              geometry.size.width
+            )
+            memorySegment(
+              MlxMemoryPalette.unexplainedHeadroom,
+              headroomSplit.unexplainedHeadroomByteCount,
+              geometry.size.width
+            )
+            memorySegment(
+              MlxMemoryPalette.available,
+              headroomSplit.remainderByteCount,
+              geometry.size.width
+            )
+          } else {
+            memorySegment(MlxMemoryPalette.available, breakdown.availableByteCount, geometry.size.width)
+          }
+        }
+        .clipShape(Capsule())
+      }
+      .frame(height: 7)
+      memoryLegendRow(.experts, MlxMemoryPalette.experts, breakdown.expertPayloadByteCount)
+      memoryLegendRow(.modelCore, MlxMemoryPalette.modelCore, breakdown.modelCorePayloadByteCount)
+      memoryLegendRow(
+        .drafter,
+        MlxMemoryPalette.drafter,
+        breakdown.speculativePrefillDraftMemoryByteCount
+      )
+      memoryLegendRow(.runtimeWork, MlxMemoryPalette.runtimeWork, breakdown.runtimeWorkByteCount)
+      memoryLegendRow(.contextState, MlxMemoryPalette.contextState, breakdown.contextStatePayloadByteCount)
+      if headroomSplit.enginePublishedTheSplit {
+        memoryLegendRow(
+          .recoverableExperts,
+          MlxMemoryPalette.recoverableExperts,
+          headroomSplit.recoverableExpertBudgetByteCount
+        )
+        memoryLegendRow(
+          .reservedContextGrowth,
+          MlxMemoryPalette.reservedContextGrowth,
+          headroomSplit.reservedContextGrowthByteCount
+        )
+        memoryLegendRow(
+          .reservedActivations,
+          MlxMemoryPalette.reservedActivations,
+          headroomSplit.reservedActivationByteCount
+        )
+        if headroomSplit.reservedModelCoreSlackByteCount > 0 {
+          memoryLegendRow(
+            .reservedModelCoreSlack,
+            MlxMemoryPalette.modelCore.opacity(0.45),
+            headroomSplit.reservedModelCoreSlackByteCount
+          )
+        }
+        if headroomSplit.unexplainedHeadroomByteCount > 0 {
+          memoryLegendRow(
+            .unexplainedHeadroom,
+            MlxMemoryPalette.unexplainedHeadroom,
+            headroomSplit.unexplainedHeadroomByteCount
+          )
+        }
+        if headroomSplit.ownerOverrunByteCount > 0 {
+          memoryLegendRow(
+            .ownerOverrun,
+            MlxMemoryPalette.ownerOverrun,
+            headroomSplit.ownerOverrunByteCount
+          )
+        }
+      } else {
+        memoryLegendRow(.available, MlxMemoryPalette.available, breakdown.availableByteCount)
+      }
+    }
+    .accessibilityElement(children: .combine)
+    .accessibilityLabel(accessibilitySummary)
+  }
+
+  private var accessibilitySummary: String {
+    if headroomSplit.enginePublishedTheSplit {
+      return "MLX memory, \(sourceTitle). Occupied ownership plus named unused-capacity owners from the engine budget."
+    }
+    return "MLX memory, \(sourceTitle). Latest worker observation; colors are reconciled ownership estimates."
+  }
+
+  private func memorySegment(
+    _ color: Color,
+    _ byteCount: UInt64,
+    _ width: CGFloat,
+    showsTrailingDivider: Bool = false
+  ) -> some View {
+    color
+      .frame(width: width * memoryBreakdownFraction(byteCount, limitByteCount))
+      .overlay(alignment: .trailing) {
+        if showsTrailingDivider {
+          MlxMemoryPalette.segmentDivider.frame(width: 1)
+        }
+      }
+  }
+
+  private func memoryLegendRow(
+    _ legendItem: MlxMemoryLegendItem,
+    _ color: Color,
+    _ byteCount: UInt64
+  ) -> some View {
+    HStack {
+      RoundedRectangle(cornerRadius: 3).fill(color).frame(width: 10, height: 10)
+      Text(legendItem.title).foregroundStyle(.secondary)
+      Button {
+        selectedMemoryLegendItem = legendItem
+      } label: {
+        Image(systemName: "info.circle")
+      }
+      .buttonStyle(.plain)
+      .foregroundStyle(.secondary)
+      .accessibilityLabel(legendItem.infoButtonAccessibilityLabel)
+      .popover(isPresented: memoryLegendPopoverIsPresented(for: legendItem)) {
+        Text(legendItem.explanationText)
+          .frame(width: 260, alignment: .leading)
+          .padding(12)
+      }
+      Spacer()
+      Text(decimalGigabyteValueText(byteCount: byteCount)).font(PopoverTypography.monospacedBody)
+    }
+  }
+
+  private func memoryLegendPopoverIsPresented(for legendItem: MlxMemoryLegendItem) -> Binding<Bool> {
+    Binding(
+      get: { selectedMemoryLegendItem == legendItem },
+      set: { shouldPresentPopover in
+        if shouldPresentPopover {
+          selectedMemoryLegendItem = legendItem
+        } else if selectedMemoryLegendItem == legendItem {
+          selectedMemoryLegendItem = nil
+        }
+      }
+    )
+  }
+}
+
+func memoryBreakdownFraction(_ byteCount: UInt64, _ limitByteCount: UInt64) -> Double {
+  guard limitByteCount > 0 else { return 0 }
+  return min(1, Double(byteCount) / Double(limitByteCount))
+}

--- a/apps/astronomical-menu/Sources/AstronomicalMenuCore/MlxMemoryCeilingUtilization.swift
+++ b/apps/astronomical-menu/Sources/AstronomicalMenuCore/MlxMemoryCeilingUtilization.swift
@@ -35,7 +35,7 @@ struct MlxMemoryCeilingUtilization: Codable, Equatable {
 /// unchanged. Integer scaling keeps the colored segments summing to
 /// `availableByteCount` instead of drifting from the occupancy bar.
 struct MlxHeadroomSplit: Equatable {
-  let recoverableExpertBudgetByteCount: UInt64
+  let unusedBudgetByteCount: UInt64
   let reservedContextGrowthByteCount: UInt64
   let reservedActivationByteCount: UInt64
   let reservedModelCoreSlackByteCount: UInt64
@@ -46,7 +46,7 @@ struct MlxHeadroomSplit: Equatable {
 
   static func undifferentiated(availableByteCount: UInt64) -> MlxHeadroomSplit {
     MlxHeadroomSplit(
-      recoverableExpertBudgetByteCount: 0,
+      unusedBudgetByteCount: 0,
       reservedContextGrowthByteCount: 0,
       reservedActivationByteCount: 0,
       reservedModelCoreSlackByteCount: 0,
@@ -74,7 +74,7 @@ struct MlxHeadroomSplit: Equatable {
     let allocated = allocateProportions(weights, onto: availableByteCount)
     let allocatedSum = allocated.reduce(0, +)
     return MlxHeadroomSplit(
-      recoverableExpertBudgetByteCount: allocated[0],
+      unusedBudgetByteCount: allocated[0],
       reservedContextGrowthByteCount: allocated[1],
       reservedActivationByteCount: allocated[2],
       reservedModelCoreSlackByteCount: allocated[3],
@@ -86,7 +86,7 @@ struct MlxHeadroomSplit: Equatable {
   }
 
   var paintedByteCount: UInt64 {
-    recoverableExpertBudgetByteCount
+    unusedBudgetByteCount
       + reservedContextGrowthByteCount
       + reservedActivationByteCount
       + reservedModelCoreSlackByteCount

--- a/apps/astronomical-menu/Sources/AstronomicalMenuCore/MlxMemoryCeilingUtilization.swift
+++ b/apps/astronomical-menu/Sources/AstronomicalMenuCore/MlxMemoryCeilingUtilization.swift
@@ -1,0 +1,118 @@
+import Foundation
+
+/// Engine-published split of unused MLX headroom (issue #509).
+///
+/// The worker composes this from the same RAM-budget owner that admits
+/// forwards, so the menu must not invent a second arithmetic. Missing on
+/// older snapshots; the popover then keeps a single undifferentiated
+/// headroom row.
+struct MlxMemoryCeilingUtilization: Codable, Equatable {
+  let unusedHeadroomBytes: UInt64
+  let reservedModelCoreSlackBytes: UInt64
+  let reservedContextGrowthBytes: UInt64
+  let reservedActivationAndWorkspaceBytes: UInt64
+  let unseatedExpertEntitlementBytes: UInt64
+  let speculativeDraftPayloadBytes: UInt64
+  let unexplainedHeadroomBytes: UInt64
+  let ownerOverrunBytes: UInt64
+
+  enum CodingKeys: String, CodingKey {
+    case unusedHeadroomBytes = "unused_headroom_bytes"
+    case reservedModelCoreSlackBytes = "reserved_model_core_slack_bytes"
+    case reservedContextGrowthBytes = "reserved_context_growth_bytes"
+    case reservedActivationAndWorkspaceBytes = "reserved_activation_and_workspace_bytes"
+    case unseatedExpertEntitlementBytes = "unseated_expert_entitlement_bytes"
+    case speculativeDraftPayloadBytes = "speculative_draft_payload_bytes"
+    case unexplainedHeadroomBytes = "unexplained_headroom_bytes"
+    case ownerOverrunBytes = "owner_overrun_bytes"
+  }
+}
+
+/// Headroom owners scaled onto the popover's remaining-capacity width.
+///
+/// Occupied MLX bytes stay in the existing ownership bar. This split only
+/// paints the unused remainder, so the headline active/ceiling number is
+/// unchanged. Integer scaling keeps the colored segments summing to
+/// `availableByteCount` instead of drifting from the occupancy bar.
+struct MlxHeadroomSplit: Equatable {
+  let recoverableExpertBudgetByteCount: UInt64
+  let reservedContextGrowthByteCount: UInt64
+  let reservedActivationByteCount: UInt64
+  let reservedModelCoreSlackByteCount: UInt64
+  let unexplainedHeadroomByteCount: UInt64
+  let remainderByteCount: UInt64
+  let ownerOverrunByteCount: UInt64
+  let enginePublishedTheSplit: Bool
+
+  static func undifferentiated(availableByteCount: UInt64) -> MlxHeadroomSplit {
+    MlxHeadroomSplit(
+      recoverableExpertBudgetByteCount: 0,
+      reservedContextGrowthByteCount: 0,
+      reservedActivationByteCount: 0,
+      reservedModelCoreSlackByteCount: 0,
+      unexplainedHeadroomByteCount: 0,
+      remainderByteCount: availableByteCount,
+      ownerOverrunByteCount: 0,
+      enginePublishedTheSplit: false
+    )
+  }
+
+  static func from(
+    utilization: MlxMemoryCeilingUtilization?,
+    availableByteCount: UInt64
+  ) -> MlxHeadroomSplit {
+    guard let utilization else {
+      return .undifferentiated(availableByteCount: availableByteCount)
+    }
+    let weights = [
+      utilization.unseatedExpertEntitlementBytes,
+      utilization.reservedContextGrowthBytes,
+      utilization.reservedActivationAndWorkspaceBytes,
+      utilization.reservedModelCoreSlackBytes,
+      utilization.unexplainedHeadroomBytes,
+    ]
+    let allocated = allocateProportions(weights, onto: availableByteCount)
+    let allocatedSum = allocated.reduce(0, +)
+    return MlxHeadroomSplit(
+      recoverableExpertBudgetByteCount: allocated[0],
+      reservedContextGrowthByteCount: allocated[1],
+      reservedActivationByteCount: allocated[2],
+      reservedModelCoreSlackByteCount: allocated[3],
+      unexplainedHeadroomByteCount: allocated[4],
+      remainderByteCount: availableByteCount.saturatingSubtracting(allocatedSum),
+      ownerOverrunByteCount: utilization.ownerOverrunBytes,
+      enginePublishedTheSplit: true
+    )
+  }
+
+  var paintedByteCount: UInt64 {
+    recoverableExpertBudgetByteCount
+      + reservedContextGrowthByteCount
+      + reservedActivationByteCount
+      + reservedModelCoreSlackByteCount
+      + unexplainedHeadroomByteCount
+      + remainderByteCount
+  }
+}
+
+/// Distributes `total` across `weights` with integer proportions.
+///
+/// Remainder bytes go to the last positive weight so the painted bar never
+/// undershoots the unused-capacity width by rounding.
+func allocateProportions(_ weights: [UInt64], onto total: UInt64) -> [UInt64] {
+  let weightSum = weights.reduce(0, +)
+  guard weightSum > 0, total > 0 else {
+    return Array(repeating: 0, count: weights.count)
+  }
+  var allocated = weights.map { weight in
+    UInt64((Double(weight) / Double(weightSum)) * Double(total))
+  }
+  let allocatedSum = allocated.reduce(0, +)
+  let roundingRemainder = total.saturatingSubtracting(allocatedSum)
+  if roundingRemainder > 0, let lastPositiveIndex = allocated.lastIndex(where: { $0 > 0 }) {
+    allocated[lastPositiveIndex] += roundingRemainder
+  } else if roundingRemainder > 0, !allocated.isEmpty {
+    allocated[allocated.count - 1] += roundingRemainder
+  }
+  return allocated
+}

--- a/apps/astronomical-menu/Sources/AstronomicalMenuCore/OrbitalTelemetryPopover.swift
+++ b/apps/astronomical-menu/Sources/AstronomicalMenuCore/OrbitalTelemetryPopover.swift
@@ -1,7 +1,7 @@
 import AppKit
 import SwiftUI
 
-private enum PopoverTypography {
+enum PopoverTypography {
   static let bodyPointSize = NSFont.preferredFont(forTextStyle: .body).pointSize + 1
   static let captionPointSize = NSFont.preferredFont(forTextStyle: .caption1).pointSize + 1
   static let headlinePointSize = NSFont.preferredFont(forTextStyle: .headline).pointSize + 1
@@ -11,55 +11,6 @@ private enum PopoverTypography {
   static let boldCaption = Font.system(size: captionPointSize, weight: .bold)
   static let semiboldCaption = Font.system(size: captionPointSize, weight: .semibold)
   static let headline = Font.system(size: headlinePointSize, weight: .semibold)
-}
-
-enum MlxMemoryPalette {
-  static let experts = Color(.sRGB, red: 10 / 255, green: 132 / 255, blue: 255 / 255, opacity: 1)
-  static let modelCore = Color(.sRGB, red: 86 / 255, green: 180 / 255, blue: 233 / 255, opacity: 1)
-  static let drafter = Color(.sRGB, red: 230 / 255, green: 159 / 255, blue: 0, opacity: 1)
-  static let contextState = Color(.sRGB, red: 240 / 255, green: 228 / 255, blue: 66 / 255, opacity: 1)
-  static let runtimeWork = Color(.sRGB, red: 167 / 255, green: 139 / 255, blue: 250 / 255, opacity: 1)
-  static let available = Color.secondary.opacity(0.18)
-  static let segmentDivider = Color(.sRGB, red: 24 / 255, green: 25 / 255, blue: 25 / 255, opacity: 1)
-}
-
-enum MlxMemoryLegendItem: Equatable {
-  case experts
-  case modelCore
-  case drafter
-  case contextState
-  case runtimeWork
-  case available
-
-  var title: String {
-    switch self {
-    case .experts: return "Experts"
-    case .modelCore: return "Model core"
-    case .drafter: return "Drafter"
-    case .contextState: return "Live context state"
-    case .runtimeWork: return "Runtime work"
-    case .available: return "Nominal MLX headroom"
-    }
-  }
-
-  var explanationText: String {
-    switch self {
-    case .experts:
-      return "Sparse MoE weights currently resident in MLX, including loaded expert pages."
-    case .modelCore:
-      return "Always-resident non-expert weights, including embeddings, attention, and vision weights."
-    case .drafter:
-      return "All active MLX memory attributed to live request-scoped drafter scoring, including draft weights, resident draft expert pages, temporary decoder context, visual inputs, scoring tensors, and draft-phase work. It returns to zero after the drafter is released and is separate from the client conversation window."
-    case .contextState:
-      return "Decoder state for the active request, including conversation key-value state. It is released after completion and is separate from the client conversation window."
-    case .runtimeWork:
-      return "Temporary computation work and other active MLX memory not attributed above."
-    case .available:
-      return "Calculated capacity below this Mac's MLX ceiling. It is not free RAM; macOS memory pressure and temporary work can reduce what is safely usable."
-    }
-  }
-
-  var infoButtonAccessibilityLabel: String { "Explain \(title)" }
 }
 
 struct OrbitalTelemetryPopover: View {
@@ -155,6 +106,7 @@ struct OrbitalTelemetryPopover: View {
         activeByteCount: statusDocument.mlxMemoryActiveBytes,
         limitByteCount: statusDocument.mlxMemoryCeilingBytes,
         breakdown: statusDocument.mlxMemoryBreakdown,
+        headroomSplit: statusDocument.mlxHeadroomSplit,
         sourceTitle: statusDocument.mlxMemorySourceTitle
       )
       maximumMlxMemoryControl(statusDocument)
@@ -293,125 +245,6 @@ func orbitalTelemetryBackgroundColor(colorScheme: ColorScheme) -> Color {
     return Color(.sRGB, red: 24 / 255, green: 25 / 255, blue: 25 / 255, opacity: 1)
   }
   return Color(nsColor: .windowBackgroundColor)
-}
-
-struct MlxMemoryBreakdownBar: View {
-  let activeByteCount: UInt64
-  let limitByteCount: UInt64
-  let breakdown: SupervisorStatusDocument.MlxMemoryBreakdown
-  let sourceTitle: String
-  @State private var selectedMemoryLegendItem: MlxMemoryLegendItem?
-
-  var body: some View {
-    VStack(spacing: 6) {
-      HStack {
-        Text("MLX memory").foregroundStyle(.secondary)
-        Spacer()
-        Text(
-          "\(decimalGigabyteText(byteCount: activeByteCount)) / \(decimalGigabyteText(byteCount: limitByteCount))"
-        ).font(PopoverTypography.monospacedBody)
-      }
-      Text(sourceTitle).font(.caption).foregroundStyle(.secondary)
-      GeometryReader { geometry in
-        HStack(spacing: 0) {
-          memorySegment(MlxMemoryPalette.experts, breakdown.expertPayloadByteCount, geometry.size.width)
-          memorySegment(MlxMemoryPalette.modelCore, breakdown.modelCorePayloadByteCount, geometry.size.width)
-          memorySegment(
-            MlxMemoryPalette.drafter,
-            breakdown.speculativePrefillDraftMemoryByteCount,
-            geometry.size.width
-          )
-          memorySegment(
-            MlxMemoryPalette.runtimeWork,
-            breakdown.runtimeWorkByteCount,
-            geometry.size.width
-          )
-          memorySegment(
-            MlxMemoryPalette.contextState,
-            breakdown.contextStatePayloadByteCount,
-            geometry.size.width,
-            showsTrailingDivider: breakdown.contextStatePayloadByteCount > 0 && breakdown.availableByteCount > 0
-          )
-          memorySegment(MlxMemoryPalette.available, breakdown.availableByteCount, geometry.size.width)
-        }
-        .clipShape(Capsule())
-      }
-      .frame(height: 7)
-      memoryLegendRow(.experts, MlxMemoryPalette.experts, breakdown.expertPayloadByteCount)
-      memoryLegendRow(.modelCore, MlxMemoryPalette.modelCore, breakdown.modelCorePayloadByteCount)
-      memoryLegendRow(
-        .drafter,
-        MlxMemoryPalette.drafter,
-        breakdown.speculativePrefillDraftMemoryByteCount
-      )
-      memoryLegendRow(.runtimeWork, MlxMemoryPalette.runtimeWork, breakdown.runtimeWorkByteCount)
-      memoryLegendRow(.contextState, MlxMemoryPalette.contextState, breakdown.contextStatePayloadByteCount)
-      memoryLegendRow(.available, MlxMemoryPalette.available, breakdown.availableByteCount)
-    }
-    .accessibilityElement(children: .combine)
-    .accessibilityLabel(
-      "MLX memory, \(sourceTitle). Latest worker observation; colors are reconciled ownership estimates."
-    )
-  }
-
-  private func memorySegment(
-    _ color: Color,
-    _ byteCount: UInt64,
-    _ width: CGFloat,
-    showsTrailingDivider: Bool = false
-  ) -> some View {
-    color
-      .frame(width: width * memoryBreakdownFraction(byteCount, limitByteCount))
-      .overlay(alignment: .trailing) {
-        if showsTrailingDivider {
-          MlxMemoryPalette.segmentDivider.frame(width: 1)
-        }
-      }
-  }
-
-  private func memoryLegendRow(
-    _ legendItem: MlxMemoryLegendItem,
-    _ color: Color,
-    _ byteCount: UInt64
-  ) -> some View {
-    HStack {
-      RoundedRectangle(cornerRadius: 3).fill(color).frame(width: 10, height: 10)
-      Text(legendItem.title).foregroundStyle(.secondary)
-      Button {
-        selectedMemoryLegendItem = legendItem
-      } label: {
-        Image(systemName: "info.circle")
-      }
-      .buttonStyle(.plain)
-      .foregroundStyle(.secondary)
-      .accessibilityLabel(legendItem.infoButtonAccessibilityLabel)
-      .popover(isPresented: memoryLegendPopoverIsPresented(for: legendItem)) {
-        Text(legendItem.explanationText)
-          .frame(width: 260, alignment: .leading)
-          .padding(12)
-      }
-      Spacer()
-      Text(decimalGigabyteValueText(byteCount: byteCount)).font(PopoverTypography.monospacedBody)
-    }
-  }
-
-  private func memoryLegendPopoverIsPresented(for legendItem: MlxMemoryLegendItem) -> Binding<Bool> {
-    Binding(
-      get: { selectedMemoryLegendItem == legendItem },
-      set: { shouldPresentPopover in
-        if shouldPresentPopover {
-          selectedMemoryLegendItem = legendItem
-        } else if selectedMemoryLegendItem == legendItem {
-          selectedMemoryLegendItem = nil
-        }
-      }
-    )
-  }
-}
-
-func memoryBreakdownFraction(_ byteCount: UInt64, _ limitByteCount: UInt64) -> Double {
-  guard limitByteCount > 0 else { return 0 }
-  return min(1, Double(byteCount) / Double(limitByteCount))
 }
 
 struct GPUUtilizationBar: View {

--- a/apps/astronomical-menu/Sources/AstronomicalMenuCore/SupervisorStatusDocument.swift
+++ b/apps/astronomical-menu/Sources/AstronomicalMenuCore/SupervisorStatusDocument.swift
@@ -41,6 +41,7 @@ struct SupervisorStatusDocument: Codable, Equatable {
     let modelCorePayloadBytes: UInt64
     let contextStatePayloadBytes: UInt64
     let speculativePrefillDraftMemoryBytes: UInt64
+    let memoryCeilingUtilization: MlxMemoryCeilingUtilization?
 
     enum CodingKeys: String, CodingKey {
       case source
@@ -51,6 +52,7 @@ struct SupervisorStatusDocument: Codable, Equatable {
       case modelCorePayloadBytes = "model_core_payload_bytes"
       case contextStatePayloadBytes = "context_state_payload_bytes"
       case speculativePrefillDraftMemoryBytes = "speculative_prefill_draft_memory_bytes"
+      case memoryCeilingUtilization = "memory_ceiling_utilization"
     }
 
     init(from decoder: Decoder) throws {
@@ -66,6 +68,9 @@ struct SupervisorStatusDocument: Codable, Equatable {
         try container.decode(UInt64.self, forKey: .contextStatePayloadBytes)
       speculativePrefillDraftMemoryBytes =
         try container.decodeIfPresent(UInt64.self, forKey: .speculativePrefillDraftMemoryBytes) ?? 0
+      memoryCeilingUtilization =
+        try container.decodeIfPresent(
+          MlxMemoryCeilingUtilization.self, forKey: .memoryCeilingUtilization)
     }
   }
   struct ServingSession: Codable, Equatable {
@@ -375,6 +380,12 @@ struct SupervisorStatusDocument: Codable, Equatable {
         mlxMemoryActiveBytes)
     )
   }
+  var mlxHeadroomSplit: MlxHeadroomSplit {
+    MlxHeadroomSplit.from(
+      utilization: mlxMemorySnapshot?.memoryCeilingUtilization,
+      availableByteCount: mlxMemoryBreakdown.availableByteCount
+    )
+  }
   var sessionTitle: String {
     let requestCount = servingSession.completedRequestCount
     return
@@ -430,7 +441,7 @@ extension UInt64 {
     return didOverflow ? UInt64.max : summedTokenCount
   }
 
-  fileprivate func saturatingSubtracting(_ byteCount: UInt64) -> UInt64 {
+  func saturatingSubtracting(_ byteCount: UInt64) -> UInt64 {
     self >= byteCount ? self - byteCount : 0
   }
 }

--- a/apps/astronomical-menu/tests/AstronomicalMenuContractTests/MlxHeadroomSplitTests.swift
+++ b/apps/astronomical-menu/tests/AstronomicalMenuContractTests/MlxHeadroomSplitTests.swift
@@ -1,0 +1,84 @@
+import XCTest
+
+@testable import AstronomicalMenuCore
+
+final class MlxHeadroomSplitTests: XCTestCase {
+  func test_should_keep_undifferentiated_headroom_when_the_engine_omits_the_split() {
+    let headroomSplit = MlxHeadroomSplit.from(utilization: nil, availableByteCount: 5_400_000_000)
+
+    XCTAssertFalse(headroomSplit.enginePublishedTheSplit)
+    XCTAssertEqual(headroomSplit.remainderByteCount, 5_400_000_000)
+    XCTAssertEqual(headroomSplit.recoverableExpertBudgetByteCount, 0)
+    XCTAssertEqual(headroomSplit.paintedByteCount, 5_400_000_000)
+  }
+
+  func test_should_scale_named_owners_onto_the_unused_capacity_width() {
+    let utilization = MlxMemoryCeilingUtilization(
+      unusedHeadroomBytes: 4_970_000_000,
+      reservedModelCoreSlackBytes: 670_000_000,
+      reservedContextGrowthBytes: 1_300_000_000,
+      reservedActivationAndWorkspaceBytes: 30_000_000,
+      unseatedExpertEntitlementBytes: 2_970_000_000,
+      speculativeDraftPayloadBytes: 0,
+      unexplainedHeadroomBytes: 0,
+      ownerOverrunBytes: 0
+    )
+    let availableByteCount: UInt64 = 4_970_000_000
+    let headroomSplit = MlxHeadroomSplit.from(
+      utilization: utilization, availableByteCount: availableByteCount)
+
+    XCTAssertTrue(headroomSplit.enginePublishedTheSplit)
+    XCTAssertEqual(headroomSplit.paintedByteCount, availableByteCount)
+    XCTAssertEqual(
+      headroomSplit.recoverableExpertBudgetByteCount
+        + headroomSplit.reservedContextGrowthByteCount
+        + headroomSplit.reservedActivationByteCount
+        + headroomSplit.reservedModelCoreSlackByteCount
+        + headroomSplit.unexplainedHeadroomByteCount
+        + headroomSplit.remainderByteCount,
+      availableByteCount
+    )
+    XCTAssertGreaterThan(headroomSplit.recoverableExpertBudgetByteCount, 0)
+    XCTAssertGreaterThan(headroomSplit.reservedContextGrowthByteCount, 0)
+    XCTAssertEqual(headroomSplit.ownerOverrunByteCount, 0)
+  }
+
+  func test_should_decode_engine_utilization_from_the_status_snapshot() throws {
+    let statusDocument = try JSONDecoder().decode(
+      SupervisorStatusDocument.self,
+      from: Data(
+        """
+        {"status":"ready","activity":"generating","mlx_memory_ceiling_bytes":23000000000,"mlx_memory_snapshot":{"source":"decode_submitted","active_memory_bytes":18030000000,"allocator_cache_memory_bytes":0,"peak_memory_bytes":19570000000,"expert_payload_bytes":14950000000,"model_core_payload_bytes":2600000000,"context_state_payload_bytes":1120000000,"speculative_prefill_draft_memory_bytes":0,"memory_ceiling_utilization":{"unused_headroom_bytes":4970000000,"reserved_model_core_slack_bytes":670000000,"reserved_context_growth_bytes":1300000000,"reserved_activation_and_workspace_bytes":30000000,"unseated_expert_entitlement_bytes":2970000000,"speculative_draft_payload_bytes":0,"unexplained_headroom_bytes":0,"owner_overrun_bytes":0}}}
+        """.utf8)
+    )
+
+    let utilization = try XCTUnwrap(statusDocument.mlxMemorySnapshot?.memoryCeilingUtilization)
+    XCTAssertEqual(utilization.unseatedExpertEntitlementBytes, 2_970_000_000)
+    XCTAssertEqual(statusDocument.mlxHeadroomSplit.enginePublishedTheSplit, true)
+    XCTAssertEqual(
+      statusDocument.mlxHeadroomSplit.paintedByteCount,
+      statusDocument.mlxMemoryBreakdown.availableByteCount
+    )
+  }
+
+  func test_should_keep_legacy_snapshots_on_the_single_headroom_row() throws {
+    let statusDocument = try JSONDecoder().decode(
+      SupervisorStatusDocument.self,
+      from: Data(
+        """
+        {"status":"ready","activity":"idle","mlx_memory_ceiling_bytes":23000000000,"mlx_memory_snapshot":{"source":"idle_poll","active_memory_bytes":17600000000,"allocator_cache_memory_bytes":0,"peak_memory_bytes":19480000000,"expert_payload_bytes":15000000000,"model_core_payload_bytes":2600000000,"context_state_payload_bytes":0}}
+        """.utf8)
+    )
+
+    XCTAssertNil(statusDocument.mlxMemorySnapshot?.memoryCeilingUtilization)
+    XCTAssertFalse(statusDocument.mlxHeadroomSplit.enginePublishedTheSplit)
+    XCTAssertEqual(statusDocument.mlxHeadroomSplit.remainderByteCount, 5_400_000_000)
+  }
+
+  func test_should_give_rounding_remainder_to_a_positive_owner() {
+    let allocated = allocateProportions([2, 1], onto: 10)
+    XCTAssertEqual(allocated.reduce(0, +), 10)
+    XCTAssertEqual(allocated[0], 6)
+    XCTAssertEqual(allocated[1], 4)
+  }
+}

--- a/apps/astronomical-menu/tests/AstronomicalMenuContractTests/MlxHeadroomSplitTests.swift
+++ b/apps/astronomical-menu/tests/AstronomicalMenuContractTests/MlxHeadroomSplitTests.swift
@@ -8,7 +8,7 @@ final class MlxHeadroomSplitTests: XCTestCase {
 
     XCTAssertFalse(headroomSplit.enginePublishedTheSplit)
     XCTAssertEqual(headroomSplit.remainderByteCount, 5_400_000_000)
-    XCTAssertEqual(headroomSplit.recoverableExpertBudgetByteCount, 0)
+    XCTAssertEqual(headroomSplit.unusedBudgetByteCount, 0)
     XCTAssertEqual(headroomSplit.paintedByteCount, 5_400_000_000)
   }
 
@@ -30,7 +30,7 @@ final class MlxHeadroomSplitTests: XCTestCase {
     XCTAssertTrue(headroomSplit.enginePublishedTheSplit)
     XCTAssertEqual(headroomSplit.paintedByteCount, availableByteCount)
     XCTAssertEqual(
-      headroomSplit.recoverableExpertBudgetByteCount
+      headroomSplit.unusedBudgetByteCount
         + headroomSplit.reservedContextGrowthByteCount
         + headroomSplit.reservedActivationByteCount
         + headroomSplit.reservedModelCoreSlackByteCount
@@ -38,7 +38,7 @@ final class MlxHeadroomSplitTests: XCTestCase {
         + headroomSplit.remainderByteCount,
       availableByteCount
     )
-    XCTAssertGreaterThan(headroomSplit.recoverableExpertBudgetByteCount, 0)
+    XCTAssertGreaterThan(headroomSplit.unusedBudgetByteCount, 0)
     XCTAssertGreaterThan(headroomSplit.reservedContextGrowthByteCount, 0)
     XCTAssertEqual(headroomSplit.ownerOverrunByteCount, 0)
   }

--- a/apps/astronomical-menu/tests/AstronomicalMenuContractTests/StatusPresentationContractTests.swift
+++ b/apps/astronomical-menu/tests/AstronomicalMenuContractTests/StatusPresentationContractTests.swift
@@ -71,7 +71,7 @@ final class StatusPresentationContractTests: XCTestCase {
       (MlxMemoryPalette.modelCore, 86, 180, 233),
       (MlxMemoryPalette.contextState, 240, 228, 66),
       (MlxMemoryPalette.runtimeWork, 167, 139, 250),
-      (MlxMemoryPalette.recoverableExperts, 0, 158, 115),
+      (MlxMemoryPalette.unusedBudget, 0, 158, 115),
       (MlxMemoryPalette.reservedContextGrowth, 204, 121, 167),
       (MlxMemoryPalette.reservedActivations, 213, 94, 0),
     ]
@@ -106,8 +106,8 @@ final class StatusPresentationContractTests: XCTestCase {
       "Calculated capacity below this Mac's MLX ceiling. It is not free RAM; macOS memory pressure and temporary work can reduce what is safely usable."
     )
     XCTAssertEqual(
-      MlxMemoryLegendItem.recoverableExperts.explanationText,
-      "Expert budget the ceiling already granted that warming has not filled. This is the only unused slice a residency change can still spend."
+      MlxMemoryLegendItem.unusedBudget.explanationText,
+      "Unused budget the ceiling already granted for expert weights that are not in RAM. Distinct from Experts, which are weights already resident."
     )
     XCTAssertEqual(
       MlxMemoryLegendItem.reservedContextGrowth.explanationText,
@@ -134,8 +134,8 @@ final class StatusPresentationContractTests: XCTestCase {
       "Explain Nominal MLX headroom"
     )
     XCTAssertEqual(
-      MlxMemoryLegendItem.recoverableExperts.infoButtonAccessibilityLabel,
-      "Explain Recoverable experts"
+      MlxMemoryLegendItem.unusedBudget.infoButtonAccessibilityLabel,
+      "Explain Unused"
     )
     XCTAssertEqual(
       MlxMemoryLegendItem.reservedContextGrowth.infoButtonAccessibilityLabel,

--- a/apps/astronomical-menu/tests/AstronomicalMenuContractTests/StatusPresentationContractTests.swift
+++ b/apps/astronomical-menu/tests/AstronomicalMenuContractTests/StatusPresentationContractTests.swift
@@ -71,7 +71,6 @@ final class StatusPresentationContractTests: XCTestCase {
       (MlxMemoryPalette.modelCore, 86, 180, 233),
       (MlxMemoryPalette.contextState, 240, 228, 66),
       (MlxMemoryPalette.runtimeWork, 167, 139, 250),
-      (MlxMemoryPalette.unusedBudget, 0, 158, 115),
       (MlxMemoryPalette.reservedContextGrowth, 204, 121, 167),
       (MlxMemoryPalette.reservedActivations, 213, 94, 0),
     ]
@@ -156,6 +155,16 @@ final class StatusPresentationContractTests: XCTestCase {
     XCTAssertEqual(availableAppearanceColor.greenComponent, trackAppearanceColor.greenComponent, accuracy: 0.001)
     XCTAssertEqual(availableAppearanceColor.blueComponent, trackAppearanceColor.blueComponent, accuracy: 0.001)
     XCTAssertEqual(availableAppearanceColor.alphaComponent, trackAppearanceColor.alphaComponent, accuracy: 0.001)
+    let unusedBudgetAppearanceColor = try XCTUnwrap(
+      NSColor(MlxMemoryPalette.unusedBudget).usingColorSpace(.sRGB))
+    XCTAssertEqual(
+      unusedBudgetAppearanceColor.redComponent, trackAppearanceColor.redComponent, accuracy: 0.001)
+    XCTAssertEqual(
+      unusedBudgetAppearanceColor.greenComponent, trackAppearanceColor.greenComponent, accuracy: 0.001)
+    XCTAssertEqual(
+      unusedBudgetAppearanceColor.blueComponent, trackAppearanceColor.blueComponent, accuracy: 0.001)
+    XCTAssertEqual(
+      unusedBudgetAppearanceColor.alphaComponent, trackAppearanceColor.alphaComponent, accuracy: 0.001)
   }
 
   func test_should_match_the_visually_rendered_dark_background() throws {

--- a/apps/astronomical-menu/tests/AstronomicalMenuContractTests/StatusPresentationContractTests.swift
+++ b/apps/astronomical-menu/tests/AstronomicalMenuContractTests/StatusPresentationContractTests.swift
@@ -71,6 +71,9 @@ final class StatusPresentationContractTests: XCTestCase {
       (MlxMemoryPalette.modelCore, 86, 180, 233),
       (MlxMemoryPalette.contextState, 240, 228, 66),
       (MlxMemoryPalette.runtimeWork, 167, 139, 250),
+      (MlxMemoryPalette.recoverableExperts, 0, 158, 115),
+      (MlxMemoryPalette.reservedContextGrowth, 204, 121, 167),
+      (MlxMemoryPalette.reservedActivations, 213, 94, 0),
     ]
 
     for (paletteColor, expectedRed, expectedGreen, expectedBlue) in expectedColorComponents {
@@ -102,6 +105,22 @@ final class StatusPresentationContractTests: XCTestCase {
       MlxMemoryLegendItem.available.explanationText,
       "Calculated capacity below this Mac's MLX ceiling. It is not free RAM; macOS memory pressure and temporary work can reduce what is safely usable."
     )
+    XCTAssertEqual(
+      MlxMemoryLegendItem.recoverableExperts.explanationText,
+      "Expert budget the ceiling already granted that warming has not filled. This is the only unused slice a residency change can still spend."
+    )
+    XCTAssertEqual(
+      MlxMemoryLegendItem.reservedContextGrowth.explanationText,
+      "Held so conversation state can grow. Spending it on expert weights invites eviction mid-request."
+    )
+    XCTAssertEqual(
+      MlxMemoryLegendItem.reservedActivations.explanationText,
+      "Held for temporary decode and prefill workspace, including one expert page. It is a promise, not idle RAM."
+    )
+    XCTAssertEqual(
+      MlxMemoryLegendItem.unexplainedHeadroom.explanationText,
+      "Unused capacity with no named owner yet. The engine reports this instead of folding it into a reserved bucket."
+    )
   }
 
   func test_should_name_each_mlx_memory_explanation_control() {
@@ -113,6 +132,18 @@ final class StatusPresentationContractTests: XCTestCase {
     XCTAssertEqual(
       MlxMemoryLegendItem.available.infoButtonAccessibilityLabel,
       "Explain Nominal MLX headroom"
+    )
+    XCTAssertEqual(
+      MlxMemoryLegendItem.recoverableExperts.infoButtonAccessibilityLabel,
+      "Explain Recoverable experts"
+    )
+    XCTAssertEqual(
+      MlxMemoryLegendItem.reservedContextGrowth.infoButtonAccessibilityLabel,
+      "Explain Held for context"
+    )
+    XCTAssertEqual(
+      MlxMemoryLegendItem.ownerOverrun.infoButtonAccessibilityLabel,
+      "Explain Owner overrun"
     )
   }
 


### PR DESCRIPTION
## Linked issue

Closes #509

## Summary

The popover already showed how much MLX capacity was unused. It did not say why. The headline active/ceiling number is unchanged. When the worker publishes the engine budget split, the grey remainder of the occupancy bar is painted as named owners.

## Colors

Okabe-Ito palette, unused in the occupancy bar:

- **Recoverable experts** — bluish green. Expert budget the ceiling granted that warming has not filled.
- **Held for context** — reddish purple. Promise for conversation-state growth.
- **Held for activations** — vermillion. Temporary workspace and one expert page.
- **Core slack / unexplained / overrun** — shown only when non-zero.

Each row keeps the info-circle explanation. Snapshots without the split still show a single Nominal MLX headroom row.

## Verification

Menu contract tests: 108 passed, including five new headroom-split tests. `scripts/verify-before-commit.sh` 18/18.
