### PR TITLE
Compose the embeddings-lane unused-headroom split from measured evidence

### DIFF
--- a/apps/inference-worker/tests/serving_acceptance/chat/embeddings_rest.rs
+++ b/apps/inference-worker/tests/serving_acceptance/chat/embeddings_rest.rs
@@ -142,6 +142,52 @@ async fn run_embeddings_gpu_journey() {
         "[embeddings-rest 6/6] status=success phase=semantic_similarity play={play_similarity:.3} finance={finance_similarity:.3}"
     );
 
+    // Issue #510: the finalized status must publish the unused-headroom
+    // split the menu paints. The embeddings engine owns no experts, context
+    // state, or drafter, so no owner may overrun and nothing is unexplained.
+    let status_response = get_endpoint(server_address, "/v1/status").await;
+    assert_http_ok(&status_response);
+    let status_document = http_json_body(&status_response);
+    let memory_snapshot = &status_document["mlx_memory_snapshot"];
+    assert_eq!(
+        memory_snapshot["source"].as_str(),
+        Some("finalized"),
+        "status should retain the embeddings cleanup observation: {status_document}"
+    );
+    let utilization = &memory_snapshot["memory_ceiling_utilization"];
+    assert!(
+        utilization.is_object(),
+        "the finalized embeddings status must publish the unused-headroom split: {memory_snapshot}"
+    );
+    assert_eq!(
+        utilization["unexplained_headroom_bytes"].as_u64(),
+        Some(0),
+        "the embeddings split must carry no unexplained headroom: {utilization}"
+    );
+    assert_eq!(
+        utilization["owner_overrun_bytes"].as_u64(),
+        Some(0),
+        "no embeddings owner may overrun its reserve: {utilization}"
+    );
+    let active_memory_bytes = memory_snapshot["active_memory_bytes"].as_u64().unwrap_or(0);
+    let unused_headroom_bytes = utilization["unused_headroom_bytes"].as_u64().unwrap_or(0);
+    let mlx_memory_ceiling_bytes = status_document["mlx_memory_ceiling_bytes"]
+        .as_u64()
+        .unwrap_or(0);
+    assert_eq!(
+        unused_headroom_bytes,
+        mlx_memory_ceiling_bytes.saturating_sub(active_memory_bytes),
+        "the embeddings split must report the measured unused headroom: {utilization}"
+    );
+    eprintln!(
+        "[embeddings-rest] status=progress phase=utilization unused_gb={:.2} reserved_transient_gb={:.2}",
+        unused_headroom_bytes as f64 / 1_000_000_000.0,
+        utilization["reserved_activation_and_workspace_bytes"]
+            .as_u64()
+            .unwrap_or(0) as f64
+            / 1_000_000_000.0,
+    );
+
     stop_serving_rest_server(rest_server).await;
     eprintln!(
         "[embeddings-rest] status=success model={}",

--- a/apps/supervisor/src/worker_embeddings_event.rs
+++ b/apps/supervisor/src/worker_embeddings_event.rs
@@ -2,12 +2,14 @@
 
 use std::sync::{Arc, RwLock};
 
-use astronomical_ipc_protocol::WorkerEvent;
+use astronomical_ipc_protocol::{MlxMemorySnapshotSource, WorkerEvent};
 
 use crate::{
     WorkerControlError, WorkerHealthSnapshot,
     worker_event_handler::protocol_violation,
-    worker_health::{clear_active_request_progress, publish_activity},
+    worker_health::{
+        clear_active_request_progress, publish_activity, publish_latest_mlx_memory_snapshot,
+    },
     worker_loop_types::ActiveWorkerRequest,
 };
 
@@ -47,7 +49,11 @@ pub(super) fn handle_worker_embeddings_event(
             active_embeddings.terminal_received_at = Some(tokio::time::Instant::now());
             Ok(())
         }
-        WorkerEvent::EmbeddingsFinalized { request_id, .. } => {
+        WorkerEvent::EmbeddingsFinalized {
+            request_id,
+            mlx_memory_snapshot,
+            ..
+        } => {
             let active_embeddings = matching_active_embeddings(active_worker_request, request_id)?;
             let Some(terminal_outcome) = active_embeddings.terminal_outcome.take() else {
                 return Err(protocol_violation(
@@ -60,10 +66,50 @@ pub(super) fn handle_worker_embeddings_event(
                 .try_send(terminal_outcome.map_err(crate::EmbeddingsExecutionError::WorkerFailure));
             publish_activity(health_snapshot, crate::WorkerActivity::Idle);
             clear_active_request_progress(health_snapshot);
+            publish_embeddings_finalized_memory_snapshot(health_snapshot, mlx_memory_snapshot)?;
             Ok(())
         }
         _ => Ok(()),
     }
+}
+
+/// Publishes the cleanup observation the embeddings engine captured, so the
+/// status the menu paints carries the same unused-headroom split the journeys
+/// assert (issue #510). The embeddings engine owns no experts, context
+/// state, or drafter, so any nonzero owner there is a protocol violation.
+pub(super) fn publish_embeddings_finalized_memory_snapshot(
+    health_snapshot: &Arc<RwLock<WorkerHealthSnapshot>>,
+    mlx_memory_snapshot: Option<astronomical_ipc_protocol::WorkerMlxMemorySnapshot>,
+) -> Result<(), WorkerControlError> {
+    let Some(mlx_memory_snapshot) = mlx_memory_snapshot else {
+        return Ok(());
+    };
+    let attributed_memory_bytes = mlx_memory_snapshot
+        .expert_payload_bytes
+        .saturating_add(mlx_memory_snapshot.model_core_payload_bytes)
+        .saturating_add(mlx_memory_snapshot.context_state_payload_bytes)
+        .saturating_add(mlx_memory_snapshot.speculative_prefill_draft_memory_bytes);
+    let effective_ceiling_bytes = health_snapshot
+        .read()
+        .ok()
+        .map(|snapshot| snapshot.mlx_memory_ceiling_bytes)
+        .unwrap_or(0);
+    if mlx_memory_snapshot.source != MlxMemorySnapshotSource::Finalized
+        || mlx_memory_snapshot.allocator_cache_memory_bytes != 0
+        || mlx_memory_snapshot.active_memory_bytes > mlx_memory_snapshot.peak_memory_bytes
+        || attributed_memory_bytes > mlx_memory_snapshot.active_memory_bytes
+        || mlx_memory_snapshot.expert_payload_bytes != 0
+        || mlx_memory_snapshot.context_state_payload_bytes != 0
+        || mlx_memory_snapshot.speculative_prefill_draft_memory_bytes != 0
+        || (effective_ceiling_bytes > 0
+            && mlx_memory_snapshot.active_memory_bytes > effective_ceiling_bytes)
+    {
+        return Err(protocol_violation(
+            "invalid embeddings finalization MLX memory snapshot",
+        ));
+    }
+    publish_latest_mlx_memory_snapshot(health_snapshot, mlx_memory_snapshot);
+    Ok(())
 }
 
 fn matching_active_embeddings(

--- a/crates/model-serving/src/engine_backed_worker/embeddings.rs
+++ b/crates/model-serving/src/engine_backed_worker/embeddings.rs
@@ -1,11 +1,13 @@
 //! Serializes one synchronous embeddings request and publishes its cleanup event.
 
 use astronomical_ipc_protocol::{
-    EmbeddingsCommand, EmbeddingsFailureReason, ProtocolWriter, RequestId, WorkerEvent,
+    EmbeddingsCommand, EmbeddingsFailureReason, MlxMemorySnapshotSource, ProtocolWriter, RequestId,
+    WorkerEvent,
 };
 use tokio::io::AsyncWrite;
 
 use super::WorkerRuntimeError;
+use super::output::worker_memory_snapshot;
 use super::{EngineBackedWorker, LoadedRuntime};
 use crate::EmbeddingEngine;
 use crate::InferenceEngine;
@@ -111,11 +113,22 @@ where
     where
         WriteTransport: AsyncWrite + Unpin,
     {
+        // The engine captured its post-cleanup observation during the embed
+        // call, so the finalization publishes the same split the menu paints
+        // (issue #510).
+        let mlx_memory_snapshot = match self.loaded_runtime.as_mut() {
+            Some(LoadedRuntime::Embeddings(embedding_engine)) => embedding_engine
+                .take_post_cleanup_memory_telemetry()
+                .map(|mlx_memory_telemetry| {
+                    worker_memory_snapshot(MlxMemorySnapshotSource::Finalized, mlx_memory_telemetry)
+                }),
+            _ => None,
+        };
         event_writer
             .send_event(&WorkerEvent::EmbeddingsFinalized {
                 request_id,
                 elapsed_millis,
-                mlx_memory_snapshot: None,
+                mlx_memory_snapshot,
             })
             .await?;
         Ok(())

--- a/crates/model-serving/src/engine_backed_worker/output.rs
+++ b/crates/model-serving/src/engine_backed_worker/output.rs
@@ -7,8 +7,8 @@ use tokio::io::AsyncWrite;
 use super::support::{ActiveEngineGeneration, engine_generation_error};
 use crate::model_generation_processor::{ModelGenerationOutputError, ModelGenerationProcessor};
 use crate::{
-    EngineBackedWorker, GenerationFinalization, ImageGenerationEngine, InferenceEngine,
-    MlxMemoryTelemetry, WorkerRuntimeError,
+    EmbeddingEngine, EngineBackedWorker, GenerationFinalization, ImageGenerationEngine,
+    InferenceEngine, MlxMemoryTelemetry, WorkerRuntimeError,
 };
 
 use super::LoadedRuntime;
@@ -19,6 +19,7 @@ where
     Processor: ModelGenerationProcessor + Send + 'static,
     Engine: InferenceEngine<Request = Processor::InferenceRequest> + Send + 'static,
     ImageEngine: ImageGenerationEngine,
+    EmbeddingsEngine: EmbeddingEngine,
 {
     pub(crate) async fn emit_model_outputs<WriteTransport>(
         &self,
@@ -392,7 +393,11 @@ where
                 .map(|mlx_memory_telemetry| {
                     worker_memory_observation(mlx_memory_snapshot_source, mlx_memory_telemetry)
                 }),
-            Some(LoadedRuntime::Embeddings(_)) => None,
+            Some(LoadedRuntime::Embeddings(embedding_engine)) => embedding_engine
+                .collect_mlx_memory_telemetry()
+                .map(|mlx_memory_telemetry| {
+                    worker_memory_observation(mlx_memory_snapshot_source, mlx_memory_telemetry)
+                }),
             None => None,
         };
         let Some((mlx_memory_snapshot, expert_residency)) = mlx_memory_observation else {

--- a/crates/model-serving/src/flux2_klein/memory_utilization.rs
+++ b/crates/model-serving/src/flux2_klein/memory_utilization.rs
@@ -192,6 +192,30 @@ mod tests {
     }
 
     #[test]
+    fn should_charge_the_vae_workspace_reserve_during_decoding() {
+        let geometry = geometry();
+        // Complete VAE decoder resident with its workspace partially occupied.
+        let active_memory_bytes = 500_000_000 + 300_000_000;
+        let utilization = compose_flux2_klein_memory_ceiling_utilization(
+            2_000_000_000,
+            active_memory_bytes,
+            500_000_000,
+            Flux2KleinMemoryPhase::VaeDecoding,
+            &geometry,
+        );
+        // The phase promise is VAE workspace plus the shared RGB handoff.
+        assert_eq!(
+            utilization.reserved_activation_and_workspace_bytes,
+            600_000_000 + 100_000_000 - 300_000_000
+        );
+        assert_eq!(
+            utilization.unused_headroom_bytes,
+            2_000_000_000 - active_memory_bytes
+        );
+        assert!(utilization.is_fully_explained());
+    }
+
+    #[test]
     fn should_surface_a_phase_reserve_that_overruns_the_headroom() {
         let geometry = geometry();
         // Encoding promises RGB plus PNG plus base64, but the ceiling is

--- a/crates/model-serving/src/modernbert/artifact.rs
+++ b/crates/model-serving/src/modernbert/artifact.rs
@@ -19,6 +19,9 @@ pub struct ModernBertArtifact {
     pub configuration: ModernBertConfiguration,
     pub tokenizer_bytes: Vec<u8>,
     pub weights_file: std::fs::File,
+    /// Exact safetensors payload bytes: file length minus the header block.
+    /// This is the resident model core the utilization split attributes.
+    pub weights_payload_bytes: u64,
 }
 
 impl ModernBertArtifact {
@@ -34,14 +37,40 @@ impl ModernBertArtifact {
             model_directory.join("tokenizer.json"),
             MAXIMUM_TOKENIZER_JSON_BYTES,
         )?;
-        let weights_file = std::fs::File::open(model_directory.join("model.safetensors"))
+        let mut weights_file = std::fs::File::open(model_directory.join("model.safetensors"))
             .map_err(|source| ModernBertArtifactError::MissingWeights { source })?;
+        let weights_payload_bytes = safetensors_payload_bytes(&mut weights_file)?;
         Ok(Self {
             configuration,
             tokenizer_bytes,
             weights_file,
+            weights_payload_bytes,
         })
     }
+}
+
+/// Reads the safetensors header length and returns the exact payload size.
+///
+/// The format stores an 8-byte little-endian header byte count before the
+/// JSON header, so the weight payload is the file length minus both blocks.
+fn safetensors_payload_bytes(
+    weights_file: &mut std::fs::File,
+) -> Result<u64, ModernBertArtifactError> {
+    use std::io::Read;
+    let file_length_bytes = weights_file
+        .metadata()
+        .map_err(|source| ModernBertArtifactError::MissingWeights { source })?
+        .len();
+    let mut header_length_bytes = [0_u8; 8];
+    weights_file
+        .read_exact(&mut header_length_bytes)
+        .map_err(|source| ModernBertArtifactError::MissingWeights { source })?;
+    let header_byte_count = u64::from_le_bytes(header_length_bytes);
+    let payload_bytes = file_length_bytes
+        .checked_sub(8)
+        .and_then(|remaining_bytes| remaining_bytes.checked_sub(header_byte_count))
+        .ok_or(ModernBertArtifactError::MalformedWeightsHeader)?;
+    Ok(payload_bytes)
 }
 
 fn bounded_read(
@@ -84,6 +113,8 @@ pub enum ModernBertArtifactError {
     MalformedConfig(#[from] serde_json::Error),
     #[error("ModernBERT embedding artifact model.safetensors is missing: {source}")]
     MissingWeights { source: std::io::Error },
+    #[error("ModernBERT embedding artifact model.safetensors header is malformed")]
+    MalformedWeightsHeader,
 }
 
 /// Maps a bounded artifact validation failure into a worker-admissible failure reason.

--- a/crates/model-serving/src/modernbert/engine.rs
+++ b/crates/model-serving/src/modernbert/engine.rs
@@ -13,29 +13,35 @@ use astronomical_ipc_protocol::{
     EmbeddingsCommand, EmbeddingsFailureReason, WorkerEmbeddingCapabilities,
 };
 use astronomical_runtime_integration::{
-    MlxMemoryLimits, MlxRuntime, MlxRuntimeError, MlxSafetensors,
+    MlxMemoryLimits, MlxMemorySnapshot, MlxRuntime, MlxRuntimeError, MlxSafetensors,
 };
 use tokenizers::Tokenizer;
 
 use crate::modernbert::artifact::ModernBertArtifact;
 use crate::modernbert::configuration::ModernBertConfiguration;
 use crate::modernbert::forward::embed_token_ids;
+use crate::modernbert::memory_utilization::compose_modernbert_memory_ceiling_utilization;
 use crate::modernbert::tokenizer::encode_embedding_input;
 use crate::performance_attribution::{
     ModelLoadingPerformanceAttributionMetadata, PerformanceAttribution, PerformanceAttributionLog,
     PerformanceAttributionOutcome, PerformanceOperation,
 };
-use crate::{EmbeddingEngine, EmbeddingEngineLoadResult, EmbeddingEngineOutput};
+use crate::{
+    EmbeddingEngine, EmbeddingEngineLoadResult, EmbeddingEngineOutput, MemoryCeilingUtilization,
+    MlxMemoryTelemetry,
+};
 
 /// Loaded ModernBERT runtime bound to one artifact directory.
 pub struct ModernBertEmbeddingEngine {
     model_id: String,
     effective_mlx_memory_ceiling_bytes: usize,
     allocator_cache_memory_limit_bytes: usize,
+    weights_payload_bytes: u64,
     performance_attribution_enabled: bool,
     performance_attribution_log: PerformanceAttributionLog,
     preloaded_artifact: Option<ModernBertArtifact>,
     loaded_state: Option<LoadedModernBertState>,
+    post_cleanup_memory_telemetry: Option<MlxMemoryTelemetry>,
 }
 
 struct LoadedModernBertState {
@@ -65,10 +71,12 @@ impl ModernBertEmbeddingEngine {
             model_id: model_id.into(),
             effective_mlx_memory_ceiling_bytes,
             allocator_cache_memory_limit_bytes,
+            weights_payload_bytes: artifact.weights_payload_bytes,
             performance_attribution_enabled,
             performance_attribution_log,
             preloaded_artifact: Some(artifact),
             loaded_state: None,
+            post_cleanup_memory_telemetry: None,
         })
     }
 
@@ -88,6 +96,46 @@ impl ModernBertEmbeddingEngine {
             return;
         };
         let _ignored_log_result = self.performance_attribution_log.record(&attribution_report);
+    }
+
+    /// Composes the embeddings-lane unused-headroom split for one measurement.
+    ///
+    /// The transient reserve is evidence, not policy: the allocator's
+    /// cumulative peak minus the current active bytes is exactly the forward
+    /// workspace high-water this process has proven, so an idle engine
+    /// promises its last forward's footprint and a mid-forward engine
+    /// promises the partial peak above current usage.
+    fn memory_ceiling_utilization(
+        &self,
+        active_memory_bytes: u64,
+        peak_memory_bytes: u64,
+    ) -> Option<MemoryCeilingUtilization> {
+        Some(compose_modernbert_memory_ceiling_utilization(
+            self.effective_mlx_memory_ceiling_bytes as u64,
+            active_memory_bytes,
+            self.weights_payload_bytes,
+            peak_memory_bytes.saturating_sub(active_memory_bytes),
+        ))
+    }
+
+    fn memory_telemetry_from_snapshot(
+        &self,
+        memory_snapshot: &MlxMemorySnapshot,
+    ) -> MlxMemoryTelemetry {
+        let active_memory_bytes = memory_snapshot.active_memory_bytes() as u64;
+        let mut telemetry = MlxMemoryTelemetry::new(
+            active_memory_bytes,
+            memory_snapshot.allocator_cache_memory_bytes() as u64,
+            memory_snapshot.peak_memory_bytes() as u64,
+            crate::MlxActiveMemoryBreakdown::default(),
+        );
+        if let Some(memory_ceiling_utilization) = self.memory_ceiling_utilization(
+            active_memory_bytes,
+            memory_snapshot.peak_memory_bytes() as u64,
+        ) {
+            telemetry = telemetry.with_memory_ceiling_utilization(memory_ceiling_utilization);
+        }
+        telemetry
     }
 }
 
@@ -219,6 +267,18 @@ impl EmbeddingEngine for ModernBertEmbeddingEngine {
             },
         )?;
         let elapsed_millis = u64::try_from(started_at.elapsed().as_millis()).unwrap_or(u64::MAX);
+        // The forward arrays are owned inside embed_token_ids and dropped on
+        // return, so this snapshot is the honest post-cleanup observation.
+        // Synchronizing and clearing the allocator cache first keeps the
+        // captured state free of reusable-cache bytes, exactly like the
+        // image engine's cleanup observation.
+        let _cleanup_result = loaded_state
+            .runtime
+            .synchronize_gpu_stream_and_clear_allocator_cache();
+        if let Some(memory_snapshot) = loaded_state.runtime.memory_snapshot().ok() {
+            self.post_cleanup_memory_telemetry =
+                Some(self.memory_telemetry_from_snapshot(&memory_snapshot));
+        }
         let total_input_tokens = input_token_counts
             .iter()
             .fold(0u32, |total, count| total.saturating_add(*count));
@@ -241,6 +301,16 @@ impl EmbeddingEngine for ModernBertEmbeddingEngine {
             input_token_counts,
             elapsed_millis,
         })
+    }
+
+    fn take_post_cleanup_memory_telemetry(&mut self) -> Option<MlxMemoryTelemetry> {
+        self.post_cleanup_memory_telemetry.take()
+    }
+
+    fn collect_mlx_memory_telemetry(&self) -> Option<MlxMemoryTelemetry> {
+        let loaded_state = self.loaded_state.as_ref()?;
+        let memory_snapshot = loaded_state.runtime.memory_snapshot().ok()?;
+        Some(self.memory_telemetry_from_snapshot(&memory_snapshot))
     }
 }
 

--- a/crates/model-serving/src/modernbert/memory_utilization.rs
+++ b/crates/model-serving/src/modernbert/memory_utilization.rs
@@ -1,0 +1,127 @@
+//! Embeddings-lane ceiling-utilization owners (issue #510).
+//!
+//! Embedding inference is one synchronous encoder forward pass with no
+//! experts, no context state, and no sequential release plan, so the chat
+//! owner vocabulary would invent promises nobody made. The honest owners are
+//! the same shape the image lane uses under the shared identity contract:
+//!
+//! - **Transient reserve** — the forward workspace the engine has actually
+//!   observed, measured as the MLX peak minus the current active bytes.
+//!   Evidence-driven, never a fixed constant: an idle engine carries the
+//!   high-water of its last forward as the promise for the next one, and a
+//!   mid-forward engine carries the partial peak above current usage.
+//! - **Free headroom** — everything else, free by design; the embeddings
+//!   engine does not partition its ceiling, so there is no unexplained term
+//!   and the free bytes travel through the unused remainder.
+//! - **Overrun** — inherited unchanged: a reserve larger than the headroom
+//!   surfaces instead of hiding.
+//!
+//! Resident weights attribute active memory instead: the whole safetensors
+//! payload is the model core, and active bytes beyond it are transient work
+//! charged against the reserve so they are never counted twice.
+
+use crate::memory::MemoryCeilingUtilization;
+
+/// Composes the embeddings-lane split of one ceiling measurement.
+///
+/// `weights_payload_bytes` is the resident safetensors payload; active bytes
+/// beyond it are transient forward work. `observed_transient_high_water_bytes`
+/// is the measured peak above the current active bytes at this instant.
+#[must_use]
+pub fn compose_modernbert_memory_ceiling_utilization(
+    mlx_active_memory_ceiling_bytes: u64,
+    active_memory_bytes: u64,
+    weights_payload_bytes: u64,
+    observed_transient_high_water_bytes: u64,
+) -> MemoryCeilingUtilization {
+    let unused_headroom_bytes = mlx_active_memory_ceiling_bytes.saturating_sub(active_memory_bytes);
+    let unattributed_active_bytes = active_memory_bytes.saturating_sub(weights_payload_bytes);
+    let reserved_transient_bytes =
+        observed_transient_high_water_bytes.saturating_sub(unattributed_active_bytes);
+    // A reserve larger than the headroom means the forward workspace overran
+    // its promise; surfacing it keeps the overrun visible instead of silent.
+    let owner_overrun_bytes = reserved_transient_bytes.saturating_sub(unused_headroom_bytes);
+    MemoryCeilingUtilization {
+        mlx_active_memory_ceiling_bytes,
+        active_memory_bytes,
+        unused_headroom_bytes,
+        reserved_model_core_slack_bytes: 0,
+        reserved_context_growth_bytes: 0,
+        reserved_activation_and_workspace_bytes: reserved_transient_bytes,
+        unseated_expert_entitlement_bytes: 0,
+        speculative_draft_payload_bytes: 0,
+        unexplained_headroom_bytes: 0,
+        owner_overrun_bytes,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const GIGABYTE: u64 = 1_000_000_000;
+
+    #[test]
+    fn should_charge_the_observed_transient_high_water_minus_occupied_transients() {
+        // 400 MB of weights resident, 100 MB of forward transients active,
+        // and the allocator peak proves 250 MB of transient high-water.
+        let active_memory_bytes = 500_000_000;
+        let utilization = compose_modernbert_memory_ceiling_utilization(
+            2 * GIGABYTE,
+            active_memory_bytes,
+            400_000_000,
+            250_000_000,
+        );
+        assert_eq!(
+            utilization.unused_headroom_bytes,
+            2 * GIGABYTE - active_memory_bytes
+        );
+        assert_eq!(
+            utilization.reserved_activation_and_workspace_bytes,
+            250_000_000 - 100_000_000
+        );
+        assert!(utilization.is_fully_explained());
+        assert_eq!(utilization.unexplained_headroom_bytes, 0);
+    }
+
+    #[test]
+    fn should_read_idle_headroom_beyond_the_high_water_as_free() {
+        // After cleanup the transients are released, so the whole high-water
+        // is promised and the rest of the headroom is genuinely idle.
+        let utilization = compose_modernbert_memory_ceiling_utilization(
+            2 * GIGABYTE,
+            400_000_000,
+            400_000_000,
+            250_000_000,
+        );
+        assert_eq!(
+            utilization.reserved_activation_and_workspace_bytes,
+            250_000_000
+        );
+        assert_eq!(
+            utilization.unused_headroom_bytes,
+            250_000_000 + (2 * GIGABYTE - 400_000_000 - 250_000_000)
+        );
+        assert_eq!(utilization.unexplained_headroom_bytes, 0);
+        assert!(utilization.is_fully_explained());
+    }
+
+    #[test]
+    fn should_surface_a_reserve_that_overruns_the_headroom() {
+        let utilization = compose_modernbert_memory_ceiling_utilization(
+            500_000_000,
+            400_000_000,
+            400_000_000,
+            150_000_000,
+        );
+        assert_eq!(utilization.unused_headroom_bytes, 100_000_000);
+        // The charged reserve is not clamped to the headroom; the excess
+        // surfaces as the overrun instead.
+        assert_eq!(
+            utilization.reserved_activation_and_workspace_bytes,
+            150_000_000
+        );
+        assert_eq!(utilization.owner_overrun_bytes, 50_000_000);
+        assert!(!utilization.is_fully_explained());
+    }
+}

--- a/crates/model-serving/src/modernbert/mod.rs
+++ b/crates/model-serving/src/modernbert/mod.rs
@@ -9,6 +9,7 @@ mod artifact;
 mod configuration;
 mod engine;
 mod forward;
+mod memory_utilization;
 mod tokenizer;
 
 pub use engine::ModernBertEmbeddingEngine;


### PR DESCRIPTION
## Linked issue

Refs #510

## Summary

The embeddings lane completes observability parity: the ModernBERT engine now publishes the same unused-headroom split the menu paints, with embeddings-truthful owners instead of borrowed chat semantics.

## The embeddings owners

Embedding inference is one synchronous encoder forward pass with no experts, no context state, and no release plan, so the chat owner vocabulary would invent promises nobody made.

- **Transient reserve** (painted as the existing activation reserve): the allocator's measured peak above the current active bytes. Evidence, not policy - an idle engine carries the high-water of its last forward as the promise for the next one, and a mid-forward engine carries the partial peak above current usage. No fixed constants anywhere.
- **Resident weights**: the exact safetensors payload (file length minus the parsed header block) attributes active memory; active bytes beyond it are transient work charged against the reserve so they are never counted twice.
- **Free headroom**: everything else, free by design - the embeddings engine does not partition its ceiling, so the compose has no unexplained term and the free bytes travel through the unused remainder.
- **Overrun**: inherited unchanged; a reserve larger than the headroom surfaces instead of hiding.

## Implementation

- `modernbert/memory_utilization` composes the split with identity unit tests.
- The engine captures the post-embed cleanup observation (after synchronizing and clearing the allocator cache, exactly like the image engine) and answers idle polls.
- The worker publishes the snapshot on `EmbeddingsFinalized` instead of the hardcoded `None`; the supervisor validates it (no experts, context, or drafter bytes; active within peak and ceiling) and publishes it to the status the menu paints.

## Evidence

- The embeddings REST journey asserts the finalized status publishes the split with zero unexplained and zero overrun; all six journey phases pass against the live ModernBERT model.
- Also carries the VAE-decoding phase test for the image compose, which missed the #527 squash because it was still uncommitted at merge time.
