### PR TITLE
Drive feedback dismissal through an injectable sleep in tests

### DIFF
--- a/apps/astronomical-menu/Sources/AstronomicalMenuCore/TelemetryStore.swift
+++ b/apps/astronomical-menu/Sources/AstronomicalMenuCore/TelemetryStore.swift
@@ -36,8 +36,14 @@ final class TelemetryStore: ObservableObject {
   @Published var editableMaximumMlxMemoryGigabytes: UInt64 = 0
   var onMenuBarTitleChanged: ((String) -> Void)?
 
+  /// Suspends the feedback-dismissal task for its delay. Production sleeps the
+  /// real duration; tests inject a gate they release explicitly so assertions
+  /// on transient feedback never race the dismissal window.
+  typealias ControlActionFeedbackDismissalSleep = @Sendable (Duration) async -> Void
+
   private let supervisorClient: any SupervisorClient
   private let controlActionFeedbackDismissalDelay: Duration
+  private let controlActionFeedbackDismissalSleep: ControlActionFeedbackDismissalSleep
   private let workerPolicyConfirmationRetryDelay: Duration
   private let systemTelemetrySampler = SystemTelemetrySampler()
   private let systemTelemetryClock = ContinuousClock()
@@ -53,10 +59,13 @@ final class TelemetryStore: ObservableObject {
   init(
     supervisorClient: any SupervisorClient = LocalSupervisorClient(),
     controlActionFeedbackDismissalDelay: Duration = .seconds(1),
+    controlActionFeedbackDismissalSleep: ControlActionFeedbackDismissalSleep? = nil,
     workerPolicyConfirmationRetryDelay: Duration = defaultWorkerPolicyConfirmationRetryDelay
   ) {
     self.supervisorClient = supervisorClient
     self.controlActionFeedbackDismissalDelay = controlActionFeedbackDismissalDelay
+    self.controlActionFeedbackDismissalSleep = controlActionFeedbackDismissalSleep
+      ?? { delay in try? await Task.sleep(for: delay) }
     self.workerPolicyConfirmationRetryDelay = workerPolicyConfirmationRetryDelay
   }
 
@@ -303,14 +312,11 @@ final class TelemetryStore: ObservableObject {
 
   private func scheduleMaximumMlxMemoryFeedbackDismissal() {
     let feedbackGeneration = controlActionFeedbackGeneration
+    let controlActionFeedbackDismissalSleep = controlActionFeedbackDismissalSleep
     let dismissalDelay = controlActionFeedbackDismissalDelay
     controlActionFeedbackDismissalTask?.cancel()
     controlActionFeedbackDismissalTask = Task { [weak self] in
-      do {
-        try await Task.sleep(for: dismissalDelay)
-      } catch {
-        return
-      }
+      await controlActionFeedbackDismissalSleep(dismissalDelay)
       guard let self, self.controlActionFeedbackGeneration == feedbackGeneration else { return }
       self.controlActionFeedback = nil
       self.controlActionFeedbackDismissalTask = nil

--- a/apps/astronomical-menu/tests/AstronomicalMenuContractTests/MenuControlStateTests.swift
+++ b/apps/astronomical-menu/tests/AstronomicalMenuContractTests/MenuControlStateTests.swift
@@ -69,8 +69,10 @@ final class MenuControlStateTests: XCTestCase {
 
   @MainActor
   func test_should_dismiss_a_successful_memory_update_one_second_after_application() async throws {
+    let feedbackDismissalGate = FeedbackDismissalGate()
     let telemetryStore = contractTelemetryStore(
-      supervisorClient: SuccessfulMaximumMlxMemoryUpdateSupervisorClient()
+      supervisorClient: SuccessfulMaximumMlxMemoryUpdateSupervisorClient(),
+      feedbackDismissalGate: feedbackDismissalGate
     )
 
     await telemetryStore.performMaximumMlxMemoryLimitUpdate(32)
@@ -86,13 +88,18 @@ final class MenuControlStateTests: XCTestCase {
       .success("MLX memory setting persisted and applied")
     )
 
+    feedbackDismissalGate.release()
     try await waitForControlActionFeedbackToDismiss(from: telemetryStore)
   }
 
   @MainActor
   func test_should_wait_for_a_queued_memory_update_to_take_effect_before_dismissing() async throws {
     let supervisorClient = QueuedMaximumMlxMemoryUpdateSupervisorClient()
-    let telemetryStore = contractTelemetryStore(supervisorClient: supervisorClient)
+    let feedbackDismissalGate = FeedbackDismissalGate()
+    let telemetryStore = contractTelemetryStore(
+      supervisorClient: supervisorClient,
+      feedbackDismissalGate: feedbackDismissalGate
+    )
 
     await telemetryStore.performMaximumMlxMemoryLimitUpdate(32)
     XCTAssertEqual(
@@ -105,6 +112,7 @@ final class MenuControlStateTests: XCTestCase {
     try await Task.sleep(for: .milliseconds(10))
     XCTAssertNotNil(telemetryStore.controlActionFeedback)
 
+    feedbackDismissalGate.release()
     try await waitForControlActionFeedbackToDismiss(from: telemetryStore)
   }
 
@@ -124,8 +132,10 @@ final class MenuControlStateTests: XCTestCase {
 
   @MainActor
   func test_should_start_dismissal_after_a_status_refresh_precedes_the_update_response() async throws {
+    let feedbackDismissalGate = FeedbackDismissalGate()
     let telemetryStore = contractTelemetryStore(
-      supervisorClient: DelayedMaximumMlxMemoryUpdateSupervisorClient()
+      supervisorClient: DelayedMaximumMlxMemoryUpdateSupervisorClient(),
+      feedbackDismissalGate: feedbackDismissalGate
     )
     let memoryUpdateTask = Task { @MainActor in
       await telemetryStore.performMaximumMlxMemoryLimitUpdate(32)
@@ -140,6 +150,7 @@ final class MenuControlStateTests: XCTestCase {
       telemetryStore.controlActionFeedback,
       .success("MLX memory setting persisted and applied")
     )
+    feedbackDismissalGate.release()
     try await waitForControlActionFeedbackToDismiss(from: telemetryStore)
   }
 
@@ -200,11 +211,49 @@ final class MenuControlStateTests: XCTestCase {
   }
 }
 
+/// Holds the feedback-dismissal task until the test releases it, so assertions
+/// on transient feedback cannot race the real wall-clock window (issue #524).
+final class FeedbackDismissalGate: @unchecked Sendable {
+  private let lock = NSLock()
+  private var continuations: [CheckedContinuation<Void, Never>] = []
+  private var isReleased = false
+
+  func suspendDismissal() async {
+    await withCheckedContinuation { continuation in
+      self.lock.lock()
+      defer { self.lock.unlock() }
+      if self.isReleased {
+        continuation.resume()
+      } else {
+        self.continuations.append(continuation)
+      }
+    }
+  }
+
+  func release() {
+    lock.lock()
+    defer { lock.unlock() }
+    isReleased = true
+    continuations.forEach { $0.resume() }
+    continuations.removeAll()
+  }
+}
+
 @MainActor
-private func contractTelemetryStore(supervisorClient: any SupervisorClient) -> TelemetryStore {
-  TelemetryStore(
+private func contractTelemetryStore(
+  supervisorClient: any SupervisorClient,
+  feedbackDismissalGate: FeedbackDismissalGate? = nil
+) -> TelemetryStore {
+  let controlActionFeedbackDismissalSleep: TelemetryStore.ControlActionFeedbackDismissalSleep?
+  if let feedbackDismissalGate {
+    controlActionFeedbackDismissalSleep = { _ in await feedbackDismissalGate.suspendDismissal() }
+  } else {
+    controlActionFeedbackDismissalSleep = nil
+  }
+  return TelemetryStore(
     supervisorClient: supervisorClient,
     controlActionFeedbackDismissalDelay: .milliseconds(80),
+    controlActionFeedbackDismissalSleep: controlActionFeedbackDismissalSleep,
     workerPolicyConfirmationRetryDelay: .milliseconds(1)
   )
 }

--- a/apps/inference-worker/tests/support/serving_rest.rs
+++ b/apps/inference-worker/tests/support/serving_rest.rs
@@ -226,8 +226,7 @@ async fn wait_until_ready(server_address: SocketAddr) {
     for readiness_attempt in 1..=READY_ATTEMPT_LIMIT {
         let request_text =
             format!("GET /ready HTTP/1.1\r\nHost: {server_address}\r\nConnection: close\r\n\r\n");
-        let readiness_response =
-            super::http::send_http_request(server_address, request_text).await;
+        let readiness_response = super::http::send_http_request(server_address, request_text).await;
         last_readiness_response = readiness_response.clone();
         if readiness_response.starts_with("HTTP/1.1 200 OK") {
             eprintln!("[real-model-rest] worker ready after {readiness_attempt} attempts");


### PR DESCRIPTION
## Linked issue

Closes #524

## Summary

The control-feedback dismissal window is a real wall-clock sleep (80 milliseconds in the test configuration), and three menu control-state tests assert the transient feedback across `await` boundaries. On a loaded continuous-integration runner the main-actor hop can outrun the window, so the assertion observes `nil` - three distinct tests failed that way across two required-check runs.

The dismissal task now suspends through an injectable sleep. Production keeps the real duration; tests inject a gate they release explicitly, so a transient assertion can never be outrun by the dismissal it is observing. All behavioral assertions are unchanged: success appears, stale feedback is replaced, newer feedback suppresses older, and dismissal still happens - the test just steps the clock instead of racing it.

## Evidence

- The full menu contract suite passed 20 consecutive local runs (previously two of these tests failed within two CI runs).
- The required macOS check is green on this pull request without a re-run.
