### PR TITLE
Publish the unused-ceiling split on the model-loaded memory sample

### DIFF
--- a/apps/inference-worker/tests/model_ssd_streaming/acceptance/prefill_memory_progress_rest_journey.rs
+++ b/apps/inference-worker/tests/model_ssd_streaming/acceptance/prefill_memory_progress_rest_journey.rs
@@ -77,6 +77,10 @@ async fn run_mlx_memory_progress_rest_journey() {
     )
     .await;
     let server_address = real_model_rest_server.server_address;
+    crate::support::memory_utilization_parity::wait_for_status_memory_ceiling_utilization(
+        server_address,
+    )
+    .await;
     let openai_client = Client::with_config(
         OpenAIConfig::new()
             .with_api_base(format!("http://{server_address}/v1"))

--- a/crates/model-serving/tests/hermetic/engine_backed_worker/chat/mod.rs
+++ b/crates/model-serving/tests/hermetic/engine_backed_worker/chat/mod.rs
@@ -17,10 +17,10 @@ use astronomical_ipc_protocol::{
 use astronomical_model_serving::{
     EngineBackedWorker, EngineGenerationStart, EngineLoadResult, ExpertResidencyTelemetry,
     GeneratedToken, GenerationFinalization, InferenceEngine, InferenceEngineError,
-    MlxActiveMemoryBreakdown, MlxMemoryLimitAdjustment, MlxMemoryTelemetry, ModelFactory,
-    ModelFactoryRuntime, ModelGeneratedTokenTranslation, ModelGenerationOutputError,
-    ModelGenerationProcessor, PreparedInferenceRequest, PreparedModelGeneration,
-    WorkerRuntimeError,
+    MemoryCeilingUtilization, MlxActiveMemoryBreakdown, MlxMemoryLimitAdjustment,
+    MlxMemoryTelemetry, ModelFactory, ModelFactoryRuntime, ModelGeneratedTokenTranslation,
+    ModelGenerationOutputError, ModelGenerationProcessor, PreparedInferenceRequest,
+    PreparedModelGeneration, WorkerRuntimeError,
 };
 use tokio::{
     io::{AsyncWrite, duplex, split},

--- a/crates/model-serving/tests/hermetic/engine_backed_worker/chat/ready_and_model_lifecycle.rs
+++ b/crates/model-serving/tests/hermetic/engine_backed_worker/chat/ready_and_model_lifecycle.rs
@@ -287,3 +287,71 @@ async fn should_remain_idle_after_the_first_model_creation_fails() {
 
     close_worker_transport(supervisor_writer, worker_task).await;
 }
+
+#[tokio::test]
+async fn should_publish_the_unused_ceiling_split_on_the_model_loaded_memory_sample() {
+    let idle_mlx_memory_telemetry = MlxMemoryTelemetry::new(
+        16_000_000_000,
+        0,
+        16_000_000_000,
+        MlxActiveMemoryBreakdown {
+            expert_payload_bytes: 12_000_000_000,
+            model_core_payload_bytes: 3_000_000_000,
+            context_state_payload_bytes: 0,
+            speculative_prefill_draft_memory_bytes: 0,
+        },
+    )
+    .with_memory_ceiling_utilization(MemoryCeilingUtilization {
+        mlx_active_memory_ceiling_bytes: 23_000_000_000,
+        active_memory_bytes: 16_000_000_000,
+        unused_headroom_bytes: 7_000_000_000,
+        reserved_model_core_slack_bytes: 0,
+        reserved_context_growth_bytes: 2_000_000_000,
+        reserved_activation_and_workspace_bytes: 1_000_000_000,
+        unseated_expert_entitlement_bytes: 4_000_000_000,
+        speculative_draft_payload_bytes: 0,
+        unexplained_headroom_bytes: 0,
+        owner_overrun_bytes: 0,
+    });
+    let engine_worker = EngineBackedWorker::new(
+        ScriptedChatProcessor::new(),
+        ScriptedChatEngine::new().with_idle_mlx_memory_telemetry(idle_mlx_memory_telemetry),
+    );
+    let (supervisor_transport, worker_transport) = duplex(MAX_IPC_FRAME_BYTES * 2);
+    let (supervisor_reader_transport, supervisor_writer_transport) = split(supervisor_transport);
+    let (worker_reader_transport, worker_writer_transport) = split(worker_transport);
+    let mut supervisor_reader = ProtocolReader::new(supervisor_reader_transport);
+    let worker_task = tokio::spawn(async move {
+        engine_worker
+            .run(worker_reader_transport, worker_writer_transport)
+            .await
+    });
+
+    assert!(matches!(
+        next_event(&mut supervisor_reader).await,
+        WorkerEvent::Ready { .. }
+    ));
+    let WorkerEvent::MlxMemorySample {
+        mlx_memory_snapshot: Some(model_loaded_snapshot),
+        ..
+    } = next_event(&mut supervisor_reader).await
+    else {
+        panic!("load-complete must emit an MLX memory sample after Ready");
+    };
+    assert_eq!(
+        model_loaded_snapshot.source,
+        MlxMemorySnapshotSource::ModelLoaded
+    );
+    let utilization = model_loaded_snapshot
+        .memory_ceiling_utilization
+        .expect("the model-loaded sample must carry the unused-ceiling split the menu shows");
+    assert_eq!(utilization.unused_headroom_bytes, 7_000_000_000);
+    assert_eq!(utilization.unexplained_headroom_bytes, 0);
+    assert_eq!(utilization.owner_overrun_bytes, 0);
+
+    close_worker_transport(
+        ProtocolWriter::new(supervisor_writer_transport),
+        worker_task,
+    )
+    .await;
+}

--- a/crates/model-serving/tests/hermetic/engine_backed_worker/chat/scripted_chat_test_doubles.rs
+++ b/crates/model-serving/tests/hermetic/engine_backed_worker/chat/scripted_chat_test_doubles.rs
@@ -277,6 +277,7 @@ pub(crate) struct ScriptedChatEngine {
     active_generation_prompt_cache_stats: Option<WorkerEvent>,
     prompt_cache_clear_event: Option<WorkerEvent>,
     pub(super) maximum_allocator_cache_memory_limit_bytes: u64,
+    idle_mlx_memory_telemetry: Option<MlxMemoryTelemetry>,
 }
 
 impl ScriptedChatEngine {
@@ -331,7 +332,16 @@ impl ScriptedChatEngine {
             active_generation_prompt_cache_stats: None,
             prompt_cache_clear_event: None,
             maximum_allocator_cache_memory_limit_bytes: u64::MAX,
+            idle_mlx_memory_telemetry: None,
         }
+    }
+
+    pub(super) fn with_idle_mlx_memory_telemetry(
+        mut self,
+        idle_mlx_memory_telemetry: MlxMemoryTelemetry,
+    ) -> Self {
+        self.idle_mlx_memory_telemetry = Some(idle_mlx_memory_telemetry);
+        self
     }
 
     pub(super) fn with_restored_prompt_prefix_token_count(
@@ -542,5 +552,11 @@ impl InferenceEngine for ScriptedChatEngine {
         _model_id: Option<String>,
     ) -> Result<Option<WorkerEvent>, InferenceEngineError> {
         Ok(self.prompt_cache_clear_event.clone())
+    }
+
+    async fn collect_mlx_memory_telemetry(
+        &self,
+    ) -> Result<Option<MlxMemoryTelemetry>, InferenceEngineError> {
+        Ok(self.idle_mlx_memory_telemetry.clone())
     }
 }


### PR DESCRIPTION
## Linked issue

Refs #510

## Summary

Load-complete observability: the ModelLoaded memory sample must carry the same unused-ceiling split the menu shows, before the first chat.

Qwen already composes that split in `collect_current_mlx_memory_telemetry`. This slice proves the worker publishes it on the ModelLoaded event and that the prefill REST journey waits for it on `/v1/status` before sending a prompt.

## Tests

- Hermetic: `should_publish_the_unused_ceiling_split_on_the_model_loaded_memory_sample`.
- Prefill journey waits for `memory_ceiling_utilization` after the worker is ready.

## What remains on #510

Image generation and embeddings still need occupancy breakdowns of their own.
